### PR TITLE
Adding initial version of test run GHA

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -87,5 +87,5 @@ jobs:
       with:
         action: lint
         deny-warnings: true
-        deny-notes: true
+        deny-notes: false
         except: TodoComment ContainerUri TrailingComma

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -5,13 +5,50 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
-      - '**.wdl'
+      - 'modules/**/*.wdl'
+      - 'modules/**/*.json'
       - '.github/workflows/testrun.yml'
 
 permissions:
   contents: read
 
 jobs:
+  discover-modules:
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.find-modules.outputs.modules }}
+    steps:
+    - 
+      name: Checkout
+      uses: actions/checkout@v4
+    - 
+      name: Find WDL modules
+      id: find-modules
+      run: |
+        # Find all directories in modules/ that contain both a .wdl file and inputs.json
+        modules=()
+        for module_dir in modules/*/; do
+          if [ -d "$module_dir" ]; then
+            module_name=$(basename "$module_dir")
+            wdl_file="$module_dir$module_name.wdl"
+            inputs_file="$module_dir/inputs.json"
+            
+            if [ -f "$wdl_file" ] && [ -f "$inputs_file" ]; then
+              modules+=("$module_name")
+              echo "Found module: $module_name"
+            else
+              echo "Skipping $module_name - missing required files"
+              [ ! -f "$wdl_file" ] && echo "  Missing: $wdl_file"
+              [ ! -f "$inputs_file" ] && echo "  Missing: $inputs_file"
+            fi
+          fi
+        done
+        
+        # Convert array to JSON format for matrix strategy
+        printf -v modules_json '%s\n' "${modules[@]}" | jq -R . | jq -s .
+        echo "modules=$modules_json" >> $GITHUB_OUTPUT
+        echo "Found modules: $modules_json"
+
   download-test-data:
     runs-on: ubuntu-latest
     steps:
@@ -53,8 +90,12 @@ jobs:
         retention-days: 1
 
   miniwdl-test:
-    needs: download-test-data
+    needs: [discover-modules, download-test-data]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
+      fail-fast: false
     steps:
     - 
       name: Checkout
@@ -78,8 +119,13 @@ jobs:
     - 
       name: Run workflow with miniwdl
       run: |
-        mkdir -p test-output/miniwdl
-        miniwdl run modules/ww-sra/ww-sra.wdl -i modules/ww-sra/inputs.json --dir test-output/miniwdl
+        mkdir -p test-output/miniwdl/${{ matrix.module }}
+        module_dir="modules/${{ matrix.module }}"
+        wdl_file="$module_dir/${{ matrix.module }}.wdl"
+        inputs_file="$module_dir/inputs.json"
+        
+        echo "Running ${{ matrix.module }} with miniwdl..."
+        miniwdl run "$wdl_file" -i "$inputs_file" --dir "test-output/miniwdl/${{ matrix.module }}"
     - 
       name: Display validation report
       run: |
@@ -87,8 +133,12 @@ jobs:
         find test-output/miniwdl -name "validation_report.txt" -exec cat {} \;
   
   cromwell-test:
-    needs: download-test-data
+    needs: [discover-modules, download-test-data]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
+      fail-fast: false
     steps:
     - 
       name: Checkout
@@ -112,8 +162,14 @@ jobs:
     - 
       name: Run workflow with Cromwell
       run: |
-        mkdir -p test-output/cromwell
-        java -jar cromwell-86.jar run modules/ww-sra/ww-sra.wdl -i modules/ww-sra/inputs.json -o modules/ww-sra/options.json
+        mkdir -p test-output/cromwell/${{ matrix.module }}
+        module_dir="modules/${{ matrix.module }}"
+        wdl_file="$module_dir/${{ matrix.module }}.wdl"
+        inputs_file="$module_dir/inputs.json"
+        options_file="$module_dir/options.json"
+        
+        echo "Running ${{ matrix.module }} with Cromwell..."
+        java -jar cromwell-86.jar run "$wdl_file" -i "$inputs_file" -o "$options_file"
     - 
       name: Display validation report
       run: |
@@ -121,8 +177,12 @@ jobs:
         find . -name "validation_report.txt" -exec cat {} \;
   
   sprocket-test:
-    needs: download-test-data
+    needs: [discover-modules, download-test-data]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
+      fail-fast: false
     steps:
     - 
       name: Checkout
@@ -147,7 +207,14 @@ jobs:
       run: cargo-binstall sprocket --version 0.12.2
     - 
       name: Run workflow with Sprocket
-      run: sprocket run --output test-output/sprocket modules/ww-sra/ww-sra.wdl modules/ww-sra/inputs.json
+      run: |
+        mkdir -p test-output/sprocket/${{ matrix.module }}
+        module_dir="modules/${{ matrix.module }}"
+        wdl_file="$module_dir/${{ matrix.module }}.wdl"
+        inputs_file="$module_dir/inputs.json"
+        
+        echo "Running ${{ matrix.module }} with Sprocket..."
+        sprocket run --output "test-output/sprocket/${{ matrix.module }}" "$wdl_file" "$inputs_file"
     - 
       name: Display validation report
       run: |

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -212,7 +212,6 @@ jobs:
     - 
       name: Run workflow with Sprocket
       run: |
-        mkdir -p test-output/sprocket/${{ matrix.module }}
         module_dir="modules/${{ matrix.module }}"
         wdl_file="$module_dir/${{ matrix.module }}.wdl"
         inputs_file="$module_dir/inputs.json"

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -42,7 +42,7 @@ jobs:
         
         # Download a small test RNA-seq sample (SRR13008264 - mouse RNA-seq, ~100MB)
         fasterq-dump --split-files SRR13008264 -O test-data/
-        gzip SRR13008264_1.fastq SRR13008264_2.fastq
+        gzip test-data/SRR13008264_1.fastq test-data/SRR13008264_2.fastq
         ls -la test-data/
     - 
       name: Upload test data

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -8,6 +8,9 @@ on:
       - '**.wdl'
       - '.github/workflows/testrun.yml'
 
+permissions:
+  contents: read
+
 jobs:
   miniwdl-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -1,0 +1,118 @@
+name: WDL Workflow Test Run
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - '**.wdl'
+      - '.github/workflows/testrun.yml'
+
+jobs:
+  miniwdl-test:
+    runs-on: ubuntu-latest
+    steps:
+    - 
+      name: Checkout
+      uses: actions/checkout@v4
+    - 
+      name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+    - 
+      name: Install miniwdl
+      run: |
+        python -m pip install --upgrade pip
+        pip3 install miniwdl
+    - 
+      name: Run workflow with miniwdl
+      run: |
+        mkdir -p test-output/miniwdl
+        miniwdl run modules/ww-sra/ww-sra.wdl -i modules/ww-sra/inputs.json --dir test-output/miniwdl
+    -
+      name: Check for output files
+      run: |
+        # Check that we have the expected output files
+        if [ ! -f $(find test-output/miniwdl -name "SRR13191702_1.fastq.gz") ]; then
+          echo "R1 FASTQ file not found!"
+          exit 1
+        fi
+        
+        # List the output files for debugging
+        echo "Output files:"
+        find test-output/miniwdl -type f -name "*.fastq.gz" | sort
+  
+  cromwell-test:
+    runs-on: ubuntu-latest
+    steps:
+    - 
+      name: Checkout
+      uses: actions/checkout@v4
+    - 
+      name: Set Up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+    - 
+      name: Download Cromwell
+      run: |
+        wget -q https://github.com/broadinstitute/cromwell/releases/download/86/cromwell-86.jar
+    - 
+      name: Run workflow with Cromwell
+      run: |
+        mkdir -p test-output/cromwell
+        java -jar cromwell-86.jar run modules/ww-sra/ww-sra.wdl -i modules/ww-sra/inputs.json -o modules/ww-sra/options.json
+    -
+      name: Check for output files
+      run: |
+        # Find the cromwell-executions directory
+        EXEC_DIR=$(find . -type d -name "cromwell-executions" | head -1)
+        WORKFLOW_DIR=$(find $EXEC_DIR -type d -name "sra_download" | head -1)
+        
+        # List the directories to debug
+        echo "Execution directories:"
+        ls -la $WORKFLOW_DIR
+        
+        # Check the output directory
+        echo "Output directory contents:"
+        find test-output/cromwell -type f | sort
+        
+        # If the outputs aren't in the expected directory, check the execution directory
+        find $WORKFLOW_DIR -name "*.fastq.gz" | sort
+  
+  sprocket-test:
+    runs-on: ubuntu-latest
+    steps:
+    - 
+      name: Checkout
+      uses: actions/checkout@v4
+    - 
+      name: Set Up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - 
+      name: Install cargo-binstall
+      run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+    - 
+      name: Install Sprocket
+      run: cargo-binstall sprocket --version 0.12.2
+    - 
+      name: Run workflow with Sprocket
+      run: sprocket run --output test-output/sprocket modules/ww-sra/ww-sra.wdl modules/ww-sra/inputs.json
+    -
+      name: Check for output files
+      run: |
+        # List the output directory
+        echo "Sprocket output directory:"
+        find test-output/sprocket -type f | sort
+        
+        # Check for the expected files
+        if [ ! -f $(find test-output/sprocket -name "SRR13191702_1.fastq.gz") ]; then
+          echo "R1 FASTQ file not found in Sprocket output!"
+          ls -R test-output/sprocket
+          exit 1
+        fi

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -12,12 +12,59 @@ permissions:
   contents: read
 
 jobs:
-  miniwdl-test:
+  download-test-data:
     runs-on: ubuntu-latest
     steps:
     - 
       name: Checkout
       uses: actions/checkout@v4
+    - 
+      name: Download test data
+      run: |
+        mkdir -p test-data
+
+        # Download chromosome 22 fasta
+        wget -q -O test-data/chr22.fa.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/chromosomes/chr22.fa.gz
+        gunzip test-data/chr22.fa.gz
+
+        # Download chromosome 22 GTF file
+        wget -q -O test-data/hg38.ncbiRefSeq.gtf.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/genes/hg38.ncbiRefSeq.gtf.gz
+        gunzip test-data/hg38.ncbiRefSeq.gtf.gz
+        # Extract only chromosome 22 annotations
+        grep "^chr22[[:space:]]" test-data/hg38.ncbiRefSeq.gtf > test-data/chr22.gtf
+        rm test-data/hg38.ncbiRefSeq.gtf
+        
+        # Download a specific version (3.1.1) of the SRA toolkit
+        wget -q https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/3.1.1/sratoolkit.3.1.1-ubuntu64.tar.gz
+        tar -xzf sratoolkit.3.1.1-ubuntu64.tar.gz
+        echo "$PWD/sratoolkit.3.1.1-ubuntu64/bin" >> $GITHUB_PATH
+        export PATH="$PWD/sratoolkit.3.1.1-ubuntu64/bin:$PATH"
+        
+        # Download a small test RNA-seq sample (SRR13008264 - mouse RNA-seq, ~100MB)
+        fasterq-dump --split-files SRR13008264
+        gzip SRR13008264_1.fastq SRR13008264_2.fastq
+        ls -la test-data/
+    - 
+      name: Upload test data
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-data
+        path: test-data/
+        retention-days: 1
+
+  miniwdl-test:
+    needs: download-test-data
+    runs-on: ubuntu-latest
+    steps:
+    - 
+      name: Checkout
+      uses: actions/checkout@v4
+    - 
+      name: Download test data
+      uses: actions/download-artifact@v4
+      with:
+        name: test-data
+        path: test-data/
     - 
       name: Set up Python
       uses: actions/setup-python@v5
@@ -40,11 +87,18 @@ jobs:
         find test-output/miniwdl -name "validation_report.txt" -exec cat {} \;
   
   cromwell-test:
+    needs: download-test-data
     runs-on: ubuntu-latest
     steps:
     - 
       name: Checkout
       uses: actions/checkout@v4
+    - 
+      name: Download test data
+      uses: actions/download-artifact@v4
+      with:
+        name: test-data
+        path: test-data/
     - 
       name: Set Up Java
       uses: actions/setup-java@v4
@@ -67,11 +121,18 @@ jobs:
         find . -name "validation_report.txt" -exec cat {} \;
   
   sprocket-test:
+    needs: download-test-data
     runs-on: ubuntu-latest
     steps:
     - 
       name: Checkout
       uses: actions/checkout@v4
+    - 
+      name: Download test data
+      uses: actions/download-artifact@v4
+      with:
+        name: test-data
+        path: test-data/
     - 
       name: Set Up Rust
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -41,7 +41,7 @@ jobs:
         export PATH="$PWD/sratoolkit.3.1.1-ubuntu64/bin:$PATH"
         
         # Download a small test RNA-seq sample (SRR13008264 - mouse RNA-seq, ~100MB)
-        fasterq-dump --split-files SRR13008264
+        fasterq-dump --split-files SRR13008264 -O test-data/
         gzip SRR13008264_1.fastq SRR13008264_2.fastq
         ls -la test-data/
     - 

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -45,7 +45,11 @@ jobs:
         done
         
         # Convert array to JSON format for matrix strategy
-        printf -v modules_json '%s\n' "${modules[@]}" | jq -R . | jq -s .
+        if [ ${#modules[@]} -eq 0 ]; then
+          modules_json="[]"
+        else
+          modules_json=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -s .)
+        fi
         echo "modules=$modules_json" >> $GITHUB_OUTPUT
         echo "Found modules: $modules_json"
 

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -48,7 +48,7 @@ jobs:
         if [ ${#modules[@]} -eq 0 ]; then
           modules_json="[]"
         else
-          modules_json=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -s .)
+          modules_json=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -s -c .)
         fi
         echo "modules=$modules_json" >> $GITHUB_OUTPUT
         echo "Found modules: $modules_json"

--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -30,18 +30,11 @@ jobs:
       run: |
         mkdir -p test-output/miniwdl
         miniwdl run modules/ww-sra/ww-sra.wdl -i modules/ww-sra/inputs.json --dir test-output/miniwdl
-    -
-      name: Check for output files
+    - 
+      name: Display validation report
       run: |
-        # Check that we have the expected output files
-        if [ ! -f $(find test-output/miniwdl -name "SRR13191702_1.fastq.gz") ]; then
-          echo "R1 FASTQ file not found!"
-          exit 1
-        fi
-        
-        # List the output files for debugging
-        echo "Output files:"
-        find test-output/miniwdl -type f -name "*.fastq.gz" | sort
+        echo "=== MiniWDL Validation Report ==="
+        find test-output/miniwdl -name "validation_report.txt" -exec cat {} \;
   
   cromwell-test:
     runs-on: ubuntu-latest
@@ -64,23 +57,11 @@ jobs:
       run: |
         mkdir -p test-output/cromwell
         java -jar cromwell-86.jar run modules/ww-sra/ww-sra.wdl -i modules/ww-sra/inputs.json -o modules/ww-sra/options.json
-    -
-      name: Check for output files
+    - 
+      name: Display validation report
       run: |
-        # Find the cromwell-executions directory
-        EXEC_DIR=$(find . -type d -name "cromwell-executions" | head -1)
-        WORKFLOW_DIR=$(find $EXEC_DIR -type d -name "sra_download" | head -1)
-        
-        # List the directories to debug
-        echo "Execution directories:"
-        ls -la $WORKFLOW_DIR
-        
-        # Check the output directory
-        echo "Output directory contents:"
-        find test-output/cromwell -type f | sort
-        
-        # If the outputs aren't in the expected directory, check the execution directory
-        find $WORKFLOW_DIR -name "*.fastq.gz" | sort
+        echo "=== Cromwell Validation Report ==="
+        find . -name "validation_report.txt" -exec cat {} \;
   
   sprocket-test:
     runs-on: ubuntu-latest
@@ -103,16 +84,8 @@ jobs:
     - 
       name: Run workflow with Sprocket
       run: sprocket run --output test-output/sprocket modules/ww-sra/ww-sra.wdl modules/ww-sra/inputs.json
-    -
-      name: Check for output files
+    - 
+      name: Display validation report
       run: |
-        # List the output directory
-        echo "Sprocket output directory:"
-        find test-output/sprocket -type f | sort
-        
-        # Check for the expected files
-        if [ ! -f $(find test-output/sprocket -name "SRR13191702_1.fastq.gz") ]; then
-          echo "R1 FASTQ file not found in Sprocket output!"
-          ls -R test-output/sprocket
-          exit 1
-        fi
+        echo "=== Sprocket Validation Report ==="
+        find test-output/sprocket -name "validation_report.txt" -exec cat {} \;

--- a/modules/ww-sra/inputs.json
+++ b/modules/ww-sra/inputs.json
@@ -1,3 +1,4 @@
 {
-  "sra_download.sra_id_list":["SRR32657057", "SRR33450906"]
+  "sra_download.sra_id_list":["SRR13191702"],
+  "sra_download.n_cpu":1
 }

--- a/modules/ww-sra/options.json
+++ b/modules/ww-sra/options.json
@@ -5,6 +5,6 @@
     "default_runtime_attributes": {
         "maxRetries": 1
     },
-    "final_workflow_outputs_dir": "/path_to_outputs/sra-star-rnaseq-test/",
+    "final_workflow_outputs_dir": "$PWD/test-output/cromwell",
     "use_relative_output_paths": true
 }

--- a/modules/ww-sra/ww-sra.wdl
+++ b/modules/ww-sra/ww-sra.wdl
@@ -17,7 +17,8 @@ workflow sra_download {
     outputs: {
         r1_fastqs: "array of R1 fastq files for each sample",
         r2_fastqs: "array of R2 fastq files for each sample",
-        is_paired_end: "array of booleans indicating whether each sample used paired-end sequencing"
+        is_paired_end: "array of booleans indicating whether each sample used paired-end sequencing",
+        validation_report: "validation report confirming all expected outputs were generated"
     }
   }
 
@@ -38,10 +39,18 @@ workflow sra_download {
     }
   }
 
+  call validate_outputs { input:
+    sra_ids = sra_id_list,
+    r1_files = fastqdump.r1_end,
+    r2_files = fastqdump.r2_end,
+    is_paired_flags = fastqdump.is_paired_end
+  }
+
   output {
     Array[File] r1_fastqs = fastqdump.r1_end
     Array[File] r2_fastqs = fastqdump.r2_end
     Array[Boolean] is_paired_end = fastqdump.is_paired_end
+    File validation_report = validate_outputs.report
   }
 }
 
@@ -103,5 +112,101 @@ task fastqdump {
     memory: 2 * ncpu + " GB"
     docker: "getwilds/sra-tools:3.1.1"
     cpu: ncpu
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that all expected output files were generated correctly"
+    outputs: {
+        report: "Validation report summarizing file checks and statistics"
+    }
+  }
+
+  parameter_meta {
+    r1_files: "Array of R1 FASTQ files to validate"
+    r2_files: "Array of R2 FASTQ files to validate"
+    sra_ids: "List of SRA IDs that were processed"
+    is_paired_flags: "Array of paired-end flags for each sample"
+  }
+
+  input {
+    Array[File] r1_files
+    Array[File] r2_files
+    Array[String] sra_ids
+    Array[Boolean] is_paired_flags
+  }
+
+  command <<<
+    set -eo pipefail
+    
+    echo "=== SRA Download Validation Report ===" > validation_report.txt
+    echo "" >> validation_report.txt
+    
+    # Arrays for bash processing
+    sra_ids=(~{sep=" " sra_ids})
+    r1_files=(~{sep=" " r1_files})
+    r2_files=(~{sep=" " r2_files})
+    is_paired=(~{sep=" " is_paired_flags})
+    
+    validation_passed=true
+    
+    # Check each sample
+    for i in "${!sra_ids[@]}"; do
+      sra_id="${sra_ids[$i]}"
+      r1_file="${r1_files[$i]}"
+      r2_file="${r2_files[$i]}"
+      paired="${is_paired[$i]}"
+      
+      echo "--- Sample: $sra_id ---" >> validation_report.txt
+      echo "Paired-end: $paired" >> validation_report.txt
+      
+      # Check R1 file exists and is not empty
+      if [[ -f "$r1_file" && -s "$r1_file" ]]; then
+        r1_size=$(stat -c%s "$r1_file")
+        echo "R1 file: $r1_file (${r1_size} bytes)" >> validation_report.txt
+      else
+        echo "R1 file: $r1_file - MISSING OR EMPTY" >> validation_report.txt
+        validation_passed=false
+      fi
+      
+      # Check R2 file - should exist but may be empty for single-end
+      if [[ -f "$r2_file" ]]; then
+        r2_size=$(stat -c%s "$r2_file")
+        if [[ "$paired" == "true" && "$r2_size" -gt 0 ]]; then
+          echo "R2 file: $r2_file (${r2_size} bytes)" >> validation_report.txt
+        elif [[ "$paired" == "false" && "$r2_size" -eq 0 ]]; then
+          echo "R2 file: $r2_file (empty placeholder)" >> validation_report.txt
+        else
+          echo "R2 file: $r2_file - SIZE MISMATCH FOR PAIRING" >> validation_report.txt
+          validation_passed=false
+        fi
+      else
+        echo "R2 file: $r2_file - MISSING" >> validation_report.txt
+        validation_passed=false
+      fi
+    done
+      
+    # Final validation summary
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [[ "$validation_passed" == "true" ]]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+    
+    # Also output to stdout for immediate feedback
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "getwilds/sra-tools:3.1.1"
+    memory: "1 GB"
+    cpu: 1
   }
 }

--- a/modules/ww-star/inputs.json
+++ b/modules/ww-star/inputs.json
@@ -10,5 +10,8 @@
     "name": "chr22",
     "fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa",
     "gtf": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.gtf"
-  }
+  },
+  "star_example.genome_sa_index_nbases": 11,
+  "star_example.cpus": 2,
+  "star_example.memory_gb": 8
 }

--- a/modules/ww-star/inputs.json
+++ b/modules/ww-star/inputs.json
@@ -1,19 +1,14 @@
 {
   "star_example.samples": [
     {
-      "name": "SRR10724344",
-      "r1": "/path_to_first_input/SRR10724344_1.fastq.gz",
-      "r2": "/path_to_first_input/SRR10724344_2.fastq.gz"
-    },
-    {
-      "name": "SRR12345678",
-      "r1": "/path_to_second_input/SRR12345678_1.fastq.gz",
-      "r2": "/path_to_second_input/SRR12345678_2.fastq.gz"
+      "name": "SRR13008264",
+      "r1": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/SRR13008264_1.fastq.gz",
+      "r2": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/SRR13008264_2.fastq.gz"
     }
   ],
   "star_example.reference_genome": {
-    "name": "SuperAwesomeGenome",
-    "fasta": "/path_to_ref_data/awesome_genome.fna",
-    "gtf": "/path_to_ref_data/awesome_transcripts.gtf"
+    "name": "chr22",
+    "fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa",
+    "gtf": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.gtf"
   }
 }

--- a/modules/ww-star/options.json
+++ b/modules/ww-star/options.json
@@ -5,6 +5,6 @@
     "default_runtime_attributes": {
         "maxRetries": 1
     },
-    "final_workflow_outputs_dir": "/path_to_outputs/star_test_run/",
+    "final_workflow_outputs_dir": "cromwell_outputs",
     "use_relative_output_paths": true
 }

--- a/modules/ww-star/ww-star.wdl
+++ b/modules/ww-star/ww-star.wdl
@@ -201,7 +201,9 @@ task star_align_two_pass {
       --quantMode GeneCounts \
       --quantTranscriptomeBAMcompression 5 
 
-    rm -r star_index
+    # Clean up temporary directories
+    rm -rf star_index _STARtmp
+    rm -rf _STARpass1 _STARgenome 2>/dev/null || true
 
     mv Aligned.sortedByCoord.out.bam \
       "~{sample_data.name}.~{ref_genome_name}.Aligned.sortedByCoord.out.bam"


### PR DESCRIPTION
## Description
- Adding an initial version of a "test run" GitHub Action that executes a demonstrative run using small but relevant input data to prove the each script's functionality over time, even if outside infrastructure shifts.
- Parallelizes by execution engine and module WDL script, helping to provide a speedy test set.
- Eventually want to "pythonize" this a bit more, this is quite a lot of bash which might be hard to debug in the future.

## Related Issue
- Fixes #3 

## Testing
- GItHub Actions below demonstrate that the test runs work as expected and should scale as modules are added.