### PR TITLE
Adding initial draft of ww-sra-star vignette

### DIFF
--- a/vignettes/README.md
+++ b/vignettes/README.md
@@ -1,0 +1,3 @@
+
+# WILDS WDL Vignettes
+WILDS WDL vignettes are compact workflows that link together tasks from two or three different modules to demonstrate computational patterns that are ubiquitous to bioinformatics. A great example would be the GATK best practices workflows, potentially even a bit shorter, but similar principle: standard workflows to connect basic tools to perform highly-utilized concepts. No new tasks should be contained in these scripts, just an overarching workflow that imports existing modules and strings them together appropriately. An integration test run on small datasets should be run on these workflows weekly via GitHub Actions.

--- a/vignettes/ww-sra-star/README.md
+++ b/vignettes/ww-sra-star/README.md
@@ -1,0 +1,24 @@
+# ww-sra-star
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
+
+This WILDS WDL workflow downloads paired FASTQs from [SRA](https://www.ncbi.nlm.nih.gov/sra) and aligns them using the [two-pass methodology](https://github.com/alexdobin/STAR/blob/master/doc/STARmanual.pdf) of [STAR](https://github.com/alexdobin/STAR). It is intended to be a relatively simplistic demonstration of an RNA sequencing pipeline within the context of the WILDS ecosystem.
+
+# Usage
+
+For Fred Hutch users that are new to WDL, we recommend using [PROOF](https://sciwiki.fredhutch.org/dasldemos/proof-how-to/) to submit these workflows directly to the on-premise HPC cluster, as it simplifies interaction with Cromwell and provides a user-friendly front-end for job submission and tracking. For users outside of Fred Hutch or more advanced users who who would like to run the workflow locally, command line execution is relatively straightforward: 
+```
+java -jar cromwell-86.jar run ww-sra-star.wdl --inputs ww-sra-star-inputs.json
+```
+Although Cromwell is demonstrated here, this pipeline is not specific to Cromwell and can be run using whichever WDL execution method you prefer ([miniwdl](https://github.com/chanzuckerberg/miniwdl), [Terra](https://terra.bio/), [HealthOmics](https://docs.aws.amazon.com/omics/latest/dev/workflows.html), etc.).
+
+## Support
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Data Science Lab (DaSL) at wilds@fredhutch.org, or open an issue on our [issue tracker](https://github.com/getwilds/ww-sra-star/issues).
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL workflow, see our [contribution guidelines](.github/CONTRIBUTING.md) as well out our [WILDS Contributor Guide](https://getwilds.org/guide/) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/vignettes/ww-sra-star/inputs.json
+++ b/vignettes/ww-sra-star/inputs.json
@@ -1,7 +1,8 @@
 {
-  "sra_star.sra_id_list":["SRR9713123", "SRR9713124"],
+  "sra_star.sra_id_list":["SRR13008264"],
   "sra_star.ref_genome": {
-    "star_tar":"/home/tfirman/star_index.tar.gz",
-    "ref_name":"hg38"
+    "name": "chr22",
+    "fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa",
+    "gtf": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.gtf"
   }
 }

--- a/vignettes/ww-sra-star/inputs.json
+++ b/vignettes/ww-sra-star/inputs.json
@@ -1,0 +1,7 @@
+{
+  "sra_star.sra_id_list":["SRR9713123", "SRR9713124"],
+  "sra_star.ref_genome": {
+    "star_tar":"/home/tfirman/star_index.tar.gz",
+    "ref_name":"hg38"
+  }
+}

--- a/vignettes/ww-sra-star/inputs.json
+++ b/vignettes/ww-sra-star/inputs.json
@@ -4,5 +4,7 @@
     "name": "chr22",
     "fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa",
     "gtf": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.gtf"
-  }
+  },
+  "sra_star.ncpu": 2,
+  "sra_star.memory_gb": 8
 }

--- a/vignettes/ww-sra-star/options.json
+++ b/vignettes/ww-sra-star/options.json
@@ -1,0 +1,10 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": true,
+    "read_from_cache": true,
+    "default_runtime_attributes": {
+        "maxRetries": 1
+    },
+    "final_workflow_outputs_dir": "$PWD/test-output/cromwell",
+    "use_relative_output_paths": true
+}

--- a/vignettes/ww-sra-star/ww-sra-star.wdl
+++ b/vignettes/ww-sra-star/ww-sra-star.wdl
@@ -70,7 +70,7 @@ workflow sra_star {
         sjdb_overhang = sjdb_overhang,
         memory_gb = memory_gb,
         cpu_cores = ncpu,
-        star_threads = ncpu - 2
+        star_threads = ncpu
     }
   }
 

--- a/vignettes/ww-sra-star/ww-sra-star.wdl
+++ b/vignettes/ww-sra-star/ww-sra-star.wdl
@@ -1,0 +1,86 @@
+version 1.0
+
+import "../../modules/ww-sra/ww-sra.wdl" as sra_tasks
+import "../../modules/ww-star/ww-star.wdl" as star_tasks
+
+struct RefGenome {
+    String name
+    File fasta
+    File gtf
+}
+
+workflow sra_star {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "WDL workflow to download raw sequencing data from SRA and align using STAR two-pass methodology"
+    url: "https://github.com/getwilds/ww-sra-star"
+    outputs: {
+        star_bam: "array of aligned bam files for each sample",
+        star_bai: "array of corresponding index files for each aligned bam file",
+        star_gene_counts: "array of text files containing the number of reads in each gene for each sample",
+        star_log_final: "array of text files containing an overarching summary of the analysis performed for each sample",
+        star_log_progress: "array of text files containing a detailed progress report for each sample",
+        star_log: "array of text files containing STAR's raw command line output for each sample",
+        star_sj: "array of text files containing splice junction details for each sample being analyzed"
+    }
+  }
+
+  parameter_meta {
+    sra_id_list: "list of SRA sample ID's to be pulled down and aligned"
+    ref_genome: "reference genome object containing name, fasta, and gtf files"
+    sjdb_overhang: "Length of the genomic sequence around the annotated junction to be used in constructing the splice junctions database"
+    genome_sa_index_nbases: "Length (bases) of the SA pre-indexing string, typically between 10-15 (scales with genome size)"
+    ncpu: "number of CPUs to use for SRA download and STAR alignment"
+    memory_gb: "memory allocation in GB for STAR tasks"
+  }
+
+  input {
+    Array[String] sra_id_list
+    RefGenome ref_genome
+    Int sjdb_overhang = 100
+    Int genome_sa_index_nbases = 14
+    Int ncpu = 12
+    Int memory_gb = 64
+  }
+
+  call star_tasks.build_star_index { input:
+      reference_fasta = ref_genome.fasta,
+      reference_gtf = ref_genome.gtf,
+      sjdb_overhang = sjdb_overhang,
+      genome_sa_index_nbases = genome_sa_index_nbases,
+      memory_gb = memory_gb,
+      cpu_cores = ncpu
+  }
+
+  scatter ( id in sra_id_list ){
+    call sra_tasks.fastqdump { input:
+        sra_id = id,
+        ncpu = ncpu
+    }
+
+    call star_tasks.star_align_two_pass { input:
+        star_genome_tar = build_star_index.star_index_tar,
+        sample_data = {
+          "name": id,
+          "r1": fastqdump.r1_end,
+          "r2": fastqdump.r2_end
+        },
+        ref_genome_name = ref_genome.name,
+        sjdb_overhang = sjdb_overhang,
+        memory_gb = memory_gb,
+        cpu_cores = ncpu,
+        star_threads = ncpu - 2
+    }
+  }
+
+  output {
+    Array[File] star_bam = star_align_two_pass.bam
+    Array[File] star_bai = star_align_two_pass.bai
+    Array[File] star_gene_counts = star_align_two_pass.gene_counts
+    Array[File] star_log_final = star_align_two_pass.log_final
+    Array[File] star_log_progress = star_align_two_pass.log_progress
+    Array[File] star_log = star_align_two_pass.log
+    Array[File] star_sj = star_align_two_pass.sj_out
+  }
+}


### PR DESCRIPTION
## Description
- Adding an initial version of ww-sra-star as our first vignette.
- Need to add test-run logic to run vignettes in addition to modules.

## Related Issue
- Fixes #6 

## Testing
- Ran the workflow locally using all three execution engines, works as expected.