### PR TITLE
Add bwa module

### DIFF
--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -1,0 +1,102 @@
+# ww-gatk
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for sequence alignment using the Burrows-Wheler Alignment tool (BWA).
+
+## Overview
+
+This module provides reusable WDL tasks for aligning reads to a reference using BWA-MEM.
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
+
+- **Tasks**: `bwa_mem`
+- **Workflow**: `bwa_example` (demonstration workflow that executes all tasks)
+- **Container**: `getwilds/bwa:0.7.17`
+
+## Tasks
+
+### `bwa_mem`
+Calls germline variants.
+
+**Inputs:**
+- `sample_data` (SampleInfo): Sample information struct (name, R1 and R2 FASTQs)
+- `reference_fasta` (File): Reference genome FASTA file
+- `cpu_cores` (Int): Total number of CPU cores allocated for the task
+- `memory_gb` (Int): Memory allocated for the task in GB
+
+**Outputs:**
+- `sorted_bam` (File): Sorted BWA-MEM alignment output BAM file
+
+## Features
+
+The module is designed to be a foundational component within the WILDS ecosystem, suitable for use in larger analysis pipelines.
+
+## Usage
+
+### Requirements
+
+- [Cromwell](https://cromwell.readthedocs.io/), [MiniWDL](https://github.com/chanzuckerberg/miniwdl), [Sprocket](https://sprocket.bio/), or another WDL-compatible workflow executor
+- Docker/Apptainer (the workflow uses `getwilds/bwa:0.7.17` container)
+
+### Importing into Your Workflow
+
+TBD
+
+### Integration Examples
+
+TBD
+
+## Testing the Module
+
+TBD
+
+## Configuration Guidelines
+
+### Resource Allocation
+
+The module supports flexible resource configuration:
+
+- **Memory**: TBD
+- **CPUs**: TBD
+
+### Advanced Parameters
+
+- Resource allocation can be tuned for different compute environments
+
+## Requirements
+
+- WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
+- Docker/Apptainer support
+- Sufficient memory for alignment
+
+## Features
+
+- **BWA-MEM alignment**: Align sequences 70bp to 1Mbp in length
+- **Validation**: Built-in output validation and reporting
+- **Scalable**: Configurable resource allocation
+- **Robust**: Extensive error handling and cleanup
+- **Compatible**: Works with multiple WDL executors
+
+## Module Development
+
+This module is automatically tested as part of the WILDS WDL Library CI/CD pipeline using:
+- Multiple WDL executors (Cromwell, miniWDL, Sprocket)
+- Real RNA-seq data (chromosome 22 subset for efficiency)
+- Comprehensive validation of all outputs
+
+For questions specific to this module or to contribute improvements, please see the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library).
+
+## Support
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Data Science Lab (DaSL) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL module, please see our [WILDS Contributor Guide](https://getwilds.org/guide/) and the [WILDS WDL Library contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -1,4 +1,3 @@
-```markdown
 # ww-bwa
 [![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)  
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -186,4 +185,3 @@ To contribute to this module, please review the [WILDS Contributor Guide](https:
 ## License
 
 Distributed under the MIT License. See `LICENSE` for full details.
-```

--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -29,6 +29,7 @@ Builds BWA index files from reference FASTA.
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
 
 **Outputs:**
+- `fasta` (File): "Reference genome FASTA file"
 - `amb` (File): Text file of ambiguous bases
 - `ann` (File): Text file of reference sequence information, such as name and length
 - `bwt` (File): Binary file of Burrows-Wheeler transformed reference sequence
@@ -76,7 +77,7 @@ workflow my_alignment_pipeline {
     call bwa_tasks.bwa_mem {
       input:
         sample_data = sample,
-        reference_fasta = reference_fasta
+        reference_fasta = bwa_index.fasta
     }
   }
 

--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -30,11 +30,11 @@ Builds BWA index files from reference FASTA.
 
 **Outputs:**
 - `fasta` (File): "Reference genome FASTA file"
-- `amb` (File): Text file of ambiguous bases
-- `ann` (File): Text file of reference sequence information, such as name and length
-- `bwt` (File): Binary file of Burrows-Wheeler transformed reference sequence
-- `pac` (File): Binary file of compressed reference sequence
-- `sa` (File): Binary file of the suffix array
+- `fa_amb` (File): Text file of ambiguous bases
+- `fa_ann` (File): Text file of reference sequence information, such as name and length
+- `fa_bwt` (File): Binary file of Burrows-Wheeler transformed reference sequence
+- `fa_pac` (File): Binary file of compressed reference sequence
+- `fa_sa` (File): Binary file of the suffix array
 
 ### `bwa_mem`
 

--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -29,18 +29,14 @@ Builds BWA index files from reference FASTA.
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
 
 **Outputs:**
-- `fasta` (File): "Reference genome FASTA file"
-- `fa_amb` (File): Text file of ambiguous bases
-- `fa_ann` (File): Text file of reference sequence information, such as name and length
-- `fa_bwt` (File): Binary file of Burrows-Wheeler transformed reference sequence
-- `fa_pac` (File): Binary file of compressed reference sequence
-- `fa_sa` (File): Binary file of the suffix array
+- `bwa_index_tar` (File): Compressed tarball containing BWA genome index
 
 ### `bwa_mem`
 
 Aligns paired-end reads to a reference using BWA-MEM.
 
 **Inputs:**
+- `bwa_genome_tar` (File): Compressed tarball containing BWA genome index
 - `reference_fasta` (File): Reference genome FASTA file (indexed and preprocessed externally)
 - `sample_data` (SampleInfo): Sample information struct containing sample name and R1/R2 FASTQ file paths
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
@@ -76,8 +72,9 @@ workflow my_alignment_pipeline {
   scatter (sample in samples) {
     call bwa_tasks.bwa_mem {
       input:
-        sample_data = sample,
-        reference_fasta = bwa_index.fasta
+        bwa_genome_tar = bwa_index.bwa_index_tar,
+        reference_fasta = reference_fasta,
+        sample_data = sample
     }
   }
 

--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -14,7 +14,7 @@ The module is designed to be a foundational component within the WILDS ecosystem
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
 
-- **Task**: `bwa_index`, `bwa_mem`
+- **Task**: `bwa_index`, `bwa_mem`, `validate_outputs`
 - **Workflow**: `bwa_example` (demonstration workflow that executes all tasks)
 - **Container**: `getwilds/bwa:0.7.17`
 
@@ -45,6 +45,17 @@ Aligns paired-end reads to a reference using BWA-MEM.
 **Outputs:**
 - `sorted_bam` (File): Sorted BAM alignment file
 - `sorted_bai` (File): BAM index file
+
+### `validate_outputs`
+Validates alignment outputs and generates a comprehensive report.
+
+**Inputs:**
+- `bam_files` (File): BAM file to validate
+- `bai_files` (File): BAM index file to validate
+- `sample_names` (String): Sample name that was processed
+
+**Outputs:**
+- `report` (File): Validation summary with alignment statistics
 
 ## Usage as a Module
 
@@ -145,6 +156,7 @@ sprocket run ww-bwa.wdl inputs.json
 
 - **BWA-MEM alignment**: Fast and accurate for reads 70bp to 1Mbp
 - **Sorted BAM output**: Ready for downstream analysis (variant calling, QC, etc.)
+- **Validation**: Built-in output validation and reporting
 - **Modular design**: Integrates with other WILDS workflows and tools
 - **Scalable**: Supports batch alignment across many samples
 - **Flexible**: Customizable resource settings per task
@@ -155,6 +167,7 @@ sprocket run ww-bwa.wdl inputs.json
 This module is automatically tested as part of the WILDS WDL Library CI/CD pipeline using:
 - Multiple WDL executors (Cromwell, miniWDL, Sprocket)
 - Real RNA-seq data (chromosome 22 subset for efficiency)
+- Comprehensive validation of all outputs
 
 For questions specific to this module or to contribute improvements, please see the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library).
 

--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -41,8 +41,8 @@ Builds BWA index files from reference FASTA.
 Aligns paired-end reads to a reference using BWA-MEM.
 
 **Inputs:**
-- `sample_data` (SampleInfo): Sample information struct containing sample name and R1/R2 FASTQ file paths
 - `reference_fasta` (File): Reference genome FASTA file (indexed and preprocessed externally)
+- `sample_data` (SampleInfo): Sample information struct containing sample name and R1/R2 FASTQ file paths
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
 

--- a/modules/ww-bwa/inputs.json
+++ b/modules/ww-bwa/inputs.json
@@ -6,17 +6,7 @@
       "r2": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/SRR13008264_2.fastq.gz"
     }
   ],
-  "bwa_example.reference_genome": {
-    "ref_dict": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.dict",
-    "ref_fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa",
-    "ref_amb": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.amb",
-    "ref_ann": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.ann",
-    "ref_bwt": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.bwt",
-    "ref_fasta_index": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.fai",
-    "ref_pac": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.pac",
-    "ref_sa": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.sa",
-    "ref_name": "hg38"
-  },
+  "bwa_example.reference_fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa",
   "bwa_example.cpus": 2,
   "bwa_example.memory_gb": 8
 }

--- a/modules/ww-bwa/inputs.json
+++ b/modules/ww-bwa/inputs.json
@@ -1,0 +1,22 @@
+{
+  "bwa_example.samples": [
+    {
+      "name": "SRR13008264",
+      "r1": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/SRR13008264_1.fastq.gz",
+      "r2": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/SRR13008264_2.fastq.gz"
+    }
+  ],
+  "bwa_example.reference_genome": {
+    "ref_dict": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.dict",
+    "ref_fasta": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa",
+    "ref_amb": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.amb",
+    "ref_ann": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.ann",
+    "ref_bwt": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.bwt",
+    "ref_fasta_index": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.fai",
+    "ref_pac": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.pac",
+    "ref_sa": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.sa",
+    "ref_name": "hg38"
+  },
+  "bwa_example.cpus": 2,
+  "bwa_example.memory_gb": 8
+}

--- a/modules/ww-bwa/inputs.json
+++ b/modules/ww-bwa/inputs.json
@@ -1,4 +1,5 @@
 {
+  "bwa_example.reference_fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa",
   "bwa_example.samples": [
     {
       "name": "SRR13008264",
@@ -6,7 +7,6 @@
       "r2": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/SRR13008264_2.fastq.gz"
     }
   ],
-  "bwa_example.reference_fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa",
   "bwa_example.cpus": 2,
   "bwa_example.memory_gb": 8
 }

--- a/modules/ww-bwa/inputs.json
+++ b/modules/ww-bwa/inputs.json
@@ -7,14 +7,14 @@
     }
   ],
   "bwa_example.reference_genome": {
-    "ref_dict": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.dict",
-    "ref_fasta": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa",
-    "ref_amb": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.amb",
-    "ref_ann": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.ann",
-    "ref_bwt": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.bwt",
-    "ref_fasta_index": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.fai",
-    "ref_pac": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.pac",
-    "ref_sa": "/fh/fast/paguirigan_a/sanaz/Research/VariantCalling/ww-vc-trio_sanaz/chromoseq/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.sa",
+    "ref_dict": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.dict",
+    "ref_fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa",
+    "ref_amb": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.amb",
+    "ref_ann": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.ann",
+    "ref_bwt": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.bwt",
+    "ref_fasta_index": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.fai",
+    "ref_pac": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.pac",
+    "ref_sa": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/reference_files/GRCh38/Gencode_GRCh38.primary_assembly.genome.fa.sa",
     "ref_name": "hg38"
   },
   "bwa_example.cpus": 2,

--- a/modules/ww-bwa/options.json
+++ b/modules/ww-bwa/options.json
@@ -1,0 +1,10 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": true,
+    "read_from_cache": true,
+    "default_runtime_attributes": {
+        "maxRetries": 1
+    },
+    "final_workflow_outputs_dir": "cromwell_outputs",
+    "use_relative_output_paths": true
+}

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -1,0 +1,100 @@
+## WILDS WDL for performing sequence alignment using BWA-MEM.
+## Designed to be a modular component within the WILDS ecosystem that can be used
+## independently or integrated with other WILDS workflows.
+
+version 1.0
+
+struct SampleInfo {
+    String name
+    File r1
+    File r2
+}
+
+struct RefGenome {
+    File ref_dict
+    File ref_fasta
+    File ref_amb
+    File ref_ann
+    File ref_bwt
+    File ref_fasta_index
+    File ref_pac
+    File ref_sa
+}
+ 
+workflow bwa_example {
+  meta {
+    author: "Emma Bishop"
+    email: "ebishop@fredhutch.org"
+    description: "WDL workflow for sequence alignment via BWA-MEM"
+    url: "https://github.com/getwilds/wilds-wdl-library/modules/ww-bwa"
+    outputs: {
+        bwa_bam: "Sorted BWA-MEM alignment output BAM files for each sample"
+    }
+  }
+
+  parameter_meta {
+    samples: "List of sample objects, each containing name and r1/r2 fastq files"
+    reference_genome: "Reference genome object containing name, fasta, and related files"
+    cpus: "Number of CPU cores allocated for each task in the workflow"
+    memory_gb: "Memory allocated for each task in the workflow in GB"
+  }
+
+  input {
+    Array[SampleInfo] samples
+    RefGenome reference_genome
+    Int cpus = 8
+    Int memory_gb = 64
+  }
+
+  scatter (sample in samples) {
+    call bwa_mem { input:
+        sample_data = sample,
+        reference_fasta = reference_genome.ref_fasta,
+        cpu_cores = cpus,
+        memory_gb = memory_gb
+    }
+  }
+
+  output {
+    Array[File] bwa_bam = bwa_mem.sorted_bam
+  }
+}
+
+task bwa_mem {
+  meta {
+    description: "Task for aligning sequence reads using BWA-MEM"
+    outputs: {
+        sorted_bam: "Sorted BWA-MEM alignment output BAM file"
+    }
+  }
+
+  parameter_meta {
+    sample_data: "Sample object containing name and r1/r2 fastq files"
+    reference_fasta: "Reference genome FASTA file"
+    cpu_cores: "Total number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    SampleInfo sample_data
+    File reference_fasta
+    Int cpu_cores = 8
+    Int memory_gb = 62
+  }
+
+  command <<<
+  set -eo pipefail && \
+  bwa mem -p -v 3 -t ~{cpu_cores} -M -R '@RG\tID:~{sample_data.name}\tSM:~{sample_data.name}\tPL:illumina' ~{reference_fasta} "~{sample_data.r1}" "~{sample_data.r2}" - > ~{sample_data.name}.sam && \
+  samtools sort -@ ~{cpu_cores-1} -o ~{sample_data.name}.sorted_aligned.bam ~{sample_data.name}.sam
+  >>>
+
+  output {
+    File sorted_bam = "~{sample_data.name}.sorted_aligned.bam"
+  }
+  
+  runtime {
+    docker: "getwilds/bwa:0.7.17"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -52,9 +52,16 @@ workflow bwa_example {
     }
   }
 
+    call validate_outputs { input:
+    sample_names = bwa_mem.name,
+    bam_files = bwa_mem.sorted_bam,
+    bai_files = bwa_mem.sorted_bai
+  }
+
   output {
     Array[File] bwa_bam = bwa_mem.sorted_bam
     Array[File] bwa_bai = bwa_mem.sorted_bai
+    File validation_report = validate_outputs.report
   }
 }
 
@@ -142,6 +149,7 @@ task bwa_mem {
   >>>
 
   output {
+    String name = sample_data.name
     File sorted_bam = "~{sample_data.name}.sorted_aligned.bam"
     File sorted_bai = "~{sample_data.name}.sorted_aligned.bam.bai"
   }
@@ -150,5 +158,105 @@ task bwa_mem {
     docker: "getwilds/bwa:0.7.17"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that all expected BWA-MEM output files were generated correctly"
+    outputs: {
+        report: "Validation report summarizing file checks and alignment statistics"
+    }
+  }
+
+  parameter_meta {
+    bam_files: "Array of BAM files to validate"
+    bai_files: "Array of BAM index files to validate"
+    sample_names: "Array of sample names that were processed"
+  }
+
+  input {
+    Array[File] bam_files
+    Array[File] bai_files
+    Array[String] sample_names
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== BWA-MEM Alignment Validation Report ===" > validation_report.txt
+    echo "" >> validation_report.txt
+
+    # Arrays for bash processing
+    sample_names=(~{sep=" " sample_names})
+    bam_files=(~{sep=" " bam_files})
+    bai_files=(~{sep=" " bai_files})
+
+    validation_passed=true
+    total_mapped_reads=0
+
+    # Check each sample
+    for i in "${!sample_names[@]}"; do
+      sample_name="${sample_names[$i]}"
+      bam_file="${bam_files[$i]}"
+      bai_file="${bai_files[$i]}"
+
+      echo "--- Sample: $sample_name ---" >> validation_report.txt
+
+      # Check BAM file exists and is not empty
+      if [[ -f "$bam_file" && -s "$bam_file" ]]; then
+        bam_size=$(stat -c%s "$bam_file")
+        echo "BAM file: $bam_file (${bam_size} bytes)" >> validation_report.txt
+
+        # Try to get alignment stats from samtools if available
+        if command -v samtools &> /dev/null; then
+          mapped_reads=$(samtools view -c -F 4 "$bam_file" 2>/dev/null || echo "N/A")
+          total_reads=$(samtools view -c "$bam_file" 2>/dev/null || echo "N/A")
+          echo "  Total reads: $total_reads" >> validation_report.txt
+          echo "  Mapped reads: $mapped_reads" >> validation_report.txt
+
+          if [[ "$mapped_reads" =~ ^[0-9]+$ ]]; then
+            total_mapped_reads=$((total_mapped_reads + mapped_reads))
+          fi
+        fi
+      else
+        echo "BAM file: $bam_file - MISSING OR EMPTY" >> validation_report.txt
+        validation_passed=false
+      fi
+
+      # Check BAI file exists
+      if [[ -f "$bai_file" ]]; then
+        bai_size=$(stat -c%s "$bai_file")
+        echo "BAI file: $bai_file (${bai_size} bytes)" >> validation_report.txt
+      else
+        echo "BAI file: $bai_file - MISSING" >> validation_report.txt
+        validation_passed=false
+      fi
+
+      echo "" >> validation_report.txt
+    done
+
+    # Overall summary
+    echo "=== Validation Summary ===" >> validation_report.txt
+    echo "Total samples processed: ${#sample_names[@]}" >> validation_report.txt
+    if [[ "$validation_passed" == "true" ]]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    # Also output to stdout for immediate feedback
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "getwilds/bwa:0.7.17"
+    cpu: 1
+    memory: "2 GB"
   }
 }

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -61,10 +61,10 @@ task bwa_index {
   meta {
     description: "Task for building BWA index files from a reference FASTA"
     outputs: {
-        amb: "Text file of ambiguous bases"
-        ann: "Text file of reference sequence information, such as name and length"
-        bwt: "Binary file of Burrows-Wheeler transformed reference sequence"
-        pac: "Binary file of compressed reference sequence"
+        amb: "Text file of ambiguous bases",
+        ann: "Text file of reference sequence information, such as name and length",
+        bwt: "Binary file of Burrows-Wheeler transformed reference sequence",
+        pac: "Binary file of compressed reference sequence",
         sa: "Binary file of the suffix array"
     }
   }
@@ -105,7 +105,7 @@ task bwa_mem {
   meta {
     description: "Task for aligning sequence reads using BWA-MEM"
     outputs: {
-        sorted_bam: "Sorted BWA-MEM alignment output BAM file"
+        sorted_bam: "Sorted BWA-MEM alignment output BAM file",
         sorted_bai: "Index files for the sorted BWA-MEM alignment BAM files"
     }
   }

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -123,8 +123,8 @@ task bwa_mem {
 
   command <<<
   set -eo pipefail && \
-  bwa mem -p -v 3 -t ~{cpu_cores} -M -R '@RG\tID:~{sample_data.name}\tSM:~{sample_data.name}\tPL:illumina' ~{reference_fasta} "~{sample_data.r1}" "~{sample_data.r2}" - > ~{sample_data.name}.sam && \
-  samtools sort -@ ~{cpu_cores-1} -o ~{sample_data.name}.sorted_aligned.bam ~{sample_data.name}.sam
+  bwa mem -v 3 -t max(1, ~{cpu_cores-1}) -M -R '@RG\tID:~{sample_data.name}\tSM:~{sample_data.name}\tPL:illumina' ~{reference_fasta} "~{sample_data.r1}" "~{sample_data.r2}" - > ~{sample_data.name}.sam && \
+  samtools sort -@ max(1, ~{cpu_cores-1}) -o ~{sample_data.name}.sorted_aligned.bam ~{sample_data.name}.sam
   >>>
 
   output {

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -33,8 +33,8 @@ workflow bwa_example {
   }
 
   parameter_meta {
-    samples: "List of sample objects, each containing name and r1/r2 fastq files"
-    reference_genome: "Reference genome object containing name, fasta, and related files"
+    samples: "List of sample objects, each containing sample name and R1/R2 FASTQ files"
+    reference_fasta: "Reference genome FASTA file"
     cpus: "Number of CPU cores allocated for each task in the workflow"
     memory_gb: "Memory allocated for each task in the workflow in GB"
   }
@@ -69,9 +69,9 @@ task bwa_mem {
   }
 
   parameter_meta {
-    sample_data: "Sample object containing name and r1/r2 fastq files"
-    reference_fasta: "Reference genome FASTA file"
-    cpu_cores: "Total number of CPU cores allocated for the task"
+    sample_data: "Sample object containing sample name and R1/R2 FASTQ files"
+    reference_fasta: "BWA indexed reference genome FASTA file"
+    cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
   }
 
@@ -79,7 +79,7 @@ task bwa_mem {
     SampleInfo sample_data
     File reference_fasta
     Int cpu_cores = 8
-    Int memory_gb = 62
+    Int memory_gb = 16
   }
 
   command <<<
@@ -91,7 +91,7 @@ task bwa_mem {
   output {
     File sorted_bam = "~{sample_data.name}.sorted_aligned.bam"
   }
-  
+
   runtime {
     docker: "getwilds/bwa:0.7.17"
     cpu: cpu_cores

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -17,7 +17,7 @@ workflow bwa_example {
     description: "WDL workflow for sequence alignment via BWA-MEM"
     url: "https://github.com/getwilds/wilds-wdl-library/modules/ww-bwa"
     outputs: {
-        bwa_bam: "Sorted BWA-MEM alignment output BAM files for each sample"
+        bwa_bam: "Sorted BWA-MEM alignment output BAM files for each sample",
         bwa_bai: "Index files for the sorted BWA-MEM alignment BAM files"
     }
   }
@@ -37,7 +37,7 @@ workflow bwa_example {
   }
 
   call bwa_index { input:
-      reference_fasta = reference_fasta
+      reference_fasta = reference_fasta,
       cpu_cores = cpus,
       memory_gb = memory_gb
   }

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -45,7 +45,7 @@ workflow bwa_example {
   scatter (sample in samples) {
     call bwa_mem { input:
         sample_data = sample,
-        reference_fasta = reference_fasta,
+        reference_fasta = bwa_index.fasta,
         cpu_cores = cpus,
         memory_gb = memory_gb
     }
@@ -61,6 +61,7 @@ task bwa_index {
   meta {
     description: "Task for building BWA index files from a reference FASTA"
     outputs: {
+        fasta: "Reference genome FASTA file",
         amb: "Text file of ambiguous bases",
         ann: "Text file of reference sequence information, such as name and length",
         bwt: "Binary file of Burrows-Wheeler transformed reference sequence",
@@ -87,6 +88,7 @@ task bwa_index {
   >>>
 
   output {
+    File fasta = "~{reference_fasta}"
     File amb = "~{reference_fasta}.amb"
     File ann = "~{reference_fasta}.ann"
     File bwt = "~{reference_fasta}.bwt"

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -9,7 +9,7 @@ struct SampleInfo {
     File r1
     File r2
 }
- 
+
 workflow bwa_example {
   meta {
     author: "Emma Bishop"
@@ -62,11 +62,11 @@ task bwa_index {
     description: "Task for building BWA index files from a reference FASTA"
     outputs: {
         fasta: "Reference genome FASTA file",
-        amb: "Text file of ambiguous bases",
-        ann: "Text file of reference sequence information, such as name and length",
-        bwt: "Binary file of Burrows-Wheeler transformed reference sequence",
-        pac: "Binary file of compressed reference sequence",
-        sa: "Binary file of the suffix array"
+        fa_amb: "Text file of ambiguous bases",
+        fa_ann: "Text file of reference sequence information, such as name and length",
+        fa_bwt: "Binary file of Burrows-Wheeler transformed reference sequence",
+        fa_pac: "Binary file of compressed reference sequence",
+        fa_sa: "Binary file of the suffix array"
     }
   }
 
@@ -84,16 +84,16 @@ task bwa_index {
 
   command <<<
   set -eo pipefail && \
-  bwa index ~{reference_fasta}
+  bwa index "~{reference_fasta}"
   >>>
 
   output {
     File fasta = "~{reference_fasta}"
-    File amb = "~{reference_fasta}.amb"
-    File ann = "~{reference_fasta}.ann"
-    File bwt = "~{reference_fasta}.bwt"
-    File pac = "~{reference_fasta}.pac"
-    File sa = "~{reference_fasta}.sa"
+    File fa_amb = "~{reference_fasta}.amb"
+    File fa_ann = "~{reference_fasta}.ann"
+    File fa_bwt = "~{reference_fasta}.bwt"
+    File fa_pac = "~{reference_fasta}.pac"
+    File fa_sa = "~{reference_fasta}.sa"
   }
 
   runtime {

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -18,6 +18,7 @@ workflow bwa_example {
     url: "https://github.com/getwilds/wilds-wdl-library/modules/ww-bwa"
     outputs: {
         bwa_bam: "Sorted BWA-MEM alignment output BAM files for each sample"
+        bwa_bai: "Index files for the sorted BWA-MEM alignment BAM files"
     }
   }
 
@@ -52,6 +53,7 @@ workflow bwa_example {
 
   output {
     Array[File] bwa_bam = bwa_mem.sorted_bam
+    Array[File] bwa_bai = bwa_mem.sorted_bai
   }
 }
 
@@ -104,6 +106,7 @@ task bwa_mem {
     description: "Task for aligning sequence reads using BWA-MEM"
     outputs: {
         sorted_bam: "Sorted BWA-MEM alignment output BAM file"
+        sorted_bai: "Index files for the sorted BWA-MEM alignment BAM files"
     }
   }
 
@@ -125,10 +128,12 @@ task bwa_mem {
   set -eo pipefail && \
   bwa mem -v 3 -t max(1, ~{cpu_cores-1}) -M -R '@RG\tID:~{sample_data.name}\tSM:~{sample_data.name}\tPL:illumina' ~{reference_fasta} "~{sample_data.r1}" "~{sample_data.r2}" - > ~{sample_data.name}.sam && \
   samtools sort -@ max(1, ~{cpu_cores-1}) -o ~{sample_data.name}.sorted_aligned.bam ~{sample_data.name}.sam
+  samtools index ~{sample_data.name}.sorted_aligned.bam
   >>>
 
   output {
     File sorted_bam = "~{sample_data.name}.sorted_aligned.bam"
+    File sorted_bai = "~{sample_data.name}.sorted_aligned.bam.bai"
   }
 
   runtime {

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -23,15 +23,15 @@ workflow bwa_example {
   }
 
   parameter_meta {
-    samples: "List of sample objects, each containing sample name and R1/R2 FASTQ files"
     reference_fasta: "Reference genome FASTA file"
+    samples: "List of sample objects, each containing sample name and R1/R2 FASTQ files"
     cpus: "Number of CPU cores allocated for each task in the workflow"
     memory_gb: "Memory allocated for each task in the workflow in GB"
   }
 
   input {
-    Array[SampleInfo] samples
     File reference_fasta
+    Array[SampleInfo] samples
     Int cpus = 8
     Int memory_gb = 32
   }
@@ -113,15 +113,15 @@ task bwa_mem {
   }
 
   parameter_meta {
-    sample_data: "Sample object containing sample name and R1/R2 FASTQ files"
     reference_fasta: "BWA indexed reference genome FASTA file"
+    sample_data: "Sample object containing sample name and R1/R2 FASTQ files"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
   }
 
   input {
-    SampleInfo sample_data
     File reference_fasta
+    SampleInfo sample_data
     Int cpu_cores = 8
     Int memory_gb = 16
   }


### PR DESCRIPTION
This PR adds a module for using BWA (`bwa index` and `bwa mem`)

## Description
Adds a folder that contains:
- WDL with two tasks and an example workflow that runs both
- REAMDE in the style of the `ww-star` module README
- `inputs.json` that makes use of the example files that are downloaded via GHA
- `options.json` copied from the `ww-star` module

## Related Issue

#18 

## Example

See README for example usage
