### PR TITLE
Fixing Sprocket linting error for ww-star

### DIFF
--- a/modules/ww-star/ww-star.wdl
+++ b/modules/ww-star/ww-star.wdl
@@ -262,10 +262,10 @@ task validate_outputs {
     echo "" >> validation_report.txt
     
     # Arrays for bash processing
-    sample_names=(~{sep=" " sample_names})
-    bam_files=(~{sep=" " bam_files})
-    bai_files=(~{sep=" " bai_files})
-    gene_count_files=(~{sep=" " gene_count_files})
+    sample_names=~{sep=" " sample_names}
+    bam_files=~{sep=" " bam_files}
+    bai_files=~{sep=" " bai_files}
+    gene_count_files=~{sep=" " gene_count_files}
     
     validation_passed=true
     total_mapped_reads=0


### PR DESCRIPTION
## Description
- While developing the ww-leukemia workflow, the Sprocket linting tool threw a fit about one of the STAR tasks.

## Testing
- See GitHub Actions below.
