### PR TITLE
Adding initial version of bcftools module

### DIFF
--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -64,9 +64,16 @@ jobs:
       run: |
         mkdir -p test-data
 
+        # Install samtools for creating FASTA index
+        sudo apt-get update
+        sudo apt-get install -y samtools
+
         # Download chromosome 22 fasta
         wget -q -O test-data/chr22.fa.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/chromosomes/chr22.fa.gz
         gunzip test-data/chr22.fa.gz
+
+        # Create FASTA index file (.fai) for bcftools and other tools
+        samtools faidx test-data/chr22.fa
 
         # Download chromosome 22 GTF file
         wget -q -O test-data/hg38.ncbiRefSeq.gtf.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/genes/hg38.ncbiRefSeq.gtf.gz
@@ -79,7 +86,7 @@ jobs:
         # Get chromosome length from the FASTA file
         CHR22_LENGTH=$(grep -v "^>" test-data/chr22.fa | tr -d '\n' | wc -c)
         echo -e "chr22\t0\t${CHR22_LENGTH}" > test-data/chr22.bed
-        
+
         # Download a specific version (3.1.1) of the SRA toolkit
         wget -q https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/3.1.1/sratoolkit.3.1.1-ubuntu64.tar.gz
         tar -xzf sratoolkit.3.1.1-ubuntu64.tar.gz

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -75,6 +75,11 @@ jobs:
         grep "^chr22[[:space:]]" test-data/hg38.ncbiRefSeq.gtf > test-data/chr22.gtf
         rm test-data/hg38.ncbiRefSeq.gtf
         
+        # Create a BED file covering the entire chromosome 22
+        # Get chromosome length from the FASTA file
+        CHR22_LENGTH=$(grep -v "^>" test-data/chr22.fa | tr -d '\n' | wc -c)
+        echo -e "chr22\t0\t${CHR22_LENGTH}" > test-data/chr22.bed
+        
         # Download a specific version (3.1.1) of the SRA toolkit
         wget -q https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/3.1.1/sratoolkit.3.1.1-ubuntu64.tar.gz
         tar -xzf sratoolkit.3.1.1-ubuntu64.tar.gz

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -96,6 +96,31 @@ jobs:
         # Download a small test RNA-seq sample (SRR13008264 - mouse RNA-seq, ~100MB)
         fasterq-dump --split-files SRR13008264 -O test-data/
         gzip test-data/SRR13008264_1.fastq test-data/SRR13008264_2.fastq
+        
+        # Generate a small aligned BAM file for testing workflows that need pre-aligned data
+        # This is a minimal example - for real testing, use the actual alignment modules
+        echo "Generating test BAM file..."
+        
+        # Install bwa for alignment
+        sudo apt-get install -y bwa
+        
+        # Create BWA index
+        bwa index test-data/chr22.fa
+        
+        # Align reads and create sorted BAM (using a subset of reads for speed)
+        zcat test-data/SRR13008264_1.fastq.gz | head -40000 > test-data/subset_1.fastq
+        zcat test-data/SRR13008264_2.fastq.gz | head -40000 > test-data/subset_2.fastq
+        
+        bwa mem -t 2 -R '@RG\tID:test\tSM:SRR13008264\tPL:illumina' \
+          test-data/chr22.fa test-data/subset_1.fastq test-data/subset_2.fastq | \
+          samtools sort -o test-data/SRR13008264.chr22.aligned.bam
+        
+        # Index the BAM file
+        samtools index test-data/SRR13008264.chr22.aligned.bam
+        
+        # Clean up temporary files
+        rm test-data/subset_1.fastq test-data/subset_2.fastq
+        
         ls -la test-data/
     - 
       name: Upload test data

--- a/modules/ww-bcftools/README.md
+++ b/modules/ww-bcftools/README.md
@@ -1,0 +1,197 @@
+# ww-bcftools
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for variant calling and manipulation using bcftools.
+
+## Overview
+
+This module provides reusable WDL tasks for variant calling and manipulation using bcftools, a popular suite of utilities for variant calling and manipulating VCF/BCF files. The module implements bcftools' mpileup/call pipeline for variant detection and includes additional tasks for consensus sequence generation and variant filtering.
+
+The module is designed to be a foundational component within the WILDS ecosystem, suitable for use in larger variant calling pipelines.
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
+
+- **Tasks**: `mpileup_call`, `validate_outputs`
+- **Workflow**: `bcftools_example` (demonstration workflow that executes core tasks)
+- **Container**: `getwilds/bcftools:1.19`
+
+## Tasks
+
+### `mpileup_call`
+Calls variants using bcftools mpileup and call pipeline.
+
+**Inputs:**
+- `sample_data` (SampleInfo): Sample information including BAM files
+- `reference_fasta` (File): Reference genome FASTA file
+- `reference_fasta_index` (File): Reference genome FASTA index
+- `regions_bed` (File?): Optional BED file for targeted regions
+- `max_depth` (Int): Maximum read depth (default: 10000)
+- `max_idepth` (Int): Maximum indel depth (default: 10000)
+- Various additional parameters for fine-tuning
+
+**Outputs:**
+- `output_vcf` (File): Compressed VCF file with called variants
+- `output_vcf_index` (File): Index for the VCF file
+
+### `validate_outputs`
+Validates variant calling outputs and generates comprehensive statistics.
+
+**Inputs:**
+- Arrays of output files from variant calling tasks
+
+**Outputs:**
+- `report` (File): Validation summary with variant statistics
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "path/to/ww-bcftools.wdl" as bcftools_tasks
+
+struct SampleInfo {
+    String name
+    File bam
+    File bai
+}
+
+workflow my_variant_calling_pipeline {
+  input {
+    Array[SampleInfo] samples
+    File reference_fasta
+    File reference_fasta_index
+    File? regions_bed
+  }
+  
+  scatter (sample in samples) {
+    call bcftools_tasks.mpileup_call {
+      input:
+        sample_data = sample,
+        reference_fasta = reference_fasta,
+        reference_fasta_index = reference_fasta_index,
+        regions_bed = regions_bed
+    }
+  }
+  
+  output {
+    Array[File] variant_vcfs = mpileup_call.output_vcf
+  }
+}
+```
+
+### Integration Examples
+
+This module integrates well with other WILDS components:
+- **ww-star**: Use aligned BAM files from STAR for variant calling
+- **ww-sra**: Download data, align, then call variants
+- **Custom workflows**: Combine with GATK or other variant callers for consensus calling
+
+## Testing the Module
+
+The module includes a demonstration workflow with comprehensive testing:
+
+```bash
+# Using Cromwell
+java -jar cromwell.jar run ww-bcftools.wdl --inputs inputs.json --options options.json
+
+# Using miniWDL
+miniwdl run ww-bcftools.wdl -i inputs.json
+
+# Using Sprocket
+sprocket run ww-bcftools.wdl inputs.json
+```
+
+### Test Input Format
+
+```json
+{
+  "bcftools_example.samples": [
+    {
+      "name": "sample1",
+      "bam": "/path/to/sample1.bam",
+      "bai": "/path/to/sample1.bam.bai"
+    }
+  ],
+  "bcftools_example.reference_genome": {
+    "name": "hg38",
+    "fasta": "/path/to/genome.fasta",
+    "fasta_index": "/path/to/genome.fasta.fai"
+  },
+  "bcftools_example.regions_bed": "/path/to/regions.bed",
+  "bcftools_example.max_depth": 10000,
+  "bcftools_example.memory_gb": 8,
+  "bcftools_example.cpu_cores": 2
+}
+```
+
+## Configuration Guidelines
+
+### Resource Allocation
+
+The module supports flexible resource configuration:
+- **Memory**: 4-8GB recommended for most applications
+- **CPUs**: 1-2 cores typically sufficient for bcftools operations
+- **Storage**: Sufficient space for input BAMs and output VCFs
+
+### Variant Calling Parameters
+
+- `max_depth`: Adjust based on expected coverage depth
+- `max_idepth`: Set higher for high-coverage applications
+- `annotate_format`: Customize FORMAT fields in output VCF
+- `regions_bed`: Use for targeted sequencing applications
+
+## Requirements
+
+- WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
+- Docker/Apptainer support
+- Input BAM files must be sorted and indexed
+- Reference genome with FASTA index
+
+## Features
+
+- **Variant calling**: Configurable mpileup/call parameters
+- **Targeted regions**: Support for BED file region specification
+- **Validation**: Built-in output validation and statistics
+- **Scalable**: Configurable resource allocation
+- **Compatible**: Works with multiple WDL executors
+
+## Advanced Usage
+
+The module supports various bcftools mpileup/call parameters for fine-tuning variant calling:
+
+```wdl
+call bcftools_tasks.mpileup_call {
+  input:
+    sample_data = my_sample,
+    reference_fasta = ref_fasta,
+    max_depth = 1000,
+    max_idepth = 1000,
+    annotate_format = "FORMAT/AD,FORMAT/DP,FORMAT/SP",
+    ignore_rg = false,
+    disable_baq = false
+}
+```
+
+## Module Development
+
+This module is automatically tested as part of the WILDS WDL Library CI/CD pipeline using:
+- Multiple WDL executors (Cromwell, miniWDL, Sprocket)
+- Real sequencing data (chromosome 22 subset for efficiency)
+- Comprehensive validation of all outputs
+
+For questions specific to this module or to contribute improvements, please see the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library).
+
+## Support
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Data Science Lab (DaSL) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL module, please see our [WILDS Contributor Guide](https://getwilds.org/guide/) and the [WILDS WDL Library contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/modules/ww-bcftools/README.md
+++ b/modules/ww-bcftools/README.md
@@ -167,6 +167,7 @@ The module supports various bcftools mpileup/call parameters for fine-tuning var
 call bcftools_tasks.mpileup_call {
   input:
     sample_data = my_sample,
+    regions_bed = my_bedfile,
     reference_fasta = ref_fasta,
     reference_fasta_index = ref_fasta.fai
     max_depth = 1000,

--- a/modules/ww-bcftools/README.md
+++ b/modules/ww-bcftools/README.md
@@ -50,7 +50,7 @@ Validates variant calling outputs and generates comprehensive statistics.
 ### Importing into Your Workflow
 
 ```wdl
-import "path/to/ww-bcftools.wdl" as bcftools_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bcftools/ww-bcftools.wdl" as bcftools_tasks
 
 struct SampleInfo {
     String name

--- a/modules/ww-bcftools/README.md
+++ b/modules/ww-bcftools/README.md
@@ -122,6 +122,7 @@ sprocket run ww-bcftools.wdl inputs.json
   },
   "bcftools_example.regions_bed": "/path/to/regions.bed",
   "bcftools_example.max_depth": 10000,
+  "bcftools_example.max_idepth": 10000,
   "bcftools_example.memory_gb": 8,
   "bcftools_example.cpu_cores": 2
 }

--- a/modules/ww-bcftools/README.md
+++ b/modules/ww-bcftools/README.md
@@ -167,6 +167,7 @@ call bcftools_tasks.mpileup_call {
   input:
     sample_data = my_sample,
     reference_fasta = ref_fasta,
+    reference_fasta_index = ref_fasta.fai
     max_depth = 1000,
     max_idepth = 1000,
     annotate_format = "FORMAT/AD,FORMAT/DP,FORMAT/SP",

--- a/modules/ww-bcftools/inputs.json
+++ b/modules/ww-bcftools/inputs.json
@@ -1,0 +1,19 @@
+{
+  "bcftools_example.samples": [
+    {
+      "name": "SRR13008264",
+      "bam": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/SRR13008264.chr22.aligned.bam",
+      "bai": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/SRR13008264.chr22.aligned.bam.bai"
+    }
+  ],
+  "bcftools_example.reference_genome": {
+    "name": "chr22",
+    "fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa",
+    "fasta_index": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa.fai"
+  },
+  "bcftools_example.regions_bed": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22_regions.bed",
+  "bcftools_example.max_depth": 1000,
+  "bcftools_example.max_idepth": 1000,
+  "bcftools_example.memory_gb": 4,
+  "bcftools_example.cpu_cores": 2
+}

--- a/modules/ww-bcftools/inputs.json
+++ b/modules/ww-bcftools/inputs.json
@@ -11,7 +11,7 @@
     "fasta": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa",
     "fasta_index": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.fa.fai"
   },
-  "bcftools_example.regions_bed": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22_regions.bed",
+  "bcftools_example.regions_bed": "/home/runner/work/wilds-wdl-library/wilds-wdl-library/test-data/chr22.bed",
   "bcftools_example.max_depth": 1000,
   "bcftools_example.max_idepth": 1000,
   "bcftools_example.memory_gb": 4,

--- a/modules/ww-bcftools/options.json
+++ b/modules/ww-bcftools/options.json
@@ -1,0 +1,10 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": true,
+    "read_from_cache": true,
+    "default_runtime_attributes": {
+        "maxRetries": 1
+    },
+    "final_workflow_outputs_dir": "$PWD/test-output/cromwell",
+    "use_relative_output_paths": true
+}

--- a/modules/ww-bcftools/ww-bcftools.wdl
+++ b/modules/ww-bcftools/ww-bcftools.wdl
@@ -1,0 +1,249 @@
+## WILDS WDL module for bcftools variant calling and manipulation.
+## Designed to be a modular component within the WILDS ecosystem that can be used
+## independently or integrated with other WILDS workflows.
+
+version 1.0
+
+struct SampleInfo {
+    String name
+    File bam
+    File bai
+}
+
+struct RefGenome {
+    String name
+    File fasta
+    File fasta_index
+}
+
+workflow bcftools_example {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "WDL workflow for variant calling using bcftools"
+    url: "https://github.com/getwilds/wilds-wdl-library"
+    outputs: {
+        variant_vcfs: "VCF files containing variants called by bcftools mpileup for each sample",
+        validation_report: "validation report confirming all expected outputs were generated"
+    }
+  }
+
+  parameter_meta {
+    samples: "List of sample objects, each containing name, BAM file, and BAM index"
+    reference_genome: "Reference genome object containing name, fasta, and fasta index files"
+    regions_bed: "Optional BED file specifying regions to analyze"
+    max_depth: "Maximum read depth for mpileup (default: 10000)"
+    max_idepth: "Maximum per-sample depth for indel calling (default: 10000)"
+    memory_gb: "Memory allocated for each task in the workflow in GB"
+    cpu_cores: "Number of CPU cores allocated for each task in the workflow"
+  }
+
+  input {
+    Array[SampleInfo] samples
+    RefGenome reference_genome
+    File? regions_bed
+    Int max_depth = 10000
+    Int max_idepth = 10000
+    Int memory_gb = 8
+    Int cpu_cores = 2
+  }
+
+  scatter (sample in samples) {
+    call mpileup_call {
+      input:
+        sample_data = sample,
+        reference_fasta = reference_genome.fasta,
+        reference_fasta_index = reference_genome.fasta_index,
+        regions_bed = regions_bed,
+        max_depth = max_depth,
+        max_idepth = max_idepth,
+        memory_gb = memory_gb,
+        cpu_cores = cpu_cores
+    }
+  }
+
+  call validate_outputs {
+    input:
+      sample_names = mpileup_call.sample_name,
+      vcf_files = mpileup_call.output_vcf
+  }
+
+  output {
+    Array[File] variant_vcfs = mpileup_call.output_vcf
+    File validation_report = validate_outputs.report
+  }
+}
+
+task mpileup_call {
+  meta {
+    description: "Call variants using bcftools mpileup and call"
+    outputs: {
+        sample_name: "Sample name from input data",
+        output_vcf: "Compressed VCF file containing called variants"
+    }
+  }
+
+  parameter_meta {
+    sample_data: "Sample information including name, BAM file, and BAM index"
+    reference_fasta: "Reference genome FASTA file"
+    reference_fasta_index: "Reference genome FASTA index file"
+    regions_bed: "Optional BED file specifying regions to analyze"
+    max_depth: "Maximum read depth for mpileup"
+    max_idepth: "Maximum per-sample depth for indel calling"
+    annotate_format: "FORMAT annotations to add (default: AD,DP)"
+    ignore_rg: "Ignore read groups during analysis"
+    disable_baq: "Disable BAQ (per-Base Alignment Quality) computation"
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
+  }
+
+  input {
+    SampleInfo sample_data
+    File reference_fasta
+    File reference_fasta_index
+    File? regions_bed
+    Int max_depth = 10000
+    Int max_idepth = 10000
+    String annotate_format = "FORMAT/AD,FORMAT/DP"
+    Boolean ignore_rg = true
+    Boolean disable_baq = true
+    Int memory_gb = 8
+    Int cpu_cores = 2
+  }
+
+  command <<<
+    set -eo pipefail
+    
+    # Build the bcftools mpileup command
+    bcftools_cmd="bcftools mpileup \
+      --max-depth ~{max_depth} \
+      --max-idepth ~{max_idepth} \
+      --annotate \"~{annotate_format}\" \
+      --fasta-ref \"~{reference_fasta}\""
+    
+    # Add regions file if provided
+    if [ -n "~{regions_bed}" ]; then
+      bcftools_cmd="$bcftools_cmd --regions-file \"~{regions_bed}\""
+    fi
+    
+    # Add optional flags
+    if [ "~{ignore_rg}" == "true" ]; then
+      bcftools_cmd="$bcftools_cmd --ignore-RG"
+    fi
+    
+    if [ "~{disable_baq}" == "true" ]; then
+      bcftools_cmd="$bcftools_cmd --no-BAQ"
+    fi
+    
+    # Complete the command with input BAM and piping to bcftools call
+    bcftools_cmd="$bcftools_cmd \"~{sample_data.bam}\" | bcftools call -Oz -mv -o \"~{sample_data.name}.bcftools.vcf.gz\""
+    
+    echo "Running: $bcftools_cmd"
+    eval "$bcftools_cmd"
+    
+    # Create index for the output VCF
+    bcftools index "~{sample_data.name}.bcftools.vcf.gz"
+  >>>
+
+  output {
+    String sample_name = sample_data.name
+    File output_vcf = "~{sample_data.name}.bcftools.vcf.gz"
+    File output_vcf_index = "~{sample_data.name}.bcftools.vcf.gz.csi"
+  }
+
+  runtime {
+    docker: "getwilds/bcftools:1.19"
+    memory: "~{memory_gb} GB"
+    cpu: cpu_cores
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that all expected bcftools output files were generated correctly"
+    outputs: {
+        report: "Validation report summarizing file checks and variant statistics"
+    }
+  }
+
+  parameter_meta {
+    vcf_files: "Array of VCF files to validate"
+    sample_names: "Array of sample names that were processed"
+  }
+
+  input {
+    Array[File] vcf_files
+    Array[String] sample_names
+  }
+
+  command <<<
+    set -eo pipefail
+    
+    echo "=== bcftools Variant Calling Validation Report ===" > validation_report.txt
+    echo "" >> validation_report.txt
+    
+    # Arrays for bash processing
+    sample_names=(~{sep=" " sample_names})
+    vcf_files=(~{sep=" " vcf_files})
+    
+    validation_passed=true
+    total_variants=0
+    
+    # Check each sample
+    for i in "${!sample_names[@]}"; do
+      sample_name="${sample_names[$i]}"
+      vcf_file="${vcf_files[$i]}"
+      
+      echo "--- Sample: $sample_name ---" >> validation_report.txt
+      
+      # Check VCF file exists and is not empty
+      if [[ -f "$vcf_file" && -s "$vcf_file" ]]; then
+        vcf_size=$(stat -c%s "$vcf_file")
+        echo "VCF file: $vcf_file (${vcf_size} bytes)" >> validation_report.txt
+        
+        # Try to get variant counts if bcftools is available
+        if command -v bcftools &> /dev/null; then
+          variant_count=$(bcftools view -H "$vcf_file" | wc -l 2>/dev/null || echo "N/A")
+          echo "  Total variants: $variant_count" >> validation_report.txt
+          
+          if [[ "$variant_count" =~ ^[0-9]+$ ]]; then
+            total_variants=$((total_variants + variant_count))
+          fi
+          
+          # Get basic statistics
+          snp_count=$(bcftools view -H -v snps "$vcf_file" | wc -l 2>/dev/null || echo "N/A")
+          indel_count=$(bcftools view -H -v indels "$vcf_file" | wc -l 2>/dev/null || echo "N/A")
+          echo "  SNPs: $snp_count" >> validation_report.txt
+          echo "  Indels: $indel_count" >> validation_report.txt
+        fi
+      else
+        echo "VCF file: $vcf_file - MISSING OR EMPTY" >> validation_report.txt
+        validation_passed=false
+      fi
+      
+      echo "" >> validation_report.txt
+    done
+    
+    # Overall summary
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [[ "$validation_passed" == "true" ]]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+    
+    # Also output to stdout for immediate feedback
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "getwilds/bcftools:1.19"
+    memory: "2 GB"
+    cpu: 1
+  }
+}


### PR DESCRIPTION
## Description
- For the ww-leukemia workflow, we'll need bcftools mpileup functionality.
- Adding an initial draft of the ww-bcftools module, will add to ww-leukemia next.

## Related Issue
- Fixes #29 

## Testing
- See GitHub Actions below.
- Also ran with a larger dataset via PROOF, works as expected.