### PR TITLE
Use main branch path in ichorCNA WDL

### DIFF
--- a/modules/ww-ichorcna/ww-ichorcna.wdl
+++ b/modules/ww-ichorcna/ww-ichorcna.wdl
@@ -4,7 +4,7 @@
 
 version 1.0
 
-import "https://github.com/getwilds/wilds-wdl-library/raw/add-ichor/modules/ww-bedtools/ww-bedtools.wdl" as bedtools_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bedtools/ww-bedtools.wdl" as bedtools_tasks
 
 struct SampleInfo {
     String name


### PR DESCRIPTION
## Description
I updated the `ww-bedtools` WDL as part of PR #45 , so I was referencing that branch's version of bedtools in the `ww-ichorcna` WDL. Now that the branch is merged in we need to update the path to use `main`.
