### PR TITLE
Limit Test Runs to Modified WDL's

### DIFF
--- a/.github/scripts/discover_modules.py
+++ b/.github/scripts/discover_modules.py
@@ -48,9 +48,9 @@ def find_valid_modules():
         
         if wdl_file.exists() and inputs_file.exists():
             modules.append(module_name)
-            print(f"✓ Found valid module: {module_name}")
+            print(f"Found valid module: {module_name}")
         else:
-            print(f"✗ Skipping {module_name} - missing required files")
+            print(f"Skipping {module_name} - missing required files")
             if not wdl_file.exists():
                 print(f"    Missing: {wdl_file}")
             if not inputs_file.exists():
@@ -62,7 +62,8 @@ def filter_modules_by_changes(modules, changed_files):
     """Filter modules to only those with changes"""
     if changed_files is None:
         print("No file filtering applied (workflow_dispatch or git error)")
-        return modules
+        # return modules
+        return [] # Bailing out for now, need to add workflow_dispatch support later...
         
     if not changed_files:
         print("No files changed in this PR")
@@ -98,7 +99,7 @@ def main():
     
     print(f"\nFinal selection: {len(final_modules)} modules")
     for module in final_modules:
-        print(f"  • {module}")
+        print(f"  - {module}")
     
     # Output for GitHub Actions
     modules_json = json.dumps(final_modules)

--- a/.github/scripts/discover_modules.py
+++ b/.github/scripts/discover_modules.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*-coding:utf-8 -*-
+'''
+@File    :   discover_modules.py
+@Time    :   2025/07/01 22:47:23
+@Author  :   Taylor Firman
+@Version :   v0.1
+@Contact :   tfirman@fredhutch.org
+@Desc    :   Identifies WILDS modules needing a test run based on changes in a PR.
+'''
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+def get_changed_files():
+    """Get list of changed files in PR, or None for workflow_dispatch"""
+    if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request':
+        try:
+            result = subprocess.run([
+                'git', 'diff', '--name-only', 
+                f"origin/{os.environ['GITHUB_BASE_REF']}...HEAD"
+            ], capture_output=True, text=True, check=True)
+            return result.stdout.strip().split('\n') if result.stdout.strip() else []
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: Could not get changed files: {e}")
+            print("Running all modules as fallback")
+            return None
+    return None
+
+def find_valid_modules():
+    """Find all directories with valid module structure"""
+    modules = []
+    modules_dir = Path('modules')
+    
+    if not modules_dir.exists():
+        print("No modules directory found")
+        return modules
+        
+    for module_dir in modules_dir.iterdir():
+        if not module_dir.is_dir():
+            continue
+            
+        module_name = module_dir.name
+        wdl_file = module_dir / f"{module_name}.wdl"
+        inputs_file = module_dir / "inputs.json"
+        
+        if wdl_file.exists() and inputs_file.exists():
+            modules.append(module_name)
+            print(f"✓ Found valid module: {module_name}")
+        else:
+            print(f"✗ Skipping {module_name} - missing required files")
+            if not wdl_file.exists():
+                print(f"    Missing: {wdl_file}")
+            if not inputs_file.exists():
+                print(f"    Missing: {inputs_file}")
+    
+    return sorted(modules)
+
+def filter_modules_by_changes(modules, changed_files):
+    """Filter modules to only those with changes"""
+    if changed_files is None:
+        print("No file filtering applied (workflow_dispatch or git error)")
+        return modules
+        
+    if not changed_files:
+        print("No files changed in this PR")
+        return []
+        
+    print(f"Files changed in PR: {len(changed_files)}")
+    for f in changed_files[:10]:  # Show first 10
+        print(f"  {f}")
+    if len(changed_files) > 10:
+        print(f"  ... and {len(changed_files) - 10} more")
+    
+    filtered = []
+    for module in modules:
+        module_files = [f for f in changed_files if f.startswith(f'modules/{module}/')]
+        if module_files:
+            filtered.append(module)
+            print(f"Including {module} ({len(module_files)} changed files)")
+        else:
+            print(f"Skipping {module} (no changes)")
+            
+    return filtered
+
+def main():
+    print("=== WILDS Module Discovery ===")
+    
+    # Find all valid modules
+    all_modules = find_valid_modules()
+    print(f"\nFound {len(all_modules)} valid modules")
+    
+    # Filter by changes if this is a PR
+    changed_files = get_changed_files()
+    final_modules = filter_modules_by_changes(all_modules, changed_files)
+    
+    print(f"\nFinal selection: {len(final_modules)} modules")
+    for module in final_modules:
+        print(f"  • {module}")
+    
+    # Output for GitHub Actions
+    modules_json = json.dumps(final_modules)
+    
+    # Write to GITHUB_OUTPUT
+    github_output = os.environ.get('GITHUB_OUTPUT')
+    if github_output:
+        with open(github_output, 'a') as f:
+            f.write(f"modules={modules_json}\n")
+    else:
+        print(f"modules={modules_json}")
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/discover_modules.py
+++ b/.github/scripts/discover_modules.py
@@ -25,9 +25,9 @@ def get_changed_files():
             ], capture_output=True, text=True, check=True)
             return result.stdout.strip().split('\n') if result.stdout.strip() else []
         except subprocess.CalledProcessError as e:
-            print(f"Warning: Could not get changed files: {e}")
-            print("Running all modules as fallback")
-            return None
+            print(f"ERROR: Could not get changed files: {e}")
+            print("This is a critical error - we cannot safely determine what to test")
+            raise SystemExit(1)
     return None
 
 def find_valid_modules():

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -21,6 +21,8 @@ jobs:
     -
       name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Need full history for git diff
     -
       name: Find modified WDL modules
       id: find-modules

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -2,6 +2,12 @@ name: Module Test Run
 
 on:
   workflow_dispatch:
+    inputs:
+      module_name:
+        description: 'Specific module to test (leave empty to test all modules)'
+        required: false
+        type: string
+        default: ''
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
@@ -26,7 +32,7 @@ jobs:
     -
       name: Find modified WDL modules
       id: find-modules
-      run: python3 .github/scripts/discover_modules.py
+      run: python3 .github/scripts/discover_modules.py "${{ github.event.inputs.module_name }}"
 
   download-test-data:
     runs-on: ubuntu-latest

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -22,36 +22,9 @@ jobs:
       name: Checkout
       uses: actions/checkout@v4
     -
-      name: Find WDL modules
+      name: Find modified WDL modules
       id: find-modules
-      run: |
-        # Find all directories in modules/ that contain both a .wdl file and inputs.json
-        modules=()
-        for module_dir in modules/*/; do
-          if [ -d "$module_dir" ]; then
-            module_name=$(basename "$module_dir")
-            wdl_file="$module_dir$module_name.wdl"
-            inputs_file="$module_dir/inputs.json"
-
-            if [ -f "$wdl_file" ] && [ -f "$inputs_file" ]; then
-              modules+=("$module_name")
-              echo "Found module: $module_name"
-            else
-              echo "Skipping $module_name - missing required files"
-              [ ! -f "$wdl_file" ] && echo "  Missing: $wdl_file"
-              [ ! -f "$inputs_file" ] && echo "  Missing: $inputs_file"
-            fi
-          fi
-        done
-
-        # Convert array to JSON format for matrix strategy
-        if [ ${#modules[@]} -eq 0 ]; then
-          modules_json="[]"
-        else
-          modules_json=$(printf '%s\n' "${modules[@]}" | jq -R . | jq -s -c .)
-        fi
-        echo "modules=$modules_json" >> $GITHUB_OUTPUT
-        echo "Found modules: $modules_json"
+      run: python3 .github/scripts/discover_modules.py
 
   download-test-data:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+*-test.json

--- a/modules/ww-testdata/README.md
+++ b/modules/ww-testdata/README.md
@@ -84,10 +84,13 @@ sprocket run ww-testdata.wdl inputs.json
 **RNA-seq analysis**:
 ```wdl
 call testdata.download_ref_data { 
-  input: chromo = "chr22", version = "hg38" 
+  input: 
+    chromo = "chr22",
+    version = "hg38" 
 }
 call star_tasks.build_star_index { 
-  input: reference_fasta = download_ref_data.fasta 
+  input: 
+    reference_fasta = download_ref_data.fasta 
 }
 ```
 
@@ -105,7 +108,8 @@ call ichor_tasks.run_ichor {
 ```wdl
 call testdata.download_annotsv_vcf { }
 call annotsv_tasks.annotate_variants { 
-  input: test_vcf = download_annotsv_vcf.test_vcf 
+  input: 
+    test_vcf = download_annotsv_vcf.test_vcf 
 }
 ```
 
@@ -120,10 +124,10 @@ call annotsv_tasks.annotate_variants {
 - `memory_gb` (Int): Memory allocation (default: 4)
 
 **Outputs**:
-- `fasta`: Reference chromosome FASTA file
-- `fasta_index`: Samtools FASTA index (.fai)
-- `gtf`: Chromosome-specific gene annotations
-- `bed`: BED file covering entire chromosome
+- `fasta` (File): Reference chromosome FASTA file
+- `fasta_index` (File): Samtools FASTA index (.fai)
+- `gtf` (File): Chromosome-specific gene annotations
+- `bed` (File): BED file covering entire chromosome
 
 ### download_ichor_data
 
@@ -132,10 +136,10 @@ call annotsv_tasks.annotate_variants {
 - `memory_gb` (Int): Memory allocation (default: 4)
 
 **Outputs**:
-- `wig_gc`: GC content in 500kb bins
-- `wig_map`: Mappability in 500kb bins
-- `centromeres`: Centromere coordinates
-- `panel_of_norm_rds`: Panel of normals for normalization
+- `wig_gc` (File): GC content in 500kb bins
+- `wig_map` (File): Mappability in 500kb bins
+- `centromeres` (File): Centromere coordinates
+- `panel_of_norm_rds` (File): Panel of normals for normalization
 
 ### download_annotsv_vcf
 
@@ -144,7 +148,7 @@ call annotsv_tasks.annotate_variants {
 - `memory_gb` (Int): Memory allocation (default: 4)
 
 **Outputs**:
-- `test_vcf`: Example VCF file for testing
+- `test_vcf` (File): Example VCF file for testing
 
 ## Data Sources
 
@@ -174,7 +178,7 @@ This module is specifically designed to support other WILDS modules:
 
 - **ww-star**: RNA-seq alignment (requires reference FASTA + GTF)
 - **ww-bwa**: DNA alignment (requires reference FASTA)
-- **ww-ichor**: Copy number analysis (requires ichorCNA reference files)
+- **ww-ichorcna**: Copy number analysis (requires ichorCNA reference files)
 - **ww-annotsv**: Structural variant annotation (requires test VCF)
 
 By centralizing test data downloads, `ww-testdata` enables:
@@ -188,7 +192,6 @@ By centralizing test data downloads, `ww-testdata` enables:
 This module is automatically tested as part of the WILDS WDL Library CI/CD pipeline using:
 - Multiple WDL executors (Cromwell, miniWDL, Sprocket)
 - Network connectivity validation
-- Output file integrity checks
 - Cross-platform compatibility testing
 
 ## Support

--- a/modules/ww-testdata/README.md
+++ b/modules/ww-testdata/README.md
@@ -1,0 +1,206 @@
+# ww-testdata
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+WILDS WDL module for downloading reference and test data.
+
+## Overview
+
+The `ww-testdata` module provides standardized tasks for downloading reference genomes, annotations, and specialized datasets used across WILDS WDL workflows. This module serves as the foundation for consistent, reproducible test data management in the WILDS ecosystem.
+
+## Purpose
+
+Rather than maintaining large static test datasets, `ww-testdata` enables:
+- **On-demand data retrieval**: Download only the data you need, when you need it
+- **Standardized datasets**: Consistent reference data across all WILDS modules
+- **Modular testing**: Each module can specify its exact data requirements
+- **Reproducibility**: Versioned, trackable data sources with checksums
+- **Efficiency**: Avoid downloading unnecessary test data for targeted module testing
+
+## Module Structure
+
+This module contains three primary tasks:
+
+### `download_ref_data`
+Downloads chromosome-specific reference genome data including:
+- Reference FASTA file (compressed)
+- FASTA index (.fai) file
+- Gene annotations (GTF format)
+- Chromosome coverage BED file
+
+**Supported genomes**: hg38, hg19
+**Configurable**: Any chromosome (chr1, chr2, chrX, etc.)
+
+### `download_ichor_data`
+Downloads specialized reference files for ichorCNA copy number analysis:
+- GC content WIG file (500kb bins)
+- Mappability WIG file (500kb bins)
+- Centromere location annotations
+- Panel of normals RDS file
+
+### `download_annotsv_vcf`
+Downloads test VCF files for structural variant annotation workflows.
+
+## Usage
+
+### As Imported Tasks
+
+Import specific tasks into your workflows:
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as testdata
+
+workflow my_analysis {
+  call testdata.download_ref_data { 
+    input: 
+      chromo = "chr22",
+      version = "hg38"
+  }
+  
+  call my_analysis_task { 
+    input: 
+      reference_fasta = download_ref_data.fasta,
+      reference_gtf = download_ref_data.gtf
+  }
+}
+```
+
+### Demonstration Workflow
+
+Run the complete demonstration workflow to download a full test dataset:
+
+```bash
+# Navigate to module directory
+cd modules/ww-testdata
+
+# Run with your preferred executor
+miniwdl run ww-testdata.wdl -i inputs.json
+java -jar cromwell.jar run ww-testdata.wdl --inputs inputs.json
+sprocket run ww-testdata.wdl inputs.json
+```
+
+### Common Integration Patterns
+
+**RNA-seq analysis**:
+```wdl
+call testdata.download_ref_data { 
+  input: chromo = "chr22", version = "hg38" 
+}
+call star_tasks.build_star_index { 
+  input: reference_fasta = download_ref_data.fasta 
+}
+```
+
+**Copy number analysis**:
+```wdl
+call testdata.download_ichor_data { }
+call ichor_tasks.run_ichor { 
+  input: 
+    gc_wig = download_ichor_data.wig_gc,
+    map_wig = download_ichor_data.wig_map
+}
+```
+
+**Variant annotation**:
+```wdl
+call testdata.download_annotsv_vcf { }
+call annotsv_tasks.annotate_variants { 
+  input: test_vcf = download_annotsv_vcf.test_vcf 
+}
+```
+
+## Task Reference
+
+### download_ref_data
+
+**Inputs**:
+- `chromo` (String): Chromosome to download (default: "chr1")
+- `version` (String): Genome version (default: "hg38")
+- `cpu_cores` (Int): CPU allocation (default: 1)
+- `memory_gb` (Int): Memory allocation (default: 4)
+
+**Outputs**:
+- `fasta`: Reference chromosome FASTA file
+- `fasta_index`: Samtools FASTA index (.fai)
+- `gtf`: Chromosome-specific gene annotations
+- `bed`: BED file covering entire chromosome
+
+### download_ichor_data
+
+**Inputs**:
+- `cpu_cores` (Int): CPU allocation (default: 1)
+- `memory_gb` (Int): Memory allocation (default: 4)
+
+**Outputs**:
+- `wig_gc`: GC content in 500kb bins
+- `wig_map`: Mappability in 500kb bins
+- `centromeres`: Centromere coordinates
+- `panel_of_norm_rds`: Panel of normals for normalization
+
+### download_annotsv_vcf
+
+**Inputs**:
+- `cpu_cores` (Int): CPU allocation (default: 1)
+- `memory_gb` (Int): Memory allocation (default: 4)
+
+**Outputs**:
+- `test_vcf`: Example VCF file for testing
+
+## Data Sources
+
+All reference data is downloaded from authoritative public repositories:
+
+- **UCSC Genome Browser**: Reference genomes and annotations
+- **ichorCNA Repository**: Copy number analysis references  
+- **AnnotSV Repository**: Structural variant test data
+
+Data integrity is maintained through the use of stable URLs and version-pinned resources.
+
+## Requirements
+
+### Runtime Dependencies
+- **Container**: `getwilds/samtools:1.11`
+- **Tools**: samtools (for FASTA indexing), wget
+- **Network**: Internet access required for data downloads
+
+### Resource Requirements
+- **CPU**: 1 core (configurable)
+- **Memory**: 4 GB (configurable)
+- **Storage**: Varies by dataset (chr22: ~50MB, chr1: ~250MB)
+
+## Integration with WILDS Ecosystem
+
+This module is specifically designed to support other WILDS modules:
+
+- **ww-star**: RNA-seq alignment (requires reference FASTA + GTF)
+- **ww-bwa**: DNA alignment (requires reference FASTA)
+- **ww-ichor**: Copy number analysis (requires ichorCNA reference files)
+- **ww-annotsv**: Structural variant annotation (requires test VCF)
+
+By centralizing test data downloads, `ww-testdata` enables:
+- Consistent data across all WILDS workflows
+- Efficient GitHub Actions testing (download only needed data)
+- Simplified module development and testing
+- Clear documentation of data dependencies
+
+## Module Development
+
+This module is automatically tested as part of the WILDS WDL Library CI/CD pipeline using:
+- Multiple WDL executors (Cromwell, miniWDL, Sprocket)
+- Network connectivity validation
+- Output file integrity checks
+- Cross-platform compatibility testing
+
+## Support
+
+For questions specific to this module or to contribute improvements, please see the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library).
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Data Science Lab (DaSL) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL module, please see our [WILDS Contributor Guide](https://getwilds.org/guide/) and the [WILDS WDL Library contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/modules/ww-testdata/inputs.json
+++ b/modules/ww-testdata/inputs.json
@@ -1,0 +1,4 @@
+{
+  "testdata_example.chromo": "chr1",
+  "testdata_example.version": "hg38"
+}

--- a/modules/ww-testdata/options.json
+++ b/modules/ww-testdata/options.json
@@ -1,0 +1,10 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": true,
+    "read_from_cache": true,
+    "default_runtime_attributes": {
+        "maxRetries": 1
+    },
+    "final_workflow_outputs_dir": "cromwell_outputs",
+    "use_relative_output_paths": true
+}

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -144,16 +144,16 @@ task download_ichor_data {
 
     # Download ichorCNA reference data files
     # These files are used for normalization and centromere locations in ichorCNA analysis
-    wget -q -O gc_hg38_500kb.wig https://raw.githubusercontent.com/GavinHaLab/ichorCNA/b2bbce0a9997f31733f0f0ea4278cfba937ded41/inst/extdata/gc_hg38_500kb.wig
-    wget -q -O map_hg38_500kb.wig https://raw.githubusercontent.com/GavinHaLab/ichorCNA/b2bbce0a9997f31733f0f0ea4278cfba937ded41/inst/extdata/map_hg38_500kb.wig
-    wget -q -O GRCh38.GCA_000001405.2_centromere_acen.txt https://raw.githubusercontent.com/GavinHaLab/ichorCNA/b2bbce0a9997f31733f0f0ea4278cfba937ded41/inst/extdata/GRCh38.GCA_000001405.2_centromere_acen.txt
-    wget -q -O nextera_hg38_500kb_median_normAutosome_median.rds_median.n9.gr.rds https://github.com/genome/docker-basespace_chromoseq/raw/refs/heads/master/workflow_files/nextera_hg38_500kb_median_normAutosome_median.rds_median.n9.gr.rds
+    wget -q --no-check-certificate -O gc_hg38_500kb.wig https://raw.githubusercontent.com/GavinHaLab/ichorCNA/b2bbce0a9997f31733f0f0ea4278cfba937ded41/inst/extdata/gc_hg38_500kb.wig
+    wget -q --no-check-certificate -O map_hg38_500kb.wig https://raw.githubusercontent.com/GavinHaLab/ichorCNA/b2bbce0a9997f31733f0f0ea4278cfba937ded41/inst/extdata/map_hg38_500kb.wig
+    wget -q --no-check-certificate -O GRCh38.GCA_000001405.2_centromere_acen.txt https://raw.githubusercontent.com/GavinHaLab/ichorCNA/b2bbce0a9997f31733f0f0ea4278cfba937ded41/inst/extdata/GRCh38.GCA_000001405.2_centromere_acen.txt
+    wget -q --no-check-certificate -O nextera_hg38_500kb_median_normAutosome_median.rds_median.n9.gr.rds https://github.com/genome/docker-basespace_chromoseq/raw/refs/heads/master/workflow_files/nextera_hg38_500kb_median_normAutosome_median.rds_median.n9.gr.rds
   >>>
 
   output {
     File wig_gc = "gc_hg38_500kb.wig"
     File wig_map = "map_hg38_500kb.wig"
-    File centromeres = "GRCH38.GCA_000001405.2_centromere_acen.txt"
+    File centromeres = "GRCh38.GCA_000001405.2_centromere_acen.txt"
     File panel_of_norm_rds = "nextera_hg38_500kb_median_normAutosome_median.rds_median.n9.gr.rds"
   }
 

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -1,0 +1,105 @@
+## WILDS WDL module for downloading reference data for testing purposes.
+## Designed to be a modular component within the WILDS ecosystem that can be used
+## independently or integrated with other WILDS workflows.
+
+version 1.0
+
+workflow testdata_example {
+  meta {
+    author: "WILDS Team"
+    email: "wilds@fredhutch.org"
+    description: "WDL workflow for downloading reference data for WILDS WDL tests"
+    url: "https://github.com/getwilds/ww-testdata"
+    outputs: {
+        ref_fasta: "Reference genome FASTA file",
+        ref_fasta_index: "Index file for the reference FASTA",
+        ref_gtf: "GTF file containing gene annotations for the specified chromosome",
+        ref_bed: "BED file covering the entire chromosome"
+    }
+  }
+
+  parameter_meta {
+    chromo: "Chromosome to download (e.g., chr1, chr2, etc.)"
+    version: "Reference genome version (e.g., hg38, hg19)"
+  }
+
+  input {
+    String chromo = "chr1"
+    String version = "hg38"
+  }
+
+  # Pull down reference genome and index files for the specified chromosome
+  call download_ref_data { input:
+      chromo = chromo,
+      version = version
+  }
+
+  output {
+    File ref_fasta = download_ref_data.fasta
+    File ref_fasta_index = download_ref_data.fasta_index
+    File ref_gtf = download_ref_data.gtf
+    File ref_bed = download_ref_data.bed
+  }
+}
+
+task download_ref_data {
+  meta {
+    description: "Downloads reference genome and index files for WILDS WDL test runs"
+    outputs: {
+        fasta: "Reference genome FASTA file",
+        fasta_index: "Index file for the reference FASTA",
+        gtf: "GTF file containing gene annotations for the specified chromosome",
+        bed: "BED file covering the entire chromosome"
+    }
+  }
+
+  parameter_meta {
+    chromo: "Chromosome to download (e.g., chr1, chr2, etc.)"
+    version: "Reference genome version (e.g., hg38, hg19)"
+    cpu_cores: "Number of CPU cores to use for downloading and processing"
+    memory_gb: "Memory allocation in GB for the task"
+  }
+
+  input {
+    String chromo = "chr1"
+    String version = "hg38"
+    Int cpu_cores = 1
+    Int memory_gb = 4
+  }
+
+  command <<<
+    set -euo pipefail
+
+    # Download chromosome fasta
+    wget -q -O "~{chromo}.fa.gz" "http://hgdownload.soe.ucsc.edu/goldenPath/~{version}/chromosomes/~{chromo}.fa.gz"
+    gunzip "~{chromo}.fa.gz"
+
+    # Create FASTA index file (.fai) for bcftools and other tools
+    samtools faidx "~{chromo}.fa"
+
+    # Download chromosome 1 GTF file
+    wget -q -O "~{version}.ncbiRefSeq.gtf.gz" "http://hgdownload.soe.ucsc.edu/goldenPath/~{version}/bigZips/genes/~{version}.ncbiRefSeq.gtf.gz"
+    gunzip "~{version}.ncbiRefSeq.gtf.gz"
+    # Extract only chromosome annotations
+    grep "^~{chromo}[[:space:]]" "~{version}.ncbiRefSeq.gtf" > "~{chromo}.gtf"
+    rm "~{version}.ncbiRefSeq.gtf"
+
+    # Create a BED file covering the entire chromosome
+    # Get chromosome length from the FASTA file
+    CHR_LENGTH=$(($(grep -v "^>" "~{chromo}.fa" | tr -d '\n' | wc -c)))
+    echo -e "~{chromo}\t0\t${CHR_LENGTH}" > "~{chromo}.bed"
+  >>>
+
+  output {
+    File fasta = "~{chromo}.fa"
+    File fasta_index = "~{chromo}.fa.fai"
+    File gtf = "~{chromo}.gtf"
+    File bed = "~{chromo}.bed"
+  }
+
+  runtime {
+    docker: "getwilds/samtools:1.11"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -186,7 +186,7 @@ task download_annotsv_vcf {
     set -euo pipefail
 
     # Download AnnotSV test VCF file
-    wget -q -O annotsv_test.vcf https://raw.githubusercontent.com/lgmgeo/AnnotSV/refs/heads/master/share/doc/AnnotSV/Example/test.vcf
+    wget -q --no-check-certificate -O annotsv_test.vcf https://raw.githubusercontent.com/lgmgeo/AnnotSV/refs/heads/master/share/doc/AnnotSV/Example/test.vcf
   >>>
 
   output {

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -166,7 +166,7 @@ task download_ichor_data {
 
 task download_annotsv_vcf {
   meta {
-    description: "Downloads reference data for ichorCNA analysis on hg38"
+    description: "Downloads test VCF files for structural variant annotation workflows"
     outputs: {
         test_vcf: "Test VCF file for AnnotSV"
     }


### PR DESCRIPTION
## Description
- Any time a single module gets modified, we execute test runs for _every_ WILDS WDL module, which is a waste.
- Moving the module identification step into its own python script for better maintainability.
- Adding logic to only execute test runs for modules that have been modified in the PR in question.
- Also allows for manual workflow dispatches for specific modules or all modules.

## Related Issue
- Fixes #39 

## Testing
- As seen in the GitHub Actions below, only the `ww-testdata` test run is executed as it's the only one that has been added/modified in this pull request.
- Tested a [workflow dispatch](https://github.com/getwilds/wilds-wdl-library/actions/runs/16041945204) for a specific module (`ww-annotsv`), worked as expected.
- Tested a [workflow dispatch](https://github.com/getwilds/wilds-wdl-library/actions/runs/16042085217) for all modules, worked as expected.