### PR TITLE
Sort reads after merging

### DIFF
--- a/modules/ww-samtools/ww-samtools.wdl
+++ b/modules/ww-samtools/ww-samtools.wdl
@@ -115,6 +115,7 @@ task crams_to_fastq {
   command <<<
     # Merge CRAM/BAM/SAM files if more than one, then convert to FASTQ
     samtools merge -@ ~{cpu_cores} --reference "~{ref}" -f "~{name}.merged.cram" ~{sep=" " cram_files} && \
+    samtools sort -n "~{name}.merged.cram" && \
     samtools fastq --reference "~{ref}" -o "~{name}.fastq.gz" "~{name}.merged.cram"
   >>>
 


### PR DESCRIPTION
## Description
Add one line that runs `samtools sort -n` on the merged CRAM before running `samtools fastq`

## Related Issue
Closes #56 

## Testing
Tested on PROOF