### PR TITLE
Adding Sorting after Smoove SV calling

### DIFF
--- a/modules/ww-smoove/ww-smoove.wdl
+++ b/modules/ww-smoove/ww-smoove.wdl
@@ -148,29 +148,24 @@ task smoove_call {
     
     # Sort the resulting vcf (SV's are tricky)
     bcftools sort -Oz "results/~{sample_name}-smoove.vcf.gz" \
-      > "results/~{sample_name}-smoove.vcf.gz"
+      > "results/~{sample_name}-smoove.sorted.vcf.gz"
 
     # Index the raw output
-    tabix -p vcf "results/~{sample_name}-smoove.vcf.gz"
+    tabix -p vcf "results/~{sample_name}-smoove.sorted.vcf.gz"
 
     # Filter to target regions if provided, otherwise use raw output
     if [ -n "~{target_regions_bed}" ]; then
       # Filter VCF to only include variants overlapping target regions
-      bcftools view \
-        -R "~{target_regions_bed}" \
-        -Oz \
-        -o "~{vcf_filename}" \
-        "results/~{sample_name}-smoove.vcf.gz"
-      
-      # Sort the resulting vcf (SV's are tricky)
-      bcftools sort -Oz "~{vcf_filename}" > "~{vcf_filename}"
+      bcftools view -R "~{target_regions_bed}" \
+        "results/~{sample_name}-smoove.sorted.vcf.gz" | \
+        bcftools sort -Oz -o "~{vcf_filename}"
       
       # Index the filtered VCF
       tabix -p vcf "~{vcf_filename}"
     else
       # Move and rename output files for consistency
-      mv "results/~{sample_name}-smoove.vcf.gz" "~{vcf_filename}"
-      mv "results/~{sample_name}-smoove.vcf.gz.tbi" "~{vcf_index_filename}"
+      mv "results/~{sample_name}-smoove.sorted.vcf.gz" "~{vcf_filename}"
+      mv "results/~{sample_name}-smoove.sorted.vcf.gz.tbi" "~{vcf_index_filename}"
     fi
   >>>
 


### PR DESCRIPTION
## Description
- During full-scale testing of ww-leukemia on PROOF, the Smoove SV calling task was getting tripped up during the tabix indexing step.
- Because of the complexity of SV definitions, they can come through slightly unsorted due to overlapping calls.
- Just need to add a `bcftools sort` call right after variant calling.

## Related Issue
- Fixes #63 

## Testing
- Ran on PROOF in ww-smoove as well as in ww-leukemia, works as expected.
- See GitHub Actions below.