### PR TITLE
Bwa interleaved

### DIFF
--- a/.github/workflows/vignettes-testrun.yml
+++ b/.github/workflows/vignettes-testrun.yml
@@ -208,8 +208,8 @@ jobs:
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     -
       name: Install Sprocket
-      run: cargo-binstall sprocket --version 0.12.2
-    - 
+      run: cargo-binstall sprocket --version 0.12.1
+    -
       name: Run workflow with Sprocket
       run: |
         vignette_dir="vignettes/${{ matrix.vignette }}"

--- a/.github/workflows/vignettes-testrun.yml
+++ b/.github/workflows/vignettes-testrun.yml
@@ -208,7 +208,7 @@ jobs:
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     -
       name: Install Sprocket
-      run: cargo-binstall sprocket --version 0.12.1
+      run: cargo-binstall sprocket --version 0.12.2
     -
       name: Run workflow with Sprocket
       run: |

--- a/.github/workflows/vignettes-testrun.yml
+++ b/.github/workflows/vignettes-testrun.yml
@@ -18,10 +18,10 @@ jobs:
     outputs:
       vignettes: ${{ steps.find-vignettes.outputs.vignettes }}
     steps:
-    -
+    - 
       name: Checkout
       uses: actions/checkout@v4
-    -
+    - 
       name: Find WDL vignettes
       id: find-vignettes
       run: |
@@ -32,7 +32,7 @@ jobs:
             vignette_name=$(basename "$vignette_dir")
             wdl_file="$vignette_dir$vignette_name.wdl"
             inputs_file="$vignette_dir/inputs.json"
-
+            
             if [ -f "$wdl_file" ] && [ -f "$inputs_file" ]; then
               vignettes+=("$vignette_name")
               echo "Found vignette: $vignette_name"
@@ -43,7 +43,7 @@ jobs:
             fi
           fi
         done
-
+        
         # Convert array to JSON format for matrix strategy
         if [ ${#vignettes[@]} -eq 0 ]; then
           vignettes_json="[]"
@@ -56,10 +56,10 @@ jobs:
   download-test-data:
     runs-on: ubuntu-latest
     steps:
-    -
+    - 
       name: Checkout
       uses: actions/checkout@v4
-    -
+    - 
       name: Download test data
       run: |
         mkdir -p test-data
@@ -74,18 +74,18 @@ jobs:
         # Extract only chromosome 22 annotations
         grep "^chr22[[:space:]]" test-data/hg38.ncbiRefSeq.gtf > test-data/chr22.gtf
         rm test-data/hg38.ncbiRefSeq.gtf
-
+        
         # Download a specific version (3.1.1) of the SRA toolkit
         wget -q https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/3.1.1/sratoolkit.3.1.1-ubuntu64.tar.gz
         tar -xzf sratoolkit.3.1.1-ubuntu64.tar.gz
         echo "$PWD/sratoolkit.3.1.1-ubuntu64/bin" >> $GITHUB_PATH
         export PATH="$PWD/sratoolkit.3.1.1-ubuntu64/bin:$PATH"
-
+        
         # Download a small test RNA-seq sample (SRR13008264 - mouse RNA-seq, ~100MB)
         fasterq-dump --split-files SRR13008264 -O test-data/
         gzip test-data/SRR13008264_1.fastq test-data/SRR13008264_2.fastq
         ls -la test-data/
-    -
+    - 
       name: Upload test data
       uses: actions/upload-artifact@v4
       with:
@@ -101,41 +101,41 @@ jobs:
         vignette: ${{ fromJson(needs.discover-vignettes.outputs.vignettes) }}
       fail-fast: false
     steps:
-    -
+    - 
       name: Checkout
       uses: actions/checkout@v4
-    -
+    - 
       name: Download test data
       uses: actions/download-artifact@v4
       with:
         name: test-data
         path: test-data/
-    -
+    - 
       name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: 3.13
-    -
+    - 
       name: Install miniwdl
       run: |
         python -m pip install --upgrade pip
         pip3 install miniwdl
-    -
+    - 
       name: Run workflow with miniwdl
       run: |
         mkdir -p test-output/miniwdl/${{ matrix.vignette }}
         vignette_dir="vignettes/${{ matrix.vignette }}"
         wdl_file="$vignette_dir/${{ matrix.vignette }}.wdl"
         inputs_file="$vignette_dir/inputs.json"
-
+        
         echo "Running ${{ matrix.vignette }} with miniwdl..."
         miniwdl run "$wdl_file" -i "$inputs_file" --dir "test-output/miniwdl/${{ matrix.vignette }}"
-    -
+    - 
       name: Display validation report
       run: |
         echo "=== MiniWDL Validation Report ==="
         find test-output/miniwdl -name "validation_report.txt" -exec cat {} \;
-
+  
   cromwell-test:
     needs: [discover-vignettes, download-test-data]
     runs-on: ubuntu-latest
@@ -144,26 +144,26 @@ jobs:
         vignette: ${{ fromJson(needs.discover-vignettes.outputs.vignettes) }}
       fail-fast: false
     steps:
-    -
+    - 
       name: Checkout
       uses: actions/checkout@v4
-    -
+    - 
       name: Download test data
       uses: actions/download-artifact@v4
       with:
         name: test-data
         path: test-data/
-    -
+    - 
       name: Set Up Java
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '21'
-    -
+    - 
       name: Download Cromwell
       run: |
         wget -q https://github.com/broadinstitute/cromwell/releases/download/86/cromwell-86.jar
-    -
+    - 
       name: Run workflow with Cromwell
       run: |
         mkdir -p test-output/cromwell/${{ matrix.vignette }}
@@ -171,15 +171,15 @@ jobs:
         wdl_file="$vignette_dir/${{ matrix.vignette }}.wdl"
         inputs_file="$vignette_dir/inputs.json"
         options_file="$vignette_dir/options.json"
-
+        
         echo "Running ${{ matrix.vignette }} with Cromwell..."
         java -jar cromwell-86.jar run "$wdl_file" -i "$inputs_file" -o "$options_file"
-    -
+    - 
       name: Display validation report
       run: |
         echo "=== Cromwell Validation Report ==="
         find . -name "validation_report.txt" -exec cat {} \;
-
+  
   sprocket-test:
     needs: [discover-vignettes, download-test-data]
     runs-on: ubuntu-latest
@@ -188,37 +188,37 @@ jobs:
         vignette: ${{ fromJson(needs.discover-vignettes.outputs.vignettes) }}
       fail-fast: false
     steps:
-    -
+    - 
       name: Checkout
       uses: actions/checkout@v4
-    -
+    - 
       name: Download test data
       uses: actions/download-artifact@v4
       with:
         name: test-data
         path: test-data/
-    -
+    - 
       name: Set Up Rust
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         override: true
-    -
+    - 
       name: Install cargo-binstall
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-    -
+    - 
       name: Install Sprocket
       run: cargo-binstall sprocket --version 0.12.2
-    -
+    - 
       name: Run workflow with Sprocket
       run: |
         vignette_dir="vignettes/${{ matrix.vignette }}"
         wdl_file="$vignette_dir/${{ matrix.vignette }}.wdl"
         inputs_file="$vignette_dir/inputs.json"
-
+        
         echo "Running ${{ matrix.vignette }} with Sprocket..."
         sprocket run --output "test-output/sprocket/${{ matrix.vignette }}" "$wdl_file" "$inputs_file"
-    -
+    - 
       name: Display validation report
       run: |
         echo "=== Sprocket Validation Report ==="

--- a/.github/workflows/vignettes-testrun.yml
+++ b/.github/workflows/vignettes-testrun.yml
@@ -18,10 +18,10 @@ jobs:
     outputs:
       vignettes: ${{ steps.find-vignettes.outputs.vignettes }}
     steps:
-    - 
+    -
       name: Checkout
       uses: actions/checkout@v4
-    - 
+    -
       name: Find WDL vignettes
       id: find-vignettes
       run: |
@@ -32,7 +32,7 @@ jobs:
             vignette_name=$(basename "$vignette_dir")
             wdl_file="$vignette_dir$vignette_name.wdl"
             inputs_file="$vignette_dir/inputs.json"
-            
+
             if [ -f "$wdl_file" ] && [ -f "$inputs_file" ]; then
               vignettes+=("$vignette_name")
               echo "Found vignette: $vignette_name"
@@ -43,7 +43,7 @@ jobs:
             fi
           fi
         done
-        
+
         # Convert array to JSON format for matrix strategy
         if [ ${#vignettes[@]} -eq 0 ]; then
           vignettes_json="[]"
@@ -56,10 +56,10 @@ jobs:
   download-test-data:
     runs-on: ubuntu-latest
     steps:
-    - 
+    -
       name: Checkout
       uses: actions/checkout@v4
-    - 
+    -
       name: Download test data
       run: |
         mkdir -p test-data
@@ -74,18 +74,18 @@ jobs:
         # Extract only chromosome 22 annotations
         grep "^chr22[[:space:]]" test-data/hg38.ncbiRefSeq.gtf > test-data/chr22.gtf
         rm test-data/hg38.ncbiRefSeq.gtf
-        
+
         # Download a specific version (3.1.1) of the SRA toolkit
         wget -q https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/3.1.1/sratoolkit.3.1.1-ubuntu64.tar.gz
         tar -xzf sratoolkit.3.1.1-ubuntu64.tar.gz
         echo "$PWD/sratoolkit.3.1.1-ubuntu64/bin" >> $GITHUB_PATH
         export PATH="$PWD/sratoolkit.3.1.1-ubuntu64/bin:$PATH"
-        
+
         # Download a small test RNA-seq sample (SRR13008264 - mouse RNA-seq, ~100MB)
         fasterq-dump --split-files SRR13008264 -O test-data/
         gzip test-data/SRR13008264_1.fastq test-data/SRR13008264_2.fastq
         ls -la test-data/
-    - 
+    -
       name: Upload test data
       uses: actions/upload-artifact@v4
       with:
@@ -101,41 +101,41 @@ jobs:
         vignette: ${{ fromJson(needs.discover-vignettes.outputs.vignettes) }}
       fail-fast: false
     steps:
-    - 
+    -
       name: Checkout
       uses: actions/checkout@v4
-    - 
+    -
       name: Download test data
       uses: actions/download-artifact@v4
       with:
         name: test-data
         path: test-data/
-    - 
+    -
       name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: 3.13
-    - 
+    -
       name: Install miniwdl
       run: |
         python -m pip install --upgrade pip
         pip3 install miniwdl
-    - 
+    -
       name: Run workflow with miniwdl
       run: |
         mkdir -p test-output/miniwdl/${{ matrix.vignette }}
         vignette_dir="vignettes/${{ matrix.vignette }}"
         wdl_file="$vignette_dir/${{ matrix.vignette }}.wdl"
         inputs_file="$vignette_dir/inputs.json"
-        
+
         echo "Running ${{ matrix.vignette }} with miniwdl..."
         miniwdl run "$wdl_file" -i "$inputs_file" --dir "test-output/miniwdl/${{ matrix.vignette }}"
-    - 
+    -
       name: Display validation report
       run: |
         echo "=== MiniWDL Validation Report ==="
         find test-output/miniwdl -name "validation_report.txt" -exec cat {} \;
-  
+
   cromwell-test:
     needs: [discover-vignettes, download-test-data]
     runs-on: ubuntu-latest
@@ -144,26 +144,26 @@ jobs:
         vignette: ${{ fromJson(needs.discover-vignettes.outputs.vignettes) }}
       fail-fast: false
     steps:
-    - 
+    -
       name: Checkout
       uses: actions/checkout@v4
-    - 
+    -
       name: Download test data
       uses: actions/download-artifact@v4
       with:
         name: test-data
         path: test-data/
-    - 
+    -
       name: Set Up Java
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '21'
-    - 
+    -
       name: Download Cromwell
       run: |
         wget -q https://github.com/broadinstitute/cromwell/releases/download/86/cromwell-86.jar
-    - 
+    -
       name: Run workflow with Cromwell
       run: |
         mkdir -p test-output/cromwell/${{ matrix.vignette }}
@@ -171,15 +171,15 @@ jobs:
         wdl_file="$vignette_dir/${{ matrix.vignette }}.wdl"
         inputs_file="$vignette_dir/inputs.json"
         options_file="$vignette_dir/options.json"
-        
+
         echo "Running ${{ matrix.vignette }} with Cromwell..."
         java -jar cromwell-86.jar run "$wdl_file" -i "$inputs_file" -o "$options_file"
-    - 
+    -
       name: Display validation report
       run: |
         echo "=== Cromwell Validation Report ==="
         find . -name "validation_report.txt" -exec cat {} \;
-  
+
   sprocket-test:
     needs: [discover-vignettes, download-test-data]
     runs-on: ubuntu-latest
@@ -188,25 +188,25 @@ jobs:
         vignette: ${{ fromJson(needs.discover-vignettes.outputs.vignettes) }}
       fail-fast: false
     steps:
-    - 
+    -
       name: Checkout
       uses: actions/checkout@v4
-    - 
+    -
       name: Download test data
       uses: actions/download-artifact@v4
       with:
         name: test-data
         path: test-data/
-    - 
+    -
       name: Set Up Rust
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         override: true
-    - 
+    -
       name: Install cargo-binstall
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-    - 
+    -
       name: Install Sprocket
       run: cargo-binstall sprocket --version 0.12.2
     - 
@@ -215,10 +215,10 @@ jobs:
         vignette_dir="vignettes/${{ matrix.vignette }}"
         wdl_file="$vignette_dir/${{ matrix.vignette }}.wdl"
         inputs_file="$vignette_dir/inputs.json"
-        
+
         echo "Running ${{ matrix.vignette }} with Sprocket..."
         sprocket run --output "test-output/sprocket/${{ matrix.vignette }}" "$wdl_file" "$inputs_file"
-    - 
+    -
       name: Display validation report
       run: |
         echo "=== Sprocket Validation Report ==="

--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -1,5 +1,5 @@
 # ww-bwa
-[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)  
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A WILDS WDL module for sequence alignment using the Burrows-Wheeler Aligner (BWA).
@@ -38,9 +38,10 @@ Aligns paired-end reads to a reference using BWA-MEM with automatic read group a
 **Inputs:**
 - `bwa_genome_tar` (File): Compressed tarball containing BWA genome index
 - `reference_fasta` (File): Reference genome FASTA file
-- `r1` (File): FASTQ file for read 1
-- `r2` (File): FASTQ file for read 2
+- `reads` (File): FASTQ file for forward (R1) reads or interleaved reads
+- `mates` (File): Optional FASTQ file for reverse (R2) reads
 - `name` (String): Sample name for read group information and output files
+- `paired_end` (Boolean): Optional, indicating if reads are paired end (default: true)
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
 
@@ -67,8 +68,8 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 
 struct BwaSample {
     String name
-    File r1
-    File r2
+    File reads
+    File mates
 }
 
 workflow my_alignment_pipeline {
@@ -78,7 +79,7 @@ workflow my_alignment_pipeline {
   }
 
   call bwa_tasks.bwa_index {
-    input: 
+    input:
       reference_fasta = reference_fasta,
       cpu_cores = 8,
       memory_gb = 32
@@ -89,8 +90,8 @@ workflow my_alignment_pipeline {
       input:
         bwa_genome_tar = bwa_index.bwa_index_tar,
         reference_fasta = reference_fasta,
-        r1 = sample.r1,
-        r2 = sample.r2,
+        reads = sample.reads,
+        mates = sample.mates,
         name = sample.name,
         cpu_cores = 8,
         memory_gb = 16
@@ -162,8 +163,8 @@ When no samples or reference files are provided, the workflow automatically:
   "bwa_example.samples": [
     {
       "name": "sample1",
-      "r1": "/path/to/sample1_R1.fastq.gz",
-      "r2": "/path/to/sample1_R2.fastq.gz"
+      "reads": "/path/to/sample1_R1.fastq.gz",
+      "mates": "/path/to/sample1_R2.fastq.gz"
     }
   ],
   "bwa_example.reference_fasta": "/path/to/genome.fasta",
@@ -205,7 +206,8 @@ The module supports flexible resource configuration:
 ## Features
 
 - **Standalone execution**: Complete workflow with automatic test data download
-- **Flexible input**: Use your own data or automatic demo data from `ww-testdata`
+- **Optional input**: Use your own data or automatic demo data from `ww-testdata`
+- **Paired-end or single-end input**: Use separate or interleaved paired-end FASTQs, or single-end data.
 - **BWA-MEM alignment**: Fast and accurate for reads 70bp to 1Mbp
 - **Automatic indexing**: Builds BWA index from reference FASTA with tarball packaging
 - **Sorted BAM output**: Ready for downstream analysis (variant calling, QC, etc.)
@@ -235,13 +237,13 @@ For human genome alignment:
   "bwa_example.samples": [
     {
       "name": "control_1",
-      "r1": "/data/control_1_R1.fastq.gz",
-      "r2": "/data/control_1_R2.fastq.gz"
+      "reads": "/data/control_1_R1.fastq.gz",
+      "mates": "/data/control_1_R2.fastq.gz"
     },
     {
-      "name": "treatment_1", 
-      "r1": "/data/treatment_1_R1.fastq.gz",
-      "r2": "/data/treatment_1_R2.fastq.gz"
+      "name": "treatment_1",
+      "reads": "/data/treatment_1_interleaved.fastq.gz",
+      "mates": ""
     }
   ],
   "bwa_example.cpus": 12,
@@ -257,8 +259,8 @@ For human genome alignment:
   "bwa_example.samples": [
     {
       "name": "sample1",
-      "r1": "/data/sample1_R1.fastq.gz",
-      "r2": "/data/sample1_R2.fastq.gz"
+      "reads": "/data/sample1_R1.fastq.gz",
+      "mates": "/data/sample1_R2.fastq.gz"
     }
   ]
 }

--- a/modules/ww-bwa/inputs.json
+++ b/modules/ww-bwa/inputs.json
@@ -2,16 +2,16 @@
   "bwa_example.samples": [
     {
       "name": "sample1",
-      "r1": "/path/to/your/sample1_R1.fastq.gz",
-      "r2": "/path/to/your/sample1_R2.fastq.gz"
+      "reads": "/path/to/your/sample1_R1.fastq.gz",
+      "mates": "/path/to/your/sample1_R2.fastq.gz"
     },
     {
       "name": "sample2",
-      "r1": "/path/to/your/sample2_R1.fastq.gz",
-      "r2": "/path/to/your/sample2_R2.fastq.gz"
+      "reads": "/path/to/your/sample2_interleaved.fastq.gz"
     }
   ],
   "bwa_example.reference_fasta": "/path/to/your/reference_genome.fasta",
+  "bwa_example.paired": true,
   "bwa_example.cpus": 8,
   "bwa_example.memory_gb": 32
 }

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -60,15 +60,16 @@ workflow bwa_example {
 
    # Create samples array - either from input or from test data download
   Array[BwaSample] final_samples = if defined(samples) then select_first([samples]) else [
-    {
-      "name": "demo_sample",
-      "reads": select_first([download_fastq_data.r1_fastq]),
-      "mates": select_first([download_fastq_data.r2_fastq])
-    },
-    {
-      "name": "demo_sample2",
-      "reads": select_first([interleave_fastq.inter_fastq])
-    },
+      BwaSample {
+          name: "demo_sample",
+          reads: select_first([download_fastq_data.r1_fastq]),
+          mates: select_first([download_fastq_data.r2_fastq])
+      },
+      BwaSample {
+          name: "demo_sample2",
+          reads: select_first([interleave_fastq.inter_fastq]),
+          mates: None
+      }
   ]
 
   call bwa_index { input:

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -26,6 +26,7 @@ workflow bwa_example {
   }
 
   parameter_meta {
+    paired: "Optional boolean indicating if reads are paired end (default: true)"
     reference_fasta: "Optional reference genome FASTA file. If not provided, test data will be used."
     samples: "Optional list of BwaSample objects, each containing sample name and FASTQ file(s). If not provided, workflow will download a demonstration sample from SRA"
     cpus: "Number of CPU cores allocated for each task in the workflow"
@@ -33,9 +34,10 @@ workflow bwa_example {
   }
 
   input {
+    Boolean paired
     File? reference_fasta
     Array[BwaSample]? samples
-    Boolean paired
+
     Int cpus = 2
     Int memory_gb = 8
   }

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -246,8 +246,8 @@ task validate_outputs {
     echo "" >> validation_report.txt
 
     # Arrays for bash processing
-    bam_files=("~{sep=" " bam_files}")
-    bai_files=("~{sep=" " bai_files}")
+    bam_files=(~{sep=" " bam_files})
+    bai_files=(~{sep=" " bai_files})
 
     validation_passed=true
     total_mapped_reads=0

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -26,18 +26,17 @@ workflow bwa_example {
   }
 
   parameter_meta {
-    paired: "Optional boolean indicating if reads are paired end (default: true)"
     reference_fasta: "Optional reference genome FASTA file. If not provided, test data will be used."
     samples: "Optional list of BwaSample objects, each containing sample name and FASTQ file(s). If not provided, workflow will download a demonstration sample from SRA"
+    paired: "Optional boolean indicating if reads are paired end (default: true)"
     cpus: "Number of CPU cores allocated for each task in the workflow"
     memory_gb: "Memory allocated for each task in the workflow in GB"
   }
 
   input {
-    Boolean paired
     File? reference_fasta
     Array[BwaSample]? samples
-
+    Boolean paired = true
     Int cpus = 2
     Int memory_gb = 8
   }

--- a/modules/ww-samtools/README.md
+++ b/modules/ww-samtools/README.md
@@ -1,5 +1,5 @@
 # ww-samtools
-[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)  
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A WILDS WDL module for processing genomic files with [Samtools](http://www.htslib.org/).
@@ -22,7 +22,7 @@ This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds
 
 ### `crams_to_fastq`
 
-Merges one or more CRAM/BAM/SAM files for a sample and converts the result to a compressed FASTQ.
+Merges one or more CRAM/BAM/SAM files for a sample, sorts by read name, and converts the result to a compressed FASTQ.
 
 **Inputs:**
 - `cram_files` (Array[String]): List of CRAM/BAM/SAM files to merge and convert


### PR DESCRIPTION
Adds functionality allowing our BWA MEM task to take interleaved fastqs (using the `bwa mem -p` flag). 

- Changes the R1 and R2 variable names to "reads" and "mates" to match BWA MEM terminology
- Adds a "paired_end" boolean parameter so that if one FASTQ is passed we know if it should be considered interleaved or single-end

## Related Issue
Closes #55 

## Testing
- Tested on PROOF and locally and works well
