### PR TITLE
Modify base quality characters when interleaving FASTQs

### DIFF
--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -422,7 +422,7 @@ task download_annotsv_vcf {
     set -euo pipefail
 
     # Download AnnotSV test VCF file
-    wget -q --no-check-certificate -O annotsv_test.vcf https://raw.githubusercontent.com/lgmgeo/AnnotSV/refs/heads/master/share/doc/AnnotSV/Example/test.vcf
+    wget -q --no-check-certificate -O annotsv_test.vcf https://raw.githubusercontent.com/lgmgeo/AnnotSV/refs/heads/master/share/doc/AnnotSV/Example/test2.vcf
   >>>
 
   output {


### PR DESCRIPTION
BBMap replaces "#" with "!" in the base quality lines when interleaving FASTQs. Originally, I did not do this with my bash command. With my bash-interleaved FASTQ, BWA MEM noted zero reads compared with 402098 with the BBMap interleaved FASTQ.

## Description
Fixed bash command to replace "#" with "!" in the quality lines.

## Related Issue
Fixes #60 

## Example
Tested on PROOF and was successful.
