### PR TITLE
Converting CRAM's to Paired Fastq's rather than Interleaved

### DIFF
--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -208,8 +208,12 @@ task bwa_mem {
       exit 1
     fi
 
+    # Converting to BAM, sorting, and indexing
     samtools sort -@ ~{cpu_threads - 1} -o "~{name}.sorted_aligned.bam" "~{name}.sam"
     samtools index "~{name}.sorted_aligned.bam"
+    
+    # Cleaning up initial SAM file to save space
+    rm -f "~{name}.sam"
   >>>
 
   output {

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -133,6 +133,9 @@ task bwa_index {
     echo "Building BWA index..." && \
     bwa index "bwa_index/~{ref_name}" && \
     tar -czf bwa_index.tar.gz bwa_index/*
+
+    # Cleaning up the bwa_index directory to save space, only need the tarball
+    rm -rf bwa_index
   >>>
 
   output {
@@ -191,7 +194,7 @@ task bwa_mem {
 
     echo "Starting BWA alignment..."
 
-  if [[ "~{mates}" == "" && "~{paired_end}" == "true" ]]; then
+    if [[ "~{mates}" == "" && "~{paired_end}" == "true" ]]; then
       # Interleaved (paired-end)
       bwa mem -p -v 3 -t ~{cpu_threads} -M -R "@RG\tID:~{name}\tSM:~{name}\tPL:illumina" \
         "bwa_index/~{ref_name}" "~{reads}" > "~{name}.sam"
@@ -211,9 +214,10 @@ task bwa_mem {
     # Converting to BAM, sorting, and indexing
     samtools sort -@ ~{cpu_threads - 1} -o "~{name}.sorted_aligned.bam" "~{name}.sam"
     samtools index "~{name}.sorted_aligned.bam"
-    
-    # Cleaning up initial SAM file to save space
-    rm -f "~{name}.sam"
+
+    # Cleaning up BWA index and initial SAM file to save space
+    rm -rf bwa_index  # Remove BWA index directory
+    rm -f "~{name}.sam"  # Remove initial SAM file
   >>>
 
   output {

--- a/modules/ww-samtools/ww-samtools.wdl
+++ b/modules/ww-samtools/ww-samtools.wdl
@@ -121,6 +121,9 @@ task crams_to_fastq {
     samtools merge -@ ~{cpu_cores} --reference "~{ref}" -f "~{name}.merged.cram" ~{sep=" " cram_files} && \
     samtools collate -u -O "~{name}.merged.cram" | \
     samtools fastq --reference "~{ref}" -1 "~{name}_R1.fastq.gz" -2 "~{name}_R2.fastq.gz" -0 /dev/null -s /dev/null -
+
+    # Cleaning up merged CRAM file to save space
+    rm -f "~{name}.merged.cram"
   >>>
 
   output {

--- a/modules/ww-samtools/ww-samtools.wdl
+++ b/modules/ww-samtools/ww-samtools.wdl
@@ -89,9 +89,10 @@ workflow samtools_example {
 
 task crams_to_fastq {
   meta {
-    description: "Merge CRAM/BAM/SAM files and convert to FASTQ using samtools."
+    description: "Merge CRAM/BAM/SAM files and convert to FASTQ's using samtools."
     outputs: {
-        fastq_file: "FASTQ file generated from merged CRAM/BAM/SAM file",
+        r1_fastq: "R1 FASTQ file generated from merged CRAM/BAM/SAM file",
+        r2_fastq: "R2 FASTQ file generated from merged CRAM/BAM/SAM file",
         sample_name: "Sample name that was processed"
     }
   }
@@ -115,12 +116,13 @@ task crams_to_fastq {
   command <<<
     # Merge CRAM/BAM/SAM files if more than one, then convert to FASTQ
     samtools merge -@ ~{cpu_cores} --reference "~{ref}" -f "~{name}.merged.cram" ~{sep=" " cram_files} && \
-    samtools sort -n "~{name}.merged.cram" && \
-    samtools fastq --reference "~{ref}" -o "~{name}.fastq.gz" "~{name}.merged.cram"
+    samtools collate -u -O "~{name}.merged.cram" | \
+    samtools fastq --reference "~{ref}" -1 "~{name}_R1.fastq.gz" -2 "~{name}_R2.fastq.gz" -0 /dev/null -s /dev/null -
   >>>
 
   output {
-    File fastq_file = "~{name}.fastq.gz"
+    File r1_fastq = "~{name}_R1.fastq.gz"
+    File r2_fastq = "~{name}_R2.fastq.gz"
     String sample_name = "~{name}"
   }
 

--- a/modules/ww-samtools/ww-samtools.wdl
+++ b/modules/ww-samtools/ww-samtools.wdl
@@ -17,7 +17,8 @@ workflow samtools_example {
     description: "WDL workflow for processing genomic files with Samtools"
     url: "https://github.com/getwilds/wilds-wdl-library/modules/ww-samtools"
     outputs: {
-        fastq_results: "FASTQ output files for each sample",
+        r1_fastqs: "Array of R1 FASTQ files generated from CRAM/BAM/SAM files",
+        r2_fastqs: "Array of R2 FASTQ files generated from CRAM/BAM/SAM files",
         validation_report: "Validation report confirming all expected outputs were generated"
     }
   }
@@ -77,12 +78,14 @@ workflow samtools_example {
   }
 
   call validate_outputs { input:
-      fastq_files = crams_to_fastq.fastq_file,
+      r1_fastqs = crams_to_fastq.r1_fastq,
+      r2_fastqs = crams_to_fastq.r2_fastq,
       sample_names = crams_to_fastq.sample_name
   }
 
   output {
-    Array[File] fastq_results = crams_to_fastq.fastq_file
+    Array[File] r1_fastqs = crams_to_fastq.r1_fastq
+    Array[File] r2_fastqs = crams_to_fastq.r2_fastq
     File validation_report = validate_outputs.report
   }
 }
@@ -142,12 +145,14 @@ task validate_outputs {
   }
 
   parameter_meta {
-    fastq_files: "Array of FASTQ files to check"
+    r1_fastqs: "Array of R1 FASTQ files to check"
+    r2_fastqs: "Array of R2 FASTQ files to check"
     sample_names: "Array of sample names corresponding to FASTQ files"
   }
 
   input {
-    Array[File] fastq_files
+    Array[File] r1_fastqs
+    Array[File] r2_fastqs
     Array[String] sample_names
   }
 
@@ -157,23 +162,34 @@ task validate_outputs {
     echo "=== Samtools FASTQ Validation Report ===" > samtools_validation_report.txt
     echo "" >> samtools_validation_report.txt
 
-    fastq_files=(~{sep=" " fastq_files})
+    r1_fastqs=(~{sep=" " r1_fastqs})
+    r2_fastqs=(~{sep=" " r2_fastqs})
     sample_names=(~{sep=" " sample_names})
 
     validation_passed=true
 
     for i in "${!sample_names[@]}"; do
       sample="${sample_names[$i]}"
-      fastq="${fastq_files[$i]}"
+      r1="${r1_fastqs[$i]}"
+      r2="${r2_fastqs[$i]}"
 
       echo "--- Sample: $sample ---" >> samtools_validation_report.txt
 
-      if [[ -f "$fastq" && -s "$fastq" ]]; then
-        size=$(stat -c%s "$fastq")
-        lines=$(zcat "$fastq" | wc -l)
-        echo "  FASTQ: PASS (${size} bytes, ${lines} lines)" >> samtools_validation_report.txt
+      if [[ -f "$r1" && -s "$r1" ]]; then
+        size=$(stat -c%s "$r1")
+        lines=$(zcat "$r1" | wc -l)
+        echo "  R1 FASTQ: PASS (${size} bytes, ${lines} lines)" >> samtools_validation_report.txt
       else
-        echo "  FASTQ: FAIL - MISSING OR EMPTY" >> samtools_validation_report.txt
+        echo "  R1 FASTQ: FAIL - MISSING OR EMPTY" >> samtools_validation_report.txt
+        validation_passed=false
+      fi
+
+      if [[ -f "$r2" && -s "$r2" ]]; then
+        size=$(stat -c%s "$r2")
+        lines=$(zcat "$r2" | wc -l)
+        echo "  R2 FASTQ: PASS (${size} bytes, ${lines} lines)" >> samtools_validation_report.txt
+      else
+        echo "  R2 FASTQ: FAIL - MISSING OR EMPTY" >> samtools_validation_report.txt
         validation_passed=false
       fi
 


### PR DESCRIPTION
## Description
- While testing ww-leukemia with full WGS data, Manta was throwing a fit about having read name overlaps and not enough paired reads. Seemed super strange, so we checked alignment stats with `samtools flagstats` and mate information wasn't being properly passed during the conversion from CRAM to interleaved fastq.
- Upon switching to paired fastq's, the issue was resolved. As such, the `crams_to_fastq` task in `ww-samtools` should be updated accordingly to produce separate R1/R2 paired fastq's rather than a single interleaved one.
- Also adding a quick cleanup steps to the end of `ww-bwa` tasks, temporary files are pretty huge.

## Related Issue
- Fixes #74 

## Testing
- Submitted on PROOF within the ww-leukemia workflow, aligns properly, and completes analysis as expected.
- See GitHub Action test runs below.