### PR TITLE
Fixing GATK SplitIntervals and Adding Internal Parallelization Back In

### DIFF
--- a/modules/ww-gatk/README.md
+++ b/modules/ww-gatk/README.md
@@ -281,10 +281,10 @@ Validates GATK outputs and generates comprehensive statistics report.
 - `recalibrated_bais` (Array[File]): Array of recalibrated BAM index files
 - `sequential_bams` (Array[File]): Array of sequential Markdup-Recal-Metrics BAM files
 - `sequential_bais` (Array[File]): Array of sequential Markdup-Recal-Metrics BAM index files
-- `haplotype_vcfs` (Array[File]): Array of HaplotypeCaller VCF files
-- `mutect2_vcfs` (Array[File]): Array of Mutect2 VCF files
-- `parallel_haplotype_vcfs` (Array[File]): Array of parallel HaplotypeCaller VCF files
-- `parallel_mutect2_vcfs` (Array[File]): Array of parallel Mutect2 VCF files
+- `haplotype_vcfs` (Array[File]): Array of HaplotypeCaller VCF files called via scatter-gather parallelization
+- `mutect2_vcfs` (Array[File]): Array of Mutect2 VCF files called via scatter-gather parallelization
+- `parallel_haplotype_vcfs` (Array[File]): Array of HaplotypeCaller VCF files called via internal parallelization
+- `parallel_mutect2_vcfs` (Array[File]): Array of Mutect2 VCF files called via internal parallelization
 - `wgs_metrics` (Array[File]): Array of WGS metrics files
 
 **Outputs:**

--- a/modules/ww-gatk/README.md
+++ b/modules/ww-gatk/README.md
@@ -12,7 +12,7 @@ The module implements GATK best practices for variant calling, including proper 
 
 ## Key Features
 
-- **Automatic parallelization**: Intelligently splits genome into optimal intervals for parallel processing
+- **Dual parallelization strategies**: Both scatter-gather and internal parallelization approaches
 - **Significant speedup**: Near-linear performance scaling for HaplotypeCaller and Mutect2 on WGS data
 - **Smart interval management**: Uses GATK SplitIntervals to create balanced computational chunks
 - **Seamless merging**: Automatically combines parallel results into final VCF files
@@ -23,7 +23,7 @@ The module implements GATK best practices for variant calling, including proper 
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
 
-- **Tasks**: `mark_duplicates`, `base_recalibrator`, `markdup_recal_metrics`, `haplotype_caller`, `mutect2`, `split_intervals`, `print_reads`, `merge_vcfs`, `merge_mutect_stats`, `create_sequence_dictionary`, `collect_wgs_metrics`, `validate_outputs`
+- **Tasks**: `mark_duplicates`, `base_recalibrator`, `markdup_recal_metrics`, `haplotype_caller`, `mutect2`, `haplotype_caller_parallel`, `mutect2_parallel`, `split_intervals`, `print_reads`, `merge_vcfs`, `merge_mutect_stats`, `create_sequence_dictionary`, `collect_wgs_metrics`, `validate_outputs`
 - **Workflow**: `gatk_example` (demonstration workflow with automatic test data support and parallelization)
 - **Container**: `getwilds/gatk:4.6.1.0`
 - **Dependencies**: Integrates with `ww-testdata` module for automatic reference genome and variant database downloads
@@ -98,7 +98,7 @@ Performs duplicate marking, base recalibration, and WGS metrics collection in a 
 ### Core Variant Calling Tasks
 
 ### `haplotype_caller`
-Calls germline variants using GATK HaplotypeCaller.
+Calls germline variants using GATK HaplotypeCaller for individual intervals in scatter-gather workflows.
 
 **Inputs:**
 - `bam` (File): Input aligned BAM file
@@ -116,8 +116,27 @@ Calls germline variants using GATK HaplotypeCaller.
 - `vcf` (File): Compressed VCF file containing germline variant calls
 - `vcf_index` (File): Index file for the VCF output
 
+### `haplotype_caller_parallel`
+Calls germline variants using GATK HaplotypeCaller with internal parallelization for reduced data duplication and improved efficiency.
+
+**Inputs:**
+- `bam` (File): Input aligned BAM file
+- `bam_index` (File): Index file for the input BAM
+- `intervals` (Array[File]): Array of interval files for parallel processing
+- `reference_fasta` (File): Reference genome FASTA file
+- `reference_fasta_index` (File): Index file for the reference FASTA
+- `reference_dict` (File): Reference genome sequence dictionary
+- `dbsnp_vcf` (File): dbSNP VCF file for variant annotation
+- `base_file_name` (String): Base name for output files
+- `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `cpu_cores` (Int): Number of CPU cores to use (should match number of intervals) (default: 2)
+
+**Outputs:**
+- `vcf` (File): Compressed VCF file containing germline variant calls
+- `vcf_index` (File): Index file for the VCF output
+
 ### `mutect2`
-Calls somatic variants using GATK Mutect2 in tumor-only mode with filtering.
+Calls somatic variants using GATK Mutect2 in tumor-only mode with filtering for individual intervals in scatter-gather workflows.
 
 **Inputs:**
 - `bam` (File): Input aligned BAM file
@@ -137,6 +156,26 @@ Calls somatic variants using GATK Mutect2 in tumor-only mode with filtering.
 - `stats_file` (File): Mutect2 statistics file
 - `f1r2_counts` (File): F1R2 counts for filtering
 
+### `mutect2_parallel`
+Calls somatic variants using GATK Mutect2 with internal parallelization for reduced data duplication and improved efficiency.
+
+**Inputs:**
+- `bam` (File): Input aligned BAM file
+- `bam_index` (File): Index file for the input BAM
+- `intervals` (Array[File]): Array of interval files for parallel processing
+- `reference_fasta` (File): Reference genome FASTA file
+- `reference_fasta_index` (File): Index file for the reference FASTA
+- `reference_dict` (File): Reference genome sequence dictionary
+- `gnomad_vcf` (File): gnomAD population allele frequency VCF for germline resource
+- `base_file_name` (String): Base name for output files
+- `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+
+**Outputs:**
+- `vcf` (File): Compressed VCF file containing filtered somatic variant calls
+- `vcf_index` (File): Index file for the Mutect2 VCF output
+- `stats_file` (File): Merged Mutect2 statistics file
+
 ### Parallelization and Utility Tasks
 
 ### `split_intervals`
@@ -148,6 +187,7 @@ Automatically splits genome intervals into optimal chunks for parallel processin
 - `reference_dict` (File): Reference genome sequence dictionary
 - `intervals` (File?): Optional interval list file defining target regions to split
 - `scatter_count` (Int): Number of interval files to create (default: 24)
+- `filter_to_canonical_chromosomes` (Boolean): Whether to restrict analysis to canonical chromosomes (chr1-22,X,Y,M) (default: true)
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
 
@@ -160,7 +200,7 @@ Extracts reads from specific intervals using GATK PrintReads for scatter-gather 
 **Inputs:**
 - `bam` (File): Input BAM file to extract reads from
 - `bam_index` (File): Index file for the input BAM
-- `interval_files` (Array[File]): Array of interval files defining regions to extract
+- `intervals` (Array[File]): Array of interval files defining regions to extract
 - `reference_fasta` (File): Reference genome FASTA file
 - `reference_fasta_index` (File): Index file for the reference FASTA
 - `reference_dict` (File): Reference genome sequence dictionary
@@ -243,6 +283,8 @@ Validates GATK outputs and generates comprehensive statistics report.
 - `sequential_bais` (Array[File]): Array of sequential Markdup-Recal-Metrics BAM index files
 - `haplotype_vcfs` (Array[File]): Array of HaplotypeCaller VCF files
 - `mutect2_vcfs` (Array[File]): Array of Mutect2 VCF files
+- `parallel_haplotype_vcfs` (Array[File]): Array of parallel HaplotypeCaller VCF files
+- `parallel_mutect2_vcfs` (Array[File]): Array of parallel Mutect2 VCF files
 - `wgs_metrics` (Array[File]): Array of WGS metrics files
 
 **Outputs:**
@@ -252,14 +294,14 @@ Validates GATK outputs and generates comprehensive statistics report.
 
 **Default behavior:**
 - Splits genome into configurable intervals (default: 2 for testing, 24 recommended for production)
-- Splits BAM files by intervals for optimal parallel processing
-- Each interval runs HaplotypeCaller and Mutect2 in parallel
+- Provides both scatter-gather and internal parallelization approaches
 - Automatically merges results into final VCF files
 - Near-linear speedup for WGS analysis
 
-**Processing approaches:**
-- **Individual tasks**: Separate duplicate marking, base recalibration, and metrics collection
-- **Combined task**: `markdup_recal_metrics` performs all preprocessing steps in one task for efficiency
+**Parallelization strategies:**
+- **Scatter-gather approach**: Uses `print_reads` to split BAMs by intervals, then runs `haplotype_caller` and `mutect2` on each interval
+- **Internal parallelization**: Uses `haplotype_caller_parallel` and `mutect2_parallel` with GNU parallel for more efficient resource usage
+- **Combined processing**: `markdup_recal_metrics` performs all preprocessing steps in one task for efficiency
 
 ## Testing the Module
 
@@ -309,11 +351,11 @@ The demonstration workflow can run with an empty inputs file (`{}`) and will aut
 
 ## Features
 
-- **Automatic interval-based parallelization**: Dramatically improves WGS performance
+- **Dual parallelization strategies**: Both scatter-gather and internal parallelization approaches for maximum flexibility
 - **Complete GATK pipeline**: Duplicate marking, base recalibration, germline and somatic variant calling, QC metrics
 - **Intelligent interval splitting**: Uses GATK SplitIntervals for optimal load balancing
 - **Seamless result merging**: Transparent combination of parallel results
-- **Flexible processing modes**: Choose between individual tasks or combined processing approaches
+- **Flexible processing modes**: Choose between individual tasks, combined processing, or different parallelization approaches
 - **Automatic test data**: Downloads reference genome, variant databases, and test BAM when not provided
 - **Best practices implementation**: Follows GATK best practices for variant calling workflows
 - **Comprehensive validation**: Built-in output validation and quality reporting
@@ -327,6 +369,12 @@ The demonstration workflow can run with an empty inputs file (`{}`) and will aut
 - **Mutect2**: Similar dramatic performance improvements
 - **Scalability**: Performance scales nearly linearly with available CPU cores
 - **Memory efficiency**: Parallel tasks use memory more efficiently than single large jobs
+- **Internal parallelization**: The `*_parallel` tasks offer better resource utilization by avoiding data duplication
+
+### Parallelization Strategy Comparison
+- **Scatter-gather approach**: Better for distributed computing environments, easier debugging of individual intervals
+- **Internal parallelization**: More efficient resource usage, reduced data duplication, better for single-node execution
+- **Both approaches**: Available in the same workflow for comparison and flexibility
 
 ### Resource Requirements
 - **Memory usage**: 16-32GB RAM total for WGS analysis (distributed across parallel tasks)
@@ -337,6 +385,7 @@ The demonstration workflow can run with an empty inputs file (`{}`) and will aut
 
 ### Optimization Tips
 - **Use appropriate scatter_count**: Balance between parallelization and overhead (default 2 for testing, 24 for production)
+- **Choose parallelization strategy**: Internal parallelization for single nodes, scatter-gather for distributed computing
 - **Ensure adequate CPU allocation**: More cores = better performance for variant calling
 - **Monitor memory usage**: Each parallel task needs sufficient memory
 - **Choose processing approach**: Combined tasks reduce I/O overhead for large datasets
@@ -358,7 +407,7 @@ This module is automatically tested as part of the WILDS WDL Library CI/CD pipel
 - Comprehensive validation of all outputs and statistics
 - Integration testing with `ww-testdata` module
 - Parallelization testing with multiple interval configurations
-- Validation of both individual and combined processing approaches
+- Validation of both scatter-gather and internal parallelization approaches
 
 ## Integration Patterns
 
@@ -367,8 +416,8 @@ This module demonstrates several key patterns:
 - **Resource management**: Coordinated memory allocation across compute-intensive tasks
 - **Best practices workflow**: Implementation of GATK recommended variant calling pipeline
 - **Comprehensive validation**: Quality assurance for complex multi-output workflows
-- **Automatic parallelization**: Transparent interval-based parallel processing with result merging
-- **Flexible processing architectures**: Both modular and combined task approaches
+- **Dual parallelization approaches**: Both scatter-gather and internal parallelization strategies
+- **Flexible processing architectures**: Multiple task orchestration patterns
 
 ## Extending the Module
 
@@ -377,8 +426,8 @@ This module can be extended by:
 - Integrating additional variant filtering and annotation tools
 - Including structural variant calling with other GATK tools
 - Adding quality control modules (e.g., FastQC, MultiQC integration)
-- Customizing parallelization strategies for specific use cases
-- Implementing additional preprocessing steps or optimizations
+- Implementing additional parallelization strategies for specific use cases
+- Adding performance benchmarking between parallelization approaches
 
 ## Related WILDS Components
 

--- a/modules/ww-gatk/ww-gatk.wdl
+++ b/modules/ww-gatk/ww-gatk.wdl
@@ -164,7 +164,7 @@ workflow gatk_example {
     call print_reads { input:
       bam = base_recalibrator.recalibrated_bam,
       bam_index = base_recalibrator.recalibrated_bai,
-      interval_files = split_intervals.interval_files,
+      intervals = split_intervals.interval_files,
       reference_fasta = genome_fasta,
       reference_fasta_index = genome_fasta_index,
       reference_dict = create_sequence_dictionary.sequence_dict,
@@ -217,6 +217,30 @@ workflow gatk_example {
         stats = mutect2.stats_file,
         base_file_name = sample.name + ".mutect2"
     }
+
+    # Run HaplotypeCaller with internal parallelization
+    call haplotype_caller_parallel { input:
+        bam = base_recalibrator.recalibrated_bam,
+        bam_index = base_recalibrator.recalibrated_bai,
+        intervals = split_intervals.interval_files,
+        reference_fasta = genome_fasta,
+        reference_fasta_index = genome_fasta_index,
+        reference_dict = create_sequence_dictionary.sequence_dict,
+        dbsnp_vcf = final_dbsnp,
+        base_file_name = sample.name
+    }
+
+    # Run Mutect2 with internal parallelization
+    call mutect2_parallel { input:
+        bam = base_recalibrator.recalibrated_bam,
+        bam_index = base_recalibrator.recalibrated_bai,
+        intervals = split_intervals.interval_files,
+        reference_fasta = genome_fasta,
+        reference_fasta_index = genome_fasta_index,
+        reference_dict = create_sequence_dictionary.sequence_dict,
+        gnomad_vcf = final_gnomad,
+        base_file_name = sample.name
+    }
   }
 
   # Validate outputs to ensure all tasks completed successfully
@@ -229,6 +253,8 @@ workflow gatk_example {
       sequential_bais = markdup_recal_metrics.recalibrated_bai,
       haplotype_vcfs = merge_haplotype_vcfs.merged_vcf,
       mutect2_vcfs = merge_mutect2_vcfs.merged_vcf,
+      parallel_haplotype_vcfs = haplotype_caller_parallel.vcf,
+      parallel_mutect2_vcfs = mutect2_parallel.vcf,
       wgs_metrics = collect_wgs_metrics.metrics_file
   }
 
@@ -732,7 +758,7 @@ task print_reads {
   parameter_meta {
     bam: "Input BAM file to extract reads from"
     bam_index: "Index file for the input BAM"
-    interval_files: "Array of interval files defining regions to extract"
+    intervals: "Array of interval files defining regions to extract"
     reference_fasta: "Reference genome FASTA file"
     reference_fasta_index: "Index file for the reference FASTA"
     reference_dict: "Reference genome sequence dictionary"
@@ -744,7 +770,7 @@ task print_reads {
   input {
     File bam
     File bam_index
-    Array[File] interval_files
+    Array[File] intervals
     File reference_fasta
     File reference_fasta_index
     File reference_dict
@@ -767,7 +793,7 @@ task print_reads {
     
     # Process each interval file
     counter=0
-    for interval_file in ~{sep=" " interval_files}; do
+    for interval_file in ~{sep=" " intervals}; do
       interval_name=$(basename "$interval_file" .interval_list)
       output_bam="~{output_basename}.${counter}.${interval_name}.bam"
       
@@ -1051,6 +1077,247 @@ task merge_mutect_stats {
   }
 }
 
+task haplotype_caller_parallel {
+  meta {
+    description: "Call germline variants using GATK HaplotypeCaller with internal parallelization for reduced data duplication"
+    outputs: {
+        vcf: "Compressed VCF file containing germline variant calls",
+        vcf_index: "Index file for the VCF output"
+    }
+  }
+
+  parameter_meta {
+    bam: "Input aligned BAM file"
+    bam_index: "Index file for the input BAM"
+    intervals: "Array of interval files for parallel processing"
+    reference_fasta: "Reference genome FASTA file"
+    reference_fasta_index: "Index file for the reference FASTA"
+    reference_dict: "Reference genome sequence dictionary"
+    dbsnp_vcf: "dbSNP VCF file for variant annotation"
+    base_file_name: "Base name for output files"
+    memory_gb: "Memory allocation in GB"
+    cpu_cores: "Number of CPU cores to use (should match number of intervals)"
+  }
+
+  input {
+    File bam
+    File bam_index
+    Array[File] intervals
+    File reference_fasta
+    File reference_fasta_index
+    File reference_dict
+    File dbsnp_vcf
+    String base_file_name
+    Int memory_gb = 8
+    Int cpu_cores = 2
+  }
+
+  command <<<
+    set -eo pipefail
+    
+    # Add local symbolic link for reference fasta and dict
+    ln -s "~{reference_fasta}" "~{basename(reference_fasta)}"
+    ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
+    ln -s "~{reference_dict}" "~{basename(reference_dict)}"
+
+    # Create index for dbSNP vcf
+    gatk IndexFeatureFile -I "~{dbsnp_vcf}"
+
+    # Calculate memory per parallel job
+    mem_per_job=$(( (~{memory_gb} - 4) / ~{length(intervals)} ))
+    if [ $mem_per_job -lt 2 ]; then
+      mem_per_job=2
+    fi
+
+    # Create array of interval files
+    intervals=(~{sep=" " intervals})
+    
+    # Function to run HaplotypeCaller on a single interval
+    run_haplotypecaller() {
+      local interval_file=$1
+      local interval_name=$(basename "$interval_file" .interval_list)
+      
+      gatk --java-options "-Xms${mem_per_job}g -Xmx${mem_per_job}g" \
+        HaplotypeCaller \
+        -R "~{basename(reference_fasta)}" \
+        -I "~{bam}" \
+        -O "~{base_file_name}.${interval_name}.vcf.gz" \
+        --intervals "$interval_file" \
+        --interval-padding 100 \
+        --dbsnp "~{dbsnp_vcf}" \
+        --verbosity WARNING
+    }
+
+    # Export the function so it can be used by parallel
+    export -f run_haplotypecaller
+    export reference_fasta="~{basename(reference_fasta)}"
+    export bam="~{bam}"
+    export dbsnp_vcf="~{dbsnp_vcf}"
+    export base_file_name="~{base_file_name}"
+    export mem_per_job
+
+    # Run HaplotypeCaller in parallel across intervals
+    printf '%s\n' "${intervals[@]}" | \
+      parallel -j ~{cpu_cores} run_haplotypecaller {}
+
+    # Collect all VCF files for merging
+    find . -name "~{base_file_name}.*.vcf.gz" | sort -V > vcf_list.txt
+    
+    # Merge VCFs using MergeVcfs with input list file
+    gatk --java-options "-Xms4g -Xmx6g" \
+      MergeVcfs \
+      --INPUT vcf_list.txt \
+      -D "~{basename(reference_dict)}" \
+      -O "~{base_file_name}.haplotypecaller.vcf.gz" \
+      --VERBOSITY WARNING
+  >>>
+
+  output {
+    File vcf = "~{base_file_name}.haplotypecaller.vcf.gz"
+    File vcf_index = "~{base_file_name}.haplotypecaller.vcf.gz.tbi"
+  }
+
+  runtime {
+    docker: "getwilds/gatk:4.6.1.0"
+    memory: "~{memory_gb} GB"
+    cpu: cpu_cores
+  }
+}
+
+task mutect2_parallel {
+  meta {
+    description: "Call somatic variants using GATK Mutect2 with internal parallelization for reduced data duplication"
+    outputs: {
+        vcf: "Compressed VCF file containing filtered somatic variant calls",
+        vcf_index: "Index file for the Mutect2 VCF output",
+        stats_file: "Merged Mutect2 statistics file"
+    }
+  }
+
+  parameter_meta {
+    bam: "Input aligned BAM file"
+    bam_index: "Index file for the input BAM"
+    intervals: "Array of interval files for parallel processing"
+    reference_fasta: "Reference genome FASTA file"
+    reference_fasta_index: "Index file for the reference FASTA"
+    reference_dict: "Reference genome sequence dictionary"
+    gnomad_vcf: "gnomAD population allele frequency VCF for germline resource"
+    base_file_name: "Base name for output files"
+    memory_gb: "Memory allocation in GB"
+    cpu_cores: "Number of CPU cores to use"
+  }
+
+  input {
+    File bam
+    File bam_index
+    Array[File] intervals
+    File reference_fasta
+    File reference_fasta_index
+    File reference_dict
+    File gnomad_vcf
+    String base_file_name
+    Int memory_gb = 8
+    Int cpu_cores = 2
+  }
+
+  command <<<
+    set -eo pipefail
+    
+    # Add local symbolic link for reference fasta and dict
+    # If soft links aren't allowed on your HPC system, copy them locally instead
+    ln -s "~{reference_fasta}" "~{basename(reference_fasta)}"
+    ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
+    ln -s "~{reference_dict}" "~{basename(reference_dict)}"
+
+    # Index gnomad VCF
+    gatk IndexFeatureFile -I "~{gnomad_vcf}"
+
+    # Calculate memory per parallel job
+    mem_per_job=$(( (~{memory_gb} - 4) / ~{length(intervals)} ))
+    if [ $mem_per_job -lt 2 ]; then
+      mem_per_job=2
+    fi
+
+    # Create array of interval files
+    intervals=(~{sep=" " intervals})
+    
+    # Function to run Mutect2 on a single interval
+    run_mutect2() {
+      local interval_file=$1
+      local interval_name=$(basename "$interval_file" .interval_list)
+      
+      # Run Mutect2
+      gatk --java-options "-Xms${mem_per_job}g -Xmx${mem_per_job}g" \
+        Mutect2 \
+        -R "~{basename(reference_fasta)}" \
+        -I "~{bam}" \
+        -O "~{base_file_name}.${interval_name}.unfiltered.vcf.gz" \
+        --intervals "$interval_file" \
+        --interval-padding 100 \
+        --germline-resource "~{gnomad_vcf}" \
+        --f1r2-tar-gz "~{base_file_name}.${interval_name}.f1r2.tar.gz" \
+        --verbosity WARNING
+
+      # Filter Mutect2 calls
+      gatk --java-options "-Xms${mem_per_job}g -Xmx${mem_per_job}g" \
+        FilterMutectCalls \
+        -V "~{base_file_name}.${interval_name}.unfiltered.vcf.gz" \
+        -R "~{basename(reference_fasta)}" \
+        -O "~{base_file_name}.${interval_name}.vcf.gz" \
+        --stats "~{base_file_name}.${interval_name}.unfiltered.vcf.gz.stats" \
+        --verbosity WARNING
+    }
+
+    # Export the function and variables
+    export -f run_mutect2
+    export reference_fasta="~{basename(reference_fasta)}"
+    export bam="~{bam}"
+    export gnomad_vcf="~{gnomad_vcf}"
+    export base_file_name="~{base_file_name}"
+    export mem_per_job
+
+    # Run Mutect2 in parallel across intervals
+    printf '%s\n' "${intervals[@]}" | \
+      parallel -j ~{cpu_cores} run_mutect2 {}
+
+    # Collect VCF files and stats files for merging
+    find . -name "~{base_file_name}.*.vcf.gz" -not -name "*.unfiltered.*" | sort -V > vcf_list.txt
+    find . -name "~{base_file_name}.*.unfiltered.vcf.gz.stats" | sort -V > stats_list.txt
+    
+    # Merge VCFs using input list file
+    gatk --java-options "-Xms4g -Xmx6g" \
+      MergeVcfs \
+      --INPUT vcf_list.txt \
+      -D "~{basename(reference_dict)}" \
+      -O "~{base_file_name}.mutect2.vcf.gz" \
+      --VERBOSITY WARNING
+
+    # Merge stats files - build argument list properly
+    stats_args=""
+    while IFS= read -r stats_file; do
+      stats_args="${stats_args} --stats ${stats_file}"
+    done < stats_list.txt
+    
+    gatk --java-options "-Xms2g -Xmx3g" \
+      MergeMutectStats \
+      ${stats_args} \
+      -O "~{base_file_name}.mutect2.stats" \
+      --verbosity WARNING
+  >>>
+
+  output {
+    File vcf = "~{base_file_name}.mutect2.vcf.gz"
+    File vcf_index = "~{base_file_name}.mutect2.vcf.gz.tbi"
+    File stats_file = "~{base_file_name}.mutect2.stats"
+  }
+
+  runtime {
+    docker: "getwilds/gatk:4.6.1.0"
+    memory: "~{memory_gb} GB"
+    cpu: cpu_cores
+  }
+}
+
 task validate_outputs {
   # TODO: Add validation for GATK dictionary, intervals, and duplicate metrics files
   # TODO: Ensure that the recalibrated BAM files match between the separate and all-in-one tasks
@@ -1070,6 +1337,8 @@ task validate_outputs {
     sequential_bais: "Array of sequential Markdup-Recal-Metrics BAM index files"
     haplotype_vcfs: "Array of HaplotypeCaller VCF files"
     mutect2_vcfs: "Array of Mutect2 VCF files"
+    parallel_haplotype_vcfs: "Array of parallel HaplotypeCaller VCF files"
+    parallel_mutect2_vcfs: "Array of parallel Mutect2 VCF files"
     wgs_metrics: "Array of WGS metrics files"
   }
 
@@ -1082,6 +1351,8 @@ task validate_outputs {
     Array[File] sequential_bais
     Array[File] haplotype_vcfs
     Array[File] mutect2_vcfs
+    Array[File] parallel_haplotype_vcfs
+    Array[File] parallel_mutect2_vcfs
     Array[File] wgs_metrics
   }
 
@@ -1177,6 +1448,26 @@ task validate_outputs {
         echo "Mutect2 VCF: $(basename $vcf) (${variants} variants)" >> validation_report.txt
       else
         echo "Missing Mutect2 VCF: $vcf" >> validation_report.txt
+      fi
+    done
+
+    # Check Parallel HaplotypeCaller VCFs if present
+    for vcf in ~{sep=" " parallel_haplotype_vcfs}; do
+      if [[ -f "$vcf" ]]; then
+        variants=$(zcat "$vcf" | grep -v '^#' | wc -l || echo "0")
+        echo "Parallel HaplotypeCaller VCF: $(basename $vcf) (${variants} variants)" >> validation_report.txt
+      else
+        echo "Missing Parallel HaplotypeCaller VCF: $vcf" >> validation_report.txt
+      fi
+    done
+    
+    # Check Parallel Mutect2 VCFs if present
+    for vcf in ~{sep=" " parallel_mutect2_vcfs}; do
+      if [[ -f "$vcf" ]]; then
+        variants=$(zcat "$vcf" | grep -v "^#" | wc -l || echo "0")
+        echo "Parallel Mutect2 VCF: $(basename $vcf) (${variants} variants)" >> validation_report.txt
+      else
+        echo "Missing Parallel Mutect2 VCF: $vcf" >> validation_report.txt
       fi
     done
     

--- a/modules/ww-gatk/ww-gatk.wdl
+++ b/modules/ww-gatk/ww-gatk.wdl
@@ -1335,10 +1335,10 @@ task validate_outputs {
     recalibrated_bais: "Array of recalibrated BAM index files"
     sequential_bams: "Array of sequential Markdup-Recal-Metrics BAM files"
     sequential_bais: "Array of sequential Markdup-Recal-Metrics BAM index files"
-    haplotype_vcfs: "Array of HaplotypeCaller VCF files"
-    mutect2_vcfs: "Array of Mutect2 VCF files"
-    parallel_haplotype_vcfs: "Array of parallel HaplotypeCaller VCF files"
-    parallel_mutect2_vcfs: "Array of parallel Mutect2 VCF files"
+    haplotype_vcfs: "Array of HaplotypeCaller VCF files called via scatter-gather parallelization"
+    mutect2_vcfs: "Array of Mutect2 VCF files called via scatter-gather parallelization"
+    parallel_haplotype_vcfs: "Array of HaplotypeCaller VCF files called via internal parallelization"
+    parallel_mutect2_vcfs: "Array of Mutect2 VCF files called via internal parallelization"
     wgs_metrics: "Array of WGS metrics files"
   }
 


### PR DESCRIPTION
## Description
- Limiting GATK SplitIntervals to canonical chromosomes by default for better reliability.
- Also adding back in the internally parallelized versions of HaplotypeCaller and Mutect2
    - Scatter-gather approach works fine, but still duplicates a ton of data.
- Updating a few variable/file names for consistency while we're at it.

## Related Issue
- Fixes #82
- Fixes #80 (again)

## Testing
- Ran on PROOF, works as expected.
- See GitHub Action test runs below.