### PR TITLE
Fixing ww-sra-star test run and ww-star ref duplication

### DIFF
--- a/modules/ww-star/ww-star.wdl
+++ b/modules/ww-star/ww-star.wdl
@@ -151,7 +151,11 @@ task build_index {
       --sjdbOverhang ~{sjdb_overhang} \
       --genomeSAindexNbases ~{genome_sa_index_nbases}
 
+    # Compress the index directory into a tarball
     tar -czf star_index.tar.gz star_index/*
+
+    # Clean up the index directory to save space
+    rm -rf star_index
   >>>
 
   output {

--- a/vignettes/ww-sra-star/README.md
+++ b/vignettes/ww-sra-star/README.md
@@ -96,8 +96,8 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/dasldemos/proof-h
 | `ref_genome` | Reference genome information | RefGenome | Yes | - |
 | `sjdb_overhang` | STAR splice junction overhang | Int | No | 100 |
 | `genome_sa_index_nbases` | STAR index parameter | Int | No | 14 |
-| `ncpu` | Number of CPU cores | Int | No | 12 |
-| `memory_gb` | Memory allocation in GB | Int | No | 64 |
+| `ncpu` | Number of CPU cores | Int | No | 2 |
+| `memory_gb` | Memory allocation in GB | Int | No | 8 |
 
 ### RefGenome Structure
 
@@ -135,8 +135,8 @@ The vignette includes comprehensive validation that checks:
 ## Resource Considerations
 
 ### Compute Requirements
-- **Memory**: 64GB recommended for human genome alignment
-- **CPUs**: 8+ cores recommended for efficient processing
+- **Memory**: 64GB recommended for human genome alignment (8GB for testing purposes)
+- **CPUs**: 8+ cores recommended for efficient processing (2 cores for testing purposes)
 - **Storage**: Sufficient space for reference genome, FASTQ files, and outputs
 - **Network**: Stable internet connection for SRA downloads
 

--- a/vignettes/ww-sra-star/README.md
+++ b/vignettes/ww-sra-star/README.md
@@ -96,8 +96,8 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/dasldemos/proof-h
 | `ref_genome` | Reference genome information | RefGenome | Yes | - |
 | `sjdb_overhang` | STAR splice junction overhang | Int | No | 100 |
 | `genome_sa_index_nbases` | STAR index parameter | Int | No | 14 |
-| `ncpu` | Number of CPU cores | Int | No | 2 |
-| `memory_gb` | Memory allocation in GB | Int | No | 8 |
+| `ncpu` | Number of CPU cores | Int | No | 12 |
+| `memory_gb` | Memory allocation in GB | Int | No | 64 |
 
 ### RefGenome Structure
 

--- a/vignettes/ww-sra-star/ww-sra-star.wdl
+++ b/vignettes/ww-sra-star/ww-sra-star.wdl
@@ -41,8 +41,8 @@ workflow sra_star {
     RefGenome ref_genome
     Int sjdb_overhang = 100
     Int genome_sa_index_nbases = 14
-    Int ncpu = 12
-    Int memory_gb = 64
+    Int ncpu = 2
+    Int memory_gb = 8
   }
 
   call star_tasks.build_index { input:

--- a/vignettes/ww-sra-star/ww-sra-star.wdl
+++ b/vignettes/ww-sra-star/ww-sra-star.wdl
@@ -14,7 +14,7 @@ workflow sra_star {
     author: "Taylor Firman"
     email: "tfirman@fredhutch.org"
     description: "WDL workflow to download raw sequencing data from SRA and align using STAR two-pass methodology"
-    url: "https://github.com/getwilds/ww-sra-star"
+    url: "https://github.com/getwilds/wilds-wdl-library/vignettes/ww-sra-star"
     outputs: {
         star_bam: "array of aligned bam files for each sample",
         star_bai: "array of corresponding index files for each aligned bam file",
@@ -41,8 +41,8 @@ workflow sra_star {
     RefGenome ref_genome
     Int sjdb_overhang = 100
     Int genome_sa_index_nbases = 14
-    Int ncpu = 2
-    Int memory_gb = 8
+    Int ncpu = 12
+    Int memory_gb = 64
   }
 
   call star_tasks.build_index { input:


### PR DESCRIPTION
## Description
- Recently realized that the previous vignette test run actually failed with ww-sra-star.
- Seemed like a one-off error having to do with Docker pull limit.
- Just retriggering the GH Action by fixing the metadata URL.
- Also added a cleanup step in STAR index task to reduce data duplication.
- Still need to update the vignettes test run GHA to mirror the modules test run, but that'll be a different PR.

## Related Issue
- Fixes #75 

## Testing
- See GitHub Action test runs below.