### PR TITLE
Adding CPU's and memory allocation to Annovar task inputs

### DIFF
--- a/modules/ww-annovar/README.md
+++ b/modules/ww-annovar/README.md
@@ -25,6 +25,8 @@ Annotates variants using Annovar with customizable protocols and operations.
 - `ref_name` (String): Reference genome build name (hg19 or hg38)
 - `annovar_protocols` (String): Comma-separated list of annotation protocols
 - `annovar_operation` (String): Comma-separated list of operations corresponding to protocols
+- `cpu_cores` (Int, optional): Number of CPU cores to allocate (default: 2)
+- `memory_gb` (Int, optional): Memory in GB to allocate (default: 8)
 
 **Outputs**:
 - `annotated_vcf` (File): VCF file with Annovar annotations added

--- a/modules/ww-annovar/ww-annovar.wdl
+++ b/modules/ww-annovar/ww-annovar.wdl
@@ -79,6 +79,8 @@ task annovar_annotate {
     ref_name: "Reference genome build name for Annovar annotation (e.g., 'hg38', 'hg19')"
     annovar_protocols: "Comma-separated list of annotation protocols to apply"
     annovar_operation: "Comma-separated list of operations corresponding to the protocols"
+    cpu_cores: "Number of CPU cores to allocate for the annotation task"
+    memory_gb: "Memory in GB to allocate for the annotation task"
   }
 
   input {
@@ -86,6 +88,8 @@ task annovar_annotate {
     String ref_name
     String annovar_protocols
     String annovar_operation
+    Int cpu_cores = 2
+    Int memory_gb = 8
   }
 
   String base_vcf_name = basename(vcf_to_annotate, ".vcf.gz")
@@ -109,8 +113,8 @@ task annovar_annotate {
 
   runtime {
     docker: "getwilds/annovar:~{ref_name}"
-    cpu: 1
-    memory: "2GB"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
   }
 }
 


### PR DESCRIPTION
## Description
- Adding inputs to the `annovar_annotate` task to specify the number of CPU's and memory allocation for the task.
- 2 CPU's and 8GB should be plenty for 99% of jobs, but already ran into an edge case with super deep WGS samples.

## Related Issue
- Fixes #96

## Testing
- Very minor change, no actual function change, just upping resources.
- See GitHub Actions below.
