### PR TITLE
Upping the runtime resources for Annovar in ww-leukemia

### DIFF
--- a/workflows/ww-leukemia/ww-leukemia.wdl
+++ b/workflows/ww-leukemia/ww-leukemia.wdl
@@ -228,21 +228,27 @@ workflow ww_leukemia {
         vcf_to_annotate = mpileup_call.mpileup_vcf,
         ref_name = ref_name,
         annovar_operation = annovar_operation,
-        annovar_protocols = annovar_protocols
+        annovar_protocols = annovar_protocols,
+        cpu_cores = 4,
+        memory_gb = 16
     }
 
     call annovar_tasks.annovar_annotate as annotateMutect { input:
         vcf_to_annotate = mutect2_parallel.vcf,
         ref_name = ref_name,
         annovar_operation = annovar_operation,
-        annovar_protocols = annovar_protocols
+        annovar_protocols = annovar_protocols,
+        cpu_cores = 4,
+        memory_gb = 16
     }
 
     call annovar_tasks.annovar_annotate as annotateHaplotype { input:
         vcf_to_annotate = haplotype_caller_parallel.vcf,
         ref_name = ref_name,
         annovar_operation = annovar_operation,
-        annovar_protocols = annovar_protocols
+        annovar_protocols = annovar_protocols,
+        cpu_cores = 4,
+        memory_gb = 16
     }
 
     # Keep custom consensus processing task


### PR DESCRIPTION
## Description
- Unfortunately ran into memory issues with real WGS samples (~80GB crams, 5M variants)
- Memory request was minimal previously, just need to up it a bit and should be good to go.

## Related Issue
- Related to #96 

## Testing
- Minor change, shouldn't effect functionality.
- Going to test with full cohort of leukemia WGS samples.