### PR TITLE
controlling verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
-lint_sprocket:
+.DEFAULT_GOAL := help
+
+# default value if not provided
+VERBOSE ?= 0
+
+.PHONY: help
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@awk 'BEGIN {FS = ":.*##"; printf "\033[36m\033[0m"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Linting
+
+lint_sprocket: ## Run sprocket lint on all WDL modules
 	@echo "Running sprocket lint on all modules..."
 	@echo "Checking if sprocket is available..."
 	@if ! command -v sprocket >/dev/null 2>&1; then \
@@ -12,7 +26,7 @@ lint_sprocket:
 		fi; \
 	done
 
-lint_miniwdl:
+lint_miniwdl: ## Run miniwdl lint on all WDL modules (use verbose=1 for detailed output)
 	@echo "Running miniwdl lint on all modules..."
 	@echo "Checking if uv is available..."
 	@if ! command -v uv >/dev/null 2>&1; then \
@@ -22,8 +36,12 @@ lint_miniwdl:
 	@for file in modules/*/*.wdl; do \
 		if [ -f "$$file" ]; then \
 			echo "Linting $$file"; \
-			uv run --python 3.13.5 --with miniwdl miniwdl check "$$file"; \
+			if [ "$(VERBOSE)" = "1" ]; then \
+				uv run --python 3.13.5 --with miniwdl miniwdl check "$$file"; \
+			else \
+ 	      result=`uv run --python 3.13.5 --with miniwdl miniwdl check "$$file"` || echo $result; \
+     	fi; \
 		fi; \
 	done
 
-lint: lint_sprocket lint_miniwdl
+lint: lint_sprocket lint_miniwdl ## Run all linting checks


### PR DESCRIPTION
- **added makefile; added two linting make cmds for sprocket and miniwdl #42**
- **lint target added to run both lints**
- **add links for installation help for sprocket and uv in makefile error message**
- **add sprocket.toml**
- **#115 makefile improvements to control miniwdl verbosity and help output for all commands**
