### PR TITLE
Remove intermediate BAM files from output

### DIFF
--- a/workflows/ww-leukemia/README.md
+++ b/workflows/ww-leukemia/README.md
@@ -135,8 +135,6 @@ The workflow produces comprehensive outputs from each analysis step:
 #### Variant Calling Outputs
 | Output | Description |
 |--------|-------------|
-| `analysis_ready_bam` | Recalibrated BAM files ready for analysis |
-| `analysis_ready_bai` | Index files for recalibrated BAMs |
 | `haplotype_vcf` | GATK HaplotypeCaller variant calls |
 | `mpileup_vcf` | samtools/bcftools variant calls |
 | `mutect_vcf` | GATK Mutect2 variant calls |

--- a/workflows/ww-leukemia/ww-leukemia.wdl
+++ b/workflows/ww-leukemia/ww-leukemia.wdl
@@ -30,7 +30,6 @@
 ## 9. Copy number analysis and tumor fraction estimation using ichorCNA
 ##
 ## Output Files:
-## - Analysis-ready BAM files with base quality recalibration
 ## - Variant calls from three different callers (VCF format)
 ## - Annotated variants with functional and clinical annotations
 ## - Consensus variant calls combining evidence from all callers
@@ -65,8 +64,6 @@ workflow ww_leukemia {
     url: "https://github.com/getwilds/ww-leukemia"
     version: "2.0.0"
     outputs: {
-        analysis_ready_bam: "Array of recalibrated BAM files ready for downstream analysis",
-        analysis_ready_bai: "Array of index files for the recalibrated BAM files",
         haplotype_vcf: "Array of variant calls from GATK HaplotypeCaller",
         mpileup_vcf: "Array of variant calls from samtools/bcftools mpileup",
         mutect_vcf: "Array of variant calls from GATK Mutect2 (tumor-only mode)",
@@ -328,8 +325,6 @@ workflow ww_leukemia {
 
   # Outputs that will be retained when execution is complete
   output {
-    Array[File] analysis_ready_bam = markdup_recal_metrics.recalibrated_bam
-    Array[File] analysis_ready_bai = markdup_recal_metrics.recalibrated_bai
     Array[File] haplotype_vcf = haplotype_caller_parallel.vcf
     Array[File] mpileup_vcf = mpileup_call.mpileup_vcf
     Array[File] mutect_vcf = mutect2_parallel.vcf


### PR DESCRIPTION
## Description
Removed the "analysis ready" intermediate BAM files from the WDL output and the README.

## Related Issue
Closes #119 

## Testing
Untested but this is a minor tweak that shouldn't affect any of the tasks. Could run it on a few samples if desired.
