### PR TITLE
Allowing user to specify a particular module for linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # default value if not provided
 VERBOSE ?= 0
+MODULE ?= *
 
 .PHONY: help
 help: ## Show this help message
@@ -12,28 +13,36 @@ help: ## Show this help message
 
 ##@ Linting
 
-lint_sprocket: ## Run sprocket lint on all WDL modules
-	@echo "Running sprocket lint on all modules..."
+lint_sprocket: ## Run sprocket lint on all modules or a specific module using MODULE=name
 	@echo "Checking if sprocket is available..."
 	@if ! command -v sprocket >/dev/null 2>&1; then \
 		echo >&2 "Error: sprocket is not installed or not in PATH. Install sprocket (https://sprocket.bio/installation.html)"; \
 		exit 1; \
 	fi
-	@for dir in modules/*/; do \
+	@if [ "$(MODULE)" != "*" ] && [ ! -d "modules/$(MODULE)" ]; then \
+		echo >&2 "Error: Module '$(MODULE)' not found in modules/ directory"; \
+		exit 1; \
+	fi
+	@echo "Running sprocket lint..."
+	@for dir in modules/$(MODULE)/; do \
 		if [ -d "$$dir" ]; then \
 			echo "Linting $$dir"; \
 			sprocket lint "$$dir"; \
 		fi; \
 	done
 
-lint_miniwdl: ## Run miniwdl lint on all WDL modules (use VERBOSE=1 for detailed output)
-	@echo "Running miniwdl lint on all modules..."
+lint_miniwdl: ## Run miniwdl lint on all modules or a specific module using MODULE=name (use VERBOSE=1 for detailed output)
 	@echo "Checking if uv is available..."
 	@if ! command -v uv >/dev/null 2>&1; then \
 		echo >&2 "Error: uv is not installed or not in PATH. Install uv (https://docs.astral.sh/uv/getting-started/installation/)"; \
 		exit 1; \
 	fi
-	@for file in modules/*/*.wdl; do \
+	@if [ "$(MODULE)" != "*" ] && [ ! -d "modules/$(MODULE)" ]; then \
+		echo >&2 "Error: Module '$(MODULE)' not found in modules/ directory"; \
+		exit 1; \
+	fi
+	@echo "Running miniwdl lint..."
+	@for file in modules/$(MODULE)/*.wdl; do \
 		if [ -f "$$file" ]; then \
 			echo "Linting $$file"; \
 			if [ "$(VERBOSE)" = "1" ]; then \


### PR DESCRIPTION
## Description
- Adding a `MODULE` input argument to narrow down linting to a specific WILDS WDL module.
- If specified module doesn't exist, the script prints a corresponding error message and bails.

## Related Issue
- Addresses #116

## Testing
- Ran linting with all modules, specific modules, and fake modules.
- Script behaved as expected in all scenarios.