### PR TITLE
Pointing Sprocket Lint Action to Config File

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -81,6 +81,3 @@ jobs:
       uses: stjude-rust-labs/sprocket-action@main
       with:
         action: lint
-        deny-warnings: true
-        deny-notes: false
-        except: TodoComment ContainerUri TrailingComma CommentWhitespace UnusedInput


### PR DESCRIPTION
## Description
- Currently the Sprocket linting GitHub Action uses hard-coded settings during execution.
- Would be much better to refer to the `sprocket.toml` config file to ensure that the local Makefile linting produces the same outputs as the GitHub Action linting.

## Related Issue
- Fixes #122 

## Testing
- Testing with a manually triggered GitHub Action now...