### PR TITLE
make non-verbose miniwdl check actually throw an error code upon failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint_miniwdl: ## Run miniwdl lint on all modules or a specific module using MODU
 			if [ "$(VERBOSE)" = "1" ]; then \
 				uv run --python 3.13 --with miniwdl miniwdl check "$$file"; \
 			else \
-				result=`uv run --python 3.13 --with miniwdl miniwdl check "$$file"` || echo $$result; \
+				uv run --python 3.13 --with miniwdl miniwdl check "$$file" >/dev/null; \
 			fi; \
 		fi; \
 	done


### PR DESCRIPTION
## Description
- Currently the `make lint_miniwdl` command upon failure shows the error message but give a non-error response code (`0`). 
- An error should return an error response code (e.g., `2`) 
- This fixes that by showing the output of the error message and giving a proper error code (test it by introduce an error in a file (e.g., `ww-annotsv/ww-annotsv.wdl`), run `make lint_miniwdl MODULE=ww-annotsv`, then run `echo $?` which gives you the last exit status, which should be `2`)

## Related Issue
#110 

## Example
- introduce an error in a file (e.g., `ww-annotsv/ww-annotsv.wdl`)
- run `make lint_miniwdl MODULE=ww-annotsv`
- then run `echo $?` which gives you the last exit status, which should be `2`