### PR TITLE
use wdlparse rust cli tool to get workflow name insetad of sed/awk

### DIFF
--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -116,7 +116,7 @@ jobs:
       name: Install Sprocket
       run: |
         cargo-binstall sprocket --version 0.15.0 -y
-        cargo install wdlparse
+        cargo install --git https://github.com/getwilds/wdlparse --tag v0.0.5
     -
       name: Run workflow with Sprocket
       run: |

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -114,13 +114,13 @@ jobs:
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     -
       name: Install Sprocket
-      run: cargo-binstall sprocket --version 0.15.0
+      run: cargo-binstall sprocket --version 0.15.0 wdlparse -y
     -
       name: Run workflow with Sprocket
       run: |
         module_dir="modules/${{ matrix.module }}"
         wdl_file="$module_dir/${{ matrix.module }}.wdl"
         # Convert ww-module-name to module_name_example
-        entrypoint=$(echo "${{ matrix.module }}" | sed 's/^ww-//' | sed 's/-/_/g')_example
+        entrypoint=$(wdlparse parse --format json "$wdl_file" | jq -r '.wdl.workflows[].name')
         echo "Running ${{ matrix.module }} with Sprocket using entrypoint: $entrypoint"
         sprocket run "$wdl_file" --entrypoint "$entrypoint"

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -116,7 +116,7 @@ jobs:
       name: Install Sprocket
       run: |
         cargo-binstall sprocket --version 0.15.0 -y
-        cargo-binstall wdlparse --version 0.1.0 -y
+        cargo install wdlparse --version 0.1.0
     -
       name: Run workflow with Sprocket
       run: |

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -114,7 +114,9 @@ jobs:
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     -
       name: Install Sprocket
-      run: cargo-binstall sprocket --version 0.15.0 wdlparse -y
+      run: |
+        cargo-binstall sprocket --version 0.15.0 -y
+        cargo-binstall wdlparse --version 0.1.0 -y
     -
       name: Run workflow with Sprocket
       run: |

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -116,7 +116,7 @@ jobs:
       name: Install Sprocket
       run: |
         cargo-binstall sprocket --version 0.15.0 -y
-        cargo install wdlparse --version 0.1.0
+        cargo install wdlparse
     -
       name: Run workflow with Sprocket
       run: |


### PR DESCRIPTION
fix #133 

- This uses `wdlparse` - a little rust package I created. The current flow with this tool is to install via cargo from the repo itself via releases (e.g., `cargo install --git https://github.com/getwilds/wdlparse --tag v0.0.5`). In that repo I have a github action that builds and puts binaries on the associated releases page for each git tag. If we decide to go this way could publish to crates.io and a bit easier to install. 
- This requires the `jq` tool as well, but I'd imagine most folks that write code would have it
- Installing `wdlparse` requires `cargo` (and therefore rust) - but I think we can figure out precompiled binaries that don't require either - let me know. 

Let me know if you'd prefer to stick with the current setup of sed/awk. The payoff right now may seem not big enough but I imagine it will help to have a specific tool for parsing WDLs as more modules get added, and as you want to pull out other pieces of metadata. 