### PR TITLE
Expanding module test runs to both amd64 and arm64

### DIFF
--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -35,25 +35,15 @@ jobs:
 
   miniwdl-test:
     needs: [discover-modules]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
-        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
     -
       name: Checkout
       uses: actions/checkout@v4
-    -
-      name: Set up Podman (macOS)
-      if: runner.os == 'macOS'
-      run: |
-        brew install podman
-        podman machine init --cpus 2 --memory 4096 --disk-size 20
-        podman machine start
-        # Create docker-compatible symlink
-        sudo ln -sf $(which podman) /usr/local/bin/docker
     -
       name: Set up Python
       uses: actions/setup-python@v5
@@ -74,25 +64,15 @@ jobs:
 
   cromwell-test:
     needs: [discover-modules]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
-        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
     -
       name: Checkout
       uses: actions/checkout@v4
-    -
-      name: Set up Podman (macOS)
-      if: runner.os == 'macOS'
-      run: |
-        brew install podman
-        podman machine init --cpus 2 --memory 4096 --disk-size 20
-        podman machine start
-        # Create docker-compatible symlink
-        sudo ln -sf $(which podman) /usr/local/bin/docker
     -
       name: Set Up Java
       uses: actions/setup-java@v4
@@ -113,25 +93,15 @@ jobs:
 
   sprocket-test:
     needs: [discover-modules]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
-        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
     -
       name: Checkout
       uses: actions/checkout@v4
-    -
-      name: Set up Podman (macOS)
-      if: runner.os == 'macOS'
-      run: |
-        brew install podman
-        podman machine init --cpus 2 --memory 4096 --disk-size 20
-        podman machine start
-        # Create docker-compatible symlink
-        sudo ln -sf $(which podman) /usr/local/bin/docker
     -
       name: Set Up Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -108,10 +108,7 @@ jobs:
       uses: actions/checkout@v4
     -
       name: Set Up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     -
       name: Install cargo-binstall
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -36,10 +36,11 @@ jobs:
 
   miniwdl-test:
     needs: [discover-modules]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
     -
@@ -65,10 +66,11 @@ jobs:
 
   cromwell-test:
     needs: [discover-modules]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
     -
@@ -94,10 +96,11 @@ jobs:
 
   sprocket-test:
     needs: [discover-modules]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         module: ${{ fromJson(needs.discover-modules.outputs.modules) }}
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
     -

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -50,7 +50,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install colima docker
-        colima start
+        colima start --cpu 2 --memory 4 --disk 20 --vm-type=qemu
     -
       name: Set up Python
       uses: actions/setup-python@v5
@@ -86,7 +86,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install colima docker
-        colima start
+        colima start --cpu 2 --memory 4 --disk 20 --vm-type=qemu
     -
       name: Set Up Java
       uses: actions/setup-java@v4
@@ -122,7 +122,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install colima docker
-        colima start
+        colima start --cpu 2 --memory 4 --disk 20 --vm-type=qemu
     -
       name: Set Up Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -46,6 +46,12 @@ jobs:
       name: Checkout
       uses: actions/checkout@v4
     -
+      name: Set up Docker (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install colima docker
+        colima start
+    -
       name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -76,6 +82,12 @@ jobs:
       name: Checkout
       uses: actions/checkout@v4
     -
+      name: Set up Docker (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install colima docker
+        colima start
+    -
       name: Set Up Java
       uses: actions/setup-java@v4
       with:
@@ -105,6 +117,12 @@ jobs:
     -
       name: Checkout
       uses: actions/checkout@v4
+    -
+      name: Set up Docker (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install colima docker
+        colima start
     -
       name: Set Up Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -46,11 +46,14 @@ jobs:
       name: Checkout
       uses: actions/checkout@v4
     -
-      name: Set up Docker (macOS)
+      name: Set up Podman (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install colima docker
-        colima start --cpu 2 --memory 4 --disk 20 --vm-type=qemu
+        brew install podman
+        podman machine init --cpus 2 --memory 4096 --disk-size 20
+        podman machine start
+        # Create docker-compatible symlink
+        sudo ln -sf $(which podman) /usr/local/bin/docker
     -
       name: Set up Python
       uses: actions/setup-python@v5
@@ -82,11 +85,14 @@ jobs:
       name: Checkout
       uses: actions/checkout@v4
     -
-      name: Set up Docker (macOS)
+      name: Set up Podman (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install colima docker
-        colima start --cpu 2 --memory 4 --disk 20 --vm-type=qemu
+        brew install podman
+        podman machine init --cpus 2 --memory 4096 --disk-size 20
+        podman machine start
+        # Create docker-compatible symlink
+        sudo ln -sf $(which podman) /usr/local/bin/docker
     -
       name: Set Up Java
       uses: actions/setup-java@v4
@@ -118,11 +124,14 @@ jobs:
       name: Checkout
       uses: actions/checkout@v4
     -
-      name: Set up Docker (macOS)
+      name: Set up Podman (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install colima docker
-        colima start --cpu 2 --memory 4 --disk 20 --vm-type=qemu
+        brew install podman
+        podman machine init --cpus 2 --memory 4096 --disk-size 20
+        podman machine start
+        # Create docker-compatible symlink
+        sudo ln -sf $(which podman) /usr/local/bin/docker
     -
       name: Set Up Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/modules-testrun.yml
+++ b/.github/workflows/modules-testrun.yml
@@ -13,7 +13,6 @@ on:
     paths:
       - 'modules/**/*.wdl'
       - 'modules/**/*.json'
-      - '.github/workflows/modules-testrun.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
We explored adding macOS (arm64) runners to the module test workflow to ensure WDL compatibility across both Linux and Mac infrastructures. Unfortunately, **running containerized WDL workflows on GitHub Actions macOS runners is not currently feasible** due to virtualization constraints.

### What We Tried

1. **Colima with VZ driver** - Failed: VZ (Virtualization.framework) requires nested virtualization, which isn't available in GitHub Actions VMs
2. **Colima with QEMU driver** - Failed: Requires `qemu-img` which needs additional setup and still has nested virtualization issues
3. **Podman** - Failed: Podman's `vfkit` backend also requires nested virtualization to run its Linux VM

### Why Container Runtimes Fail on macOS in CI

All container runtimes on macOS (Docker Desktop, Colima, Podman) require a Linux virtual machine to run containers, since containers need a Linux kernel. GitHub Actions macOS runners don't support the nested virtualization required to run VMs inside the CI environment.

