### PR TITLE
Reverting import URL's back to main branch

### DIFF
--- a/modules/ww-star/testrun.wdl
+++ b/modules/ww-star/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-star-memory/modules/ww-star/ww-star.wdl" as ww_star
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as ww_star
 
 struct StarSample {
     String name

--- a/vignettes/ww-sra-star/testrun.wdl
+++ b/vignettes/ww-sra-star/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-star-memory/vignettes/ww-sra-star/ww-sra-star.wdl" as sra_star_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/vignettes/ww-sra-star/ww-sra-star.wdl" as sra_star_workflow
 
 workflow sra_star_example {
   # Call testdata workflow to get test data

--- a/vignettes/ww-sra-star/ww-sra-star.wdl
+++ b/vignettes/ww-sra-star/ww-sra-star.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-star-memory/modules/ww-star/ww-star.wdl" as star_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 
 struct RefGenome {
     String name


### PR DESCRIPTION
## Description
No functional change, just reverting module import URL's back to the `main` branch.

## Testing
See GitHub Actions below.