### PR TITLE
Fixing import URL's from ww-gdc PR

### DIFF
--- a/modules/ww-gdc/testrun.wdl
+++ b/modules/ww-gdc/testrun.wdl
@@ -1,9 +1,7 @@
 version 1.0
 
-# import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-ww-gdc/modules/ww-gdc/ww-gdc.wdl" as ww_gdc
-# import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-ww-gdc/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "ww-gdc.wdl" as ww_gdc
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gdc/ww-gdc.wdl" as ww_gdc
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow gdc_client_example {
   meta {

--- a/modules/ww-testdata/testrun.wdl
+++ b/modules/ww-testdata/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-ww-gdc/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow testdata_example {
   # Pull down reference genome and index files for chr1


### PR DESCRIPTION
## Description
- No functional change, just switching import URL's back to `main` after #171 

## Testing
- See GitHub Actions below