### PR TITLE
Switching import URL's back to main

### DIFF
--- a/modules/ww-samtools/testrun.wdl
+++ b/modules/ww-samtools/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-varscan/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
 
 workflow samtools_example {
   # Download test data


### PR DESCRIPTION
## Description
- No functionality change, just switching import URL's back to the `main` branch.

## Testing
- See GitHub Actions below.