### PR TITLE
Returning import URL branches back to main

### DIFF
--- a/modules/ww-ena/testrun.wdl
+++ b/modules/ww-ena/testrun.wdl
@@ -1,7 +1,6 @@
 version 1.0
 
-# import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-ww-ena/modules/ww-ena/ww-ena.wdl" as ww_ena
-import "ww-ena.wdl" as ww_ena
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-ena/ww-ena.wdl" as ww_ena
 
 workflow ena_example {
   meta {

--- a/modules/ww-smoove/testrun.wdl
+++ b/modules/ww-smoove/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/fix-smoove-image/modules/ww-smoove/ww-smoove.wdl" as ww_smoove
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-smoove/ww-smoove.wdl" as ww_smoove
 
 struct SmooveSample {
     String name

--- a/modules/ww-spades/testrun.wdl
+++ b/modules/ww-spades/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-spades/modules/ww-spades/ww-spades.wdl" as ww_spades
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-spades/ww-spades.wdl" as ww_spades
 
 workflow spades_example {
   # Download test data from SRA

--- a/vignettes/ww-ena-star/testrun.wdl
+++ b/vignettes/ww-ena-star/testrun.wdl
@@ -1,9 +1,7 @@
 version 1.0
 
-# import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-ww-ena/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-# import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-ww-ena/vignettes/ww-ena-star/ww-ena-star.wdl" as ena_star_workflow
-import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "ww-ena-star.wdl" as ena_star_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/vignettes/ww-ena-star/ww-ena-star.wdl" as ena_star_workflow
 
 workflow ena_star_example {
   # Call testdata workflow to get test data

--- a/vignettes/ww-ena-star/ww-ena-star.wdl
+++ b/vignettes/ww-ena-star/ww-ena-star.wdl
@@ -1,9 +1,7 @@
 version 1.0
 
-# import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-ww-ena/modules/ww-ena/ww-ena.wdl" as ena_tasks
-# import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-ww-ena/modules/ww-star/ww-star.wdl" as star_tasks
-import "../../modules/ww-ena/ww-ena.wdl" as ena_tasks
-import "../../modules/ww-star/ww-star.wdl" as star_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-ena/ww-ena.wdl" as ena_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 
 struct RefGenome {
     String name


### PR DESCRIPTION
## Description
- No functional change, just returning import URL's back to `main` for `ww-ena`, `ww-spades`, `ww-smoove`, and `ww-ena-star`.

## Testing
- See GitHub Action test runs below.