### PR TITLE
Removing TODO comments

### DIFF
--- a/modules/ww-bedtools/testrun.wdl
+++ b/modules/ww-bedtools/testrun.wdl
@@ -66,7 +66,6 @@ workflow bedtools_example {
 }
 
 task validate_outputs {
-  # TODO: Do a basic check of the file contents too
   meta {
     description: "Validate that BEDTools output files exist and are non-empty"
     outputs: {

--- a/modules/ww-gatk/testrun.wdl
+++ b/modules/ww-gatk/testrun.wdl
@@ -312,8 +312,6 @@ workflow gatk_example {
 }
 
 task validate_outputs {
-  # TODO: Add validation for GATK dictionary, intervals, and duplicate metrics files
-  # TODO: Ensure that the recalibrated BAM files match between the separate and all-in-one tasks
   meta {
     description: "Validate GATK outputs and generate comprehensive statistics report"
     outputs: {

--- a/modules/ww-ichorcna/testrun.wdl
+++ b/modules/ww-ichorcna/testrun.wdl
@@ -75,7 +75,6 @@ workflow ichorcna_example {
 }
 
 task validate_outputs {
-  # TODO: Do a basic check of the file contents too
   meta {
     description: "Validate that ichorCNA outputs are non-empty and generate report"
     outputs: {

--- a/modules/ww-ichorcna/ww-ichorcna.wdl
+++ b/modules/ww-ichorcna/ww-ichorcna.wdl
@@ -72,7 +72,6 @@ task ichorcna_call {
   }
 
   parameter_meta {
-    # TODO: Take a user-generated WIG file as input, instead of making one from BED files
     wig_tumor: "Tumor WIG file being analyzed"
     wig_gc: "GC-content WIG file"
     wig_map: "Mappability score WIG file"

--- a/modules/ww-sra/ww-sra.wdl
+++ b/modules/ww-sra/ww-sra.wdl
@@ -1,7 +1,6 @@
-## Pulls down paired fastq's for SRA ID's provided
-## TODO: add metadata pull using efetch
-## TODO: add checksum for validation purposes
-## TODO: add logging for better visibility
+## WILDS WDL module for downloading FASTQ data from NCBI's Sequence Read Archive (SRA).
+## Designed to be a modular component within the WILDS ecosystem that can be used
+## independently or integrated with other WILDS workflows.
 
 version 1.0
 


### PR DESCRIPTION
## Description
- Removed TODO comments from WDL modules and converted them to tracked GitHub issues
- Updated `ww-sra` module header to follow the standard WILDS module format

## Related Issues
- TODO's converted to #205, #206, #207

## Testing
- No functional change, just adjusting comments
- See GitHub Action test runs below