### PR TITLE
Switching import URL's back to `main`

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -193,4 +193,3 @@ workflows:
         - differential-expression
         - star
         - deseq2
-

--- a/modules/ww-glimpse2/testrun.wdl
+++ b/modules/ww-glimpse2/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/glimpse2-phase-together/modules/ww-glimpse2/ww-glimpse2.wdl" as ww_glimpse2
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-glimpse2/ww-glimpse2.wdl" as ww_glimpse2
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow glimpse2_example {

--- a/pipelines/ww-imputation/testrun.wdl
+++ b/pipelines/ww-imputation/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/glimpse2-phase-together/pipelines/ww-imputation/ww-imputation.wdl" as ww_imputation
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-imputation/ww-imputation.wdl" as ww_imputation
 
 #### TEST WORKFLOW DEFINITION ####
 # This workflow demonstrates the ww-imputation pipeline with automatic test data download.

--- a/pipelines/ww-imputation/ww-imputation.wdl
+++ b/pipelines/ww-imputation/ww-imputation.wdl
@@ -7,7 +7,7 @@
 
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/glimpse2-phase-together/modules/ww-glimpse2/ww-glimpse2.wdl" as glimpse2
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-glimpse2/ww-glimpse2.wdl" as glimpse2
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bcftools/ww-bcftools.wdl" as bcftools
 
 struct ChromosomeData {


### PR DESCRIPTION
## Type of Change

- Other: URL's back to `main`

## Description

- Switching import URL's back to the `main` branch after merge of `ww-glimpse2` and `ww-imputation` updates.

## Testing

- No functional changes, just import URL updates, but see GitHub Actions below just in case.