### PR TITLE
Adding initial version of CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,3 +37,7 @@ authors:
   - family-names: Lo
     given-names: Chris
     affiliation: "Fred Hutch Cancer Center"
+  - family-names: Nondin
+    given-names: Caroline
+    affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0009-0009-0955-5954"


### PR DESCRIPTION
## Type of Change

- Documentation update
- Other: Citation infrastructure for Zenodo DOI integration

## Description

Adds a `CITATION.cff` file to the repository, enabling:
- GitHub's built-in "Cite this repository" button (generates APA and BibTeX formats)
- Zenodo DOI integration for persistent, versioned citations
- A standard way for researchers to cite the WILDS WDL Library in papers and presentations

The file includes project metadata, author list, keywords, and links to both the GitHub repo and the [documentation site](https://getwilds.org/wilds-wdl-library/).

## Testing

**How did you test these changes?**
Validated CITATION.cff against the CFF schema (v1.2.0) using `cffconvert --validate` and previewed APA/BibTeX output.

**What workflow engine did you use?**
N/A — no WDL changes in this PR.

**Did the tests pass?**
Yes, `cffconvert` confirmed: "Citation metadata are valid according to schema version 1.2.0."

## Additional Context

- Next step after merging: set up Zenodo GitHub integration and mint concept DOI for v0.1.0, then add the DOI back to this file.
- The `version` and `date-released` fields currently reflect v0.1.0; these will be updated alongside future releases.
