### PR TITLE
Switching solar jetlag import URL's back to main repository

### DIFF
--- a/modules/ww-sjl/testrun.wdl
+++ b/modules/ww-sjl/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/caronondin22/wilds-wdl-library/refs/heads/main/modules/ww-sjl/ww-sjl.wdl" as ww_sjl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sjl/ww-sjl.wdl" as ww_sjl
 
 workflow sjl_example {
   # Generate synthetic test tile and border points data

--- a/modules/ww-sjl/ww-sjl.wdl
+++ b/modules/ww-sjl/ww-sjl.wdl
@@ -47,7 +47,7 @@ task sjl_tiles {
     # Pull sjl_tiles script from GitHub
     # NOTE: For reproducibility in production workflows, replace the branch reference
     # (e.g., "refs/heads/main") with a specific commit hash (e.g., "abc1234...")
-    wget -q "https://raw.githubusercontent.com/caronondin22/wilds-wdl-library/refs/heads/main/modules/ww-sjl/sjl_tiles.R" \
+    wget -q "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sjl/sjl_tiles.R" \
       -O sjl_tiles.R
 
     Rscript sjl_tiles.R \

--- a/pipelines/ww-jetlag/testrun.wdl
+++ b/pipelines/ww-jetlag/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/caronondin22/wilds-wdl-library/refs/heads/main/pipelines/ww-jetlag/ww-jetlag.wdl" as ww_jetlag
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-jetlag/ww-jetlag.wdl" as ww_jetlag
 
 workflow jetlag_example {
   # Generate synthetic test tile and border points data

--- a/pipelines/ww-jetlag/ww-jetlag.wdl
+++ b/pipelines/ww-jetlag/ww-jetlag.wdl
@@ -4,7 +4,7 @@
 
 version 1.0
 
-import "https://raw.githubusercontent.com/caronondin22/wilds-wdl-library/refs/heads/main/modules/ww-sjl/ww-sjl.wdl" as ww_sjl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sjl/ww-sjl.wdl" as ww_sjl
 
 workflow jetlag {
   meta {


### PR DESCRIPTION
## Type of Change

- Bug fix

## Description

Switches import URLs in the `ww-sjl` module and `ww-jetlag` pipeline from the `caronondin22` fork back to the canonical `getwilds` repository. This ensures all WDL imports point to the main organization repo rather than a contributor's fork.

## Testing

No functional change, just switching import URL's back to WWL, but see GitHub Actions below just in case.

## Additional Context

Four files updated with identical find-and-replace (`caronondin22` → `getwilds`):
- `modules/ww-sjl/testrun.wdl` — import URL
- `modules/ww-sjl/ww-sjl.wdl` — `wget` URL for `sjl_tiles.R`
- `pipelines/ww-jetlag/testrun.wdl` — import URL
- `pipelines/ww-jetlag/ww-jetlag.wdl` — import URL