### PR TITLE
Adding ww-splicing-proteomics and author details to Dockstore

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -14,6 +14,9 @@ workflows:
     authors:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0000-0003-4484-3336
     description: "WDL workflow to align sequencing data using BWA and perform QC steps with GATK"
     topic: variant-calling
     filters:
@@ -35,6 +38,9 @@ workflows:
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
     description: "WDL workflow to download raw sequencing data from ENA and align using STAR two-pass methodology"
     topic: rna-seq
     filters:
@@ -56,8 +62,14 @@ workflows:
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0000-0003-4484-3336
     description: "Convert paired FASTQ files to unmapped CRAM format using WILDS WDL modules"
     topic: alignment
     filters:
@@ -79,10 +91,19 @@ workflows:
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0000-0003-4484-3336
       - name: Louisa Goss
         email: lgoss2@fredhutch.org
+        role: Research Associate
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0005-2936-2405
     description: "WDL workflow for genotype imputation from low-coverage WGS data using GLIMPSE2. Processes CRAM/BAM files against a reference panel to produce imputed VCF files."
     topic: imputation
     filters:
@@ -104,10 +125,19 @@ workflows:
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0000-0003-4484-3336
       - name: Caroline Nondin
         email: cnondin@fredhutch.org
+        role: Research Assistant
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0009-0955-5954
     description: "WDL pipeline to calculate sunrise/sunset times and sun time differences across an array of geographic tiles as part of the SJL model pipeline"
     topic: geospatial
     filters:
@@ -128,10 +158,19 @@ workflows:
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0000-0003-4484-3336
       - name: Sitapriya Moorthi
         email: smoorthi@fredhutch.org
+        role: Staff Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0000-0001-6372-5170
     description: "Consensus variant calling workflow for human panel/PCR-based targeted DNA sequencing with focus on leukemia analysis - Refactored with WILDS modules"
     topic: variant-calling
     filters:
@@ -153,10 +192,18 @@ workflows:
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
       - name: Sitapriya Moorthi
         email: smoorthi@fredhutch.org
+        role: Staff Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0000-0001-6372-5170
       - name: Siobhan O'Brien
         email: sobrien2@fredhutch.org
+        role: Post-Doctoral Research Fellow
+        affiliation: Fred Hutch Cancer Center
     description: "WDL workflow to analyze saturation mutagenesis data using BWA alignment and GATK AnalyzeSaturationMutagenesis"
     topic: saturation-mutagenesis
     filters:
@@ -178,8 +225,14 @@ workflows:
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0000-0003-4484-3336
     description: "WDL workflow to download raw sequencing data from SRA and quantify using Salmon quasi-mapping"
     topic: rna-seq
     filters:
@@ -201,6 +254,9 @@ workflows:
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
     description: "WDL workflow to download raw sequencing data from SRA and align using STAR two-pass methodology"
     topic: rna-seq
     filters:
@@ -222,10 +278,18 @@ workflows:
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0000-0003-4484-3336
       - name: Ethan Bouvet
         email: ebouvet@fredhutch.org
+        role: Research Technician
+        affiliation: Fred Hutch Cancer Center
     description: "WDL workflow for RNA-seq alignment via STAR and DESeq2 differential expression analysis"
     topic: differential-expression
     filters:
@@ -237,3 +301,28 @@ workflows:
         - differential-expression
         - star
         - deseq2
+
+  - name: ww-splicing-proteomics
+    subclass: WDL
+    primaryDescriptorPath: /pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl
+    readMePath: /pipelines/ww-splicing-proteomics/README.md
+    testParameterFiles:
+      - /pipelines/ww-splicing-proteomics/inputs.json
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: https://orcid.org/0009-0002-2052-1084
+    description: "WDL pipeline for alternative splicing proteomics: STAR alignment, rMATS differential splicing detection, and JCAST protein sequence translation"
+    topic: proteogenomics
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - proteogenomics
+        - alternative-splicing
+        - rmats
+        - jcast
+        - star


### PR DESCRIPTION
## Type of Change

- Documentation update

## Description

Updates `.dockstore.yml` with two changes:

1. **Added `ww-splicing-proteomics` pipeline** — the only pipeline not yet registered for Dockstore upload. This pipeline combines STAR alignment, rMATS differential splicing detection, and JCAST protein sequence translation for alternative splicing proteomics analysis.

2. **Enriched author metadata** across all pipeline entries with `role`, `affiliation`, and `orcid` (where available) fields. Previously, author entries only included `name` and `email`.

## Testing

**How did you test these changes?**
No functional testing required — changes are limited to `.dockstore.yml` metadata.

**What workflow engine did you use?**
N/A

**Did the tests pass?**
N/A

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [ ] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~

## Additional Context

Author details added per entry:
| Author | Role | ORCID |
|--------|------|-------|
| Taylor Firman | Research Informatics Data Scientist | Yes |
| Emma Bishop | Research Informatics Data Scientist | Yes |
| Caroline Nondin | Research Assistant | Yes |
| Sitapriya Moorthi | Staff Scientist | Yes |
| Louisa Goss | Research Associate | Yes |
| Siobhan O'Brien | Post-Doctoral Research Fellow | No |
| Ethan Bouvet | Research Technician | No |

All authors affiliated with Fred Hutch Cancer Center. ORCIDs sourced from `CITATION.cff` and author-provided values.
