### PR TITLE
Switching import URL back to main for ww-splicing-proteomics test run

### DIFF
--- a/pipelines/ww-splicing-proteomics/testrun.wdl
+++ b/pipelines/ww-splicing-proteomics/testrun.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/cirro-splicing/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl" as splicing_proteomics_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl" as splicing_proteomics_workflow
 
 struct SampleInfo {
     String name


### PR DESCRIPTION
## Type of Change

- Bug fix

## Description

Switching `ww-splicing-proteomics` testrun.wdl import URL back to main branch. No functional change.

## Testing

No functional change, but see GitHub Actions below just in case.