### PR TITLE
Enabling Cirro validation for a specific resource in Makefile

### DIFF
--- a/.github/scripts/validate_cirro.py
+++ b/.github/scripts/validate_cirro.py
@@ -124,10 +124,45 @@ def validate_cirro_dir(cirro_dir):
 
 
 def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Validate .cirro configurations in WILDS pipelines.")
+    parser.add_argument("name", nargs="?", default=None,
+                        help="Specific pipeline name to validate (e.g., ww-star-salmon). "
+                             "If omitted, validates all pipelines.")
+    args = parser.parse_args()
+
     pipelines_dir = Path("pipelines")
     if not pipelines_dir.exists():
         print("No pipelines directory found")
         return 0
+
+    # If a specific name is given, only validate that pipeline
+    if args.name:
+        pipeline_dir = pipelines_dir / args.name
+        if not pipeline_dir.is_dir():
+            # Could be a module — modules don't have .cirro dirs, so skip silently
+            print(f"Skipping {args.name} (not a pipeline or no pipeline directory found)")
+            return 0
+
+        cirro_dir = pipeline_dir / ".cirro"
+        if not cirro_dir.is_dir():
+            print(f"Skipping {args.name} (no .cirro directory)")
+            return 0
+
+        print(f"Validating {args.name}/.cirro/ ...")
+        errors = validate_cirro_dir(cirro_dir)
+        if errors:
+            print(f"  FAIL ({len(errors)} issue(s))")
+            print(f"\n{'='*50}")
+            print(f"Cirro validation failed for {args.name}:\n")
+            for error in errors:
+                print(error)
+            return 1
+        else:
+            print(f"  OK")
+            print(f"\nAll Cirro configurations valid!")
+            return 0
 
     found_any = False
     all_errors = {}

--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,13 @@ lint_womtool: check_java check_womtool check_name ## Run WOMtool validate on mod
 	done
 
 
-lint_cirro: ## Validate .cirro configurations in pipelines
+lint_cirro: check_name ## Validate .cirro configurations in pipelines (use NAME=foo for specific item)
 	@echo "Validating Cirro configurations..."
-	@python3 .github/scripts/validate_cirro.py
+	@if [ "$(NAME)" != "*" ]; then \
+		python3 .github/scripts/validate_cirro.py $(NAME); \
+	else \
+		python3 .github/scripts/validate_cirro.py; \
+	fi
 
 lint: lint_sprocket lint_miniwdl lint_womtool lint_cirro ## Run all linting checks
 


### PR DESCRIPTION
## Type of Change

- Bug fix

## Description

Updated `make lint_cirro` (and the underlying `validate_cirro.py` script) to respect the `NAME` parameter, consistent with all other lint targets. Previously, running `make lint NAME=ww-toolname` would validate `.cirro` configurations for **all** pipelines regardless of the `NAME` specified. Now:

- `make lint_cirro NAME=ww-pipeline-name` validates only that pipeline's `.cirro` directory
- `make lint_cirro NAME=ww-module-name` skips gracefully since modules don't have `.cirro` dirs
- `make lint_cirro` (no NAME) continues to validate all pipelines as before

## Testing

**How did you test these changes?**
Ran `make lint_cirro NAME=ww-sra-salmon` to confirm it validates only the specified pipeline, and `make lint_cirro NAME=ww-star` to confirm modules are skipped gracefully.

**What workflow engine did you use?**
N/A — linting/validation change only, no WDL execution involved.

**Did the tests pass?**
Yes

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~

## Additional Context

The `lint_cirro` Makefile target now also depends on `check_name` for input validation, matching the pattern used by `lint_sprocket`, `lint_miniwdl`, and `lint_womtool`.