### PR TITLE
Fixing GLIMPSE2 INFO Score

### DIFF
--- a/modules/ww-glimpse2/README.md
+++ b/modules/ww-glimpse2/README.md
@@ -55,7 +55,7 @@ Convert reference panel VCF to binary format for a specific chunk.
 - `input_region` (String): Input region from chunks file
 - `output_region` (String): Output region from chunks file
 - `output_prefix` (String): Prefix for output files
-- `keep_monomorphic_ref_sites` (Boolean, default=false): Keep monomorphic sites
+- `keep_monomorphic_ref_sites` (Boolean, default=true): Keep monomorphic reference sites in output
 - `cpu_cores` (Int, default=4): Number of CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
 
@@ -84,11 +84,12 @@ Perform imputation and phasing from VCF input.
 
 ### `glimpse2_phase_cram`
 
-Perform imputation directly from CRAM/BAM files. Accepts one or more BAM/CRAM files via an array input, which are passed to GLIMPSE2_phase using `--bam-list`.
+Perform imputation directly from CRAM/BAM files. Accepts one or more BAM/CRAM files via an array input, which are passed to GLIMPSE2_phase using `--bam-list`. Sample IDs are explicitly included in the BAM list alongside index paths (matching the Broad Institute's implementation) to ensure correct sample identification by GLIMPSE2.
 
 **Inputs:**
 - `input_bams` (Array[File]): Array of input CRAM or BAM files
 - `input_bam_indices` (Array[File]): Array of index files for input CRAM/BAM files
+- `sample_ids` (Array[String]): Array of sample IDs corresponding to each CRAM/BAM file
 - `reference_fasta` (File): Reference genome FASTA file
 - `reference_fasta_index` (File): Reference genome FASTA index
 - `reference_chunk` (File): Binary reference chunk

--- a/modules/ww-glimpse2/README.md
+++ b/modules/ww-glimpse2/README.md
@@ -287,6 +287,10 @@ Genetic maps can be downloaded from:
 
 ## Implementation Notes
 
+### Docker Image: `getwilds/glimpse2:2.0.1-infofix`
+
+This module uses a custom Docker image built from GLIMPSE2's `master` branch (commit `5fda8c09`) rather than the official v2.0.1 release tag. This is necessary because GLIMPSE2 v2.0.0/v2.0.1 contains a [bug in the INFO score calculation](https://github.com/odelaneau/GLIMPSE/issues/144) where the denominator incorrectly uses total haplotypes (target + reference) instead of target haplotypes only, inflating INFO scores toward 1.0. The fix ([PR #175](https://github.com/odelaneau/GLIMPSE/pull/175)) has been merged to `master` but has not yet been included in a tagged release. Note that even with this fix, INFO scores are only meaningful with a large number of target samples (see [GLIMPSE issue #69](https://github.com/odelaneau/GLIMPSE/issues/69)); for small cohorts, use `glimpse2_concordance` against truth genotypes instead.
+
 ### File and Index Co-location
 
 GLIMPSE2 (like many bioinformatics tools built on htslib) expects index files to be located in the same directory as their corresponding data files. For example, when given `sample.cram`, it looks for `sample.cram.crai` in the same directory.

--- a/modules/ww-glimpse2/README.md
+++ b/modules/ww-glimpse2/README.md
@@ -239,9 +239,9 @@ The test workflow automatically:
 1. Downloads a reference genome region (chr1:1-10000000) from UCSC
 2. Downloads genetic map files from the GLIMPSE repository
 3. Downloads and prepares a 1000 Genomes reference panel subset
-4. Downloads a VCF with genotype likelihoods (NA12878 from 1000 Genomes Phase 3)
-5. Runs the complete GLIMPSE2 imputation pipeline
-6. Outputs the final imputed VCF
+4. Downloads a NA12878 CRAM file and a VCF with genotype likelihoods (NA12878 from 1000 Genomes Phase 3)
+5. Runs the complete GLIMPSE2 imputation pipeline via both `glimpse2_phase` (VCF input) and `glimpse2_phase_cram` (CRAM input)
+6. Outputs the final imputed VCF and per-chunk CRAM-based imputed chunks
 
 ### Running the Test Workflow
 

--- a/modules/ww-glimpse2/README.md
+++ b/modules/ww-glimpse2/README.md
@@ -113,7 +113,7 @@ Ligate multiple imputed chunks into a single file.
 - `imputed_chunks` (Array[File]): Array of imputed chunk BCF files
 - `imputed_chunks_indices` (Array[File]): Array of index files
 - `output_prefix` (String): Prefix for output files
-- `output_format` (String, default="bcf"): Output format (bcf, vcf, or vcf.gz)
+- `output_format` (String, default="bcf"): Output format (`bcf` or `vcf.gz`)
 - `cpu_cores` (Int, default=4): Number of CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
 

--- a/modules/ww-glimpse2/testrun.wdl
+++ b/modules/ww-glimpse2/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-glimpse2/ww-glimpse2.wdl" as ww_glimpse2
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/fix-glimpse2-info-score/modules/ww-glimpse2/ww-glimpse2.wdl" as ww_glimpse2
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow glimpse2_example {

--- a/modules/ww-glimpse2/testrun.wdl
+++ b/modules/ww-glimpse2/testrun.wdl
@@ -33,7 +33,13 @@ workflow glimpse2_example {
       exclude_samples = "NA12878"
   }
 
-  # Step 4: Download test VCF with genotype likelihoods (NA12878 from 1000 Genomes low-coverage)
+  # Step 4a: Download test CRAM file (NA12878) for glimpse2_phase_cram test
+  call ww_testdata.download_cram_data as download_cram {
+    input:
+      ref_fasta = download_reference.fasta
+  }
+
+  # Step 4b: Download test VCF with genotype likelihoods (NA12878 from 1000 Genomes low-coverage)
   call ww_testdata.download_glimpse2_test_gl_vcf as download_gl_vcf {
     input:
       chromosome = test_chromosome,
@@ -41,7 +47,7 @@ workflow glimpse2_example {
       sample_name = "NA12878"
   }
 
-  # Step 4b: Download truth VCF for concordance evaluation (NA12878 high-coverage genotypes)
+  # Step 4c: Download truth VCF for concordance evaluation (NA12878 high-coverage genotypes)
   call ww_testdata.download_glimpse2_truth_vcf as download_truth_vcf {
     input:
       chromosome = test_chromosome,
@@ -86,6 +92,17 @@ workflow glimpse2_example {
         reference_chunk = glimpse2_split_reference.reference_chunk,
         output_prefix = "~{output_prefix}_imputed_~{idx}"
     }
+
+    call ww_glimpse2.glimpse2_phase_cram {
+      input:
+        input_bams = [download_cram.cram],
+        input_bam_indices = [download_cram.crai],
+        sample_ids = ["NA12878"],
+        reference_fasta = download_reference.fasta,
+        reference_fasta_index = download_reference.fasta_index,
+        reference_chunk = glimpse2_split_reference.reference_chunk,
+        output_prefix = "~{output_prefix}_cram_imputed_~{idx}"
+    }
   }
 
   # Step 8: Ligate all imputed chunks
@@ -118,6 +135,7 @@ workflow glimpse2_example {
     File chunks_file = glimpse2_chunk.chunks_file
     Array[File] reference_chunks = glimpse2_split_reference.reference_chunk
     Array[File] imputed_chunks = glimpse2_phase.imputed_chunk
+    Array[File] cram_imputed_chunks = glimpse2_phase_cram.imputed_chunk
 
     # Final imputed output
     File final_imputed_vcf = glimpse2_ligate.ligated_vcf

--- a/modules/ww-glimpse2/ww-glimpse2.wdl
+++ b/modules/ww-glimpse2/ww-glimpse2.wdl
@@ -49,7 +49,6 @@ task glimpse2_chunk {
     ln -s "~{reference_vcf}" "~{basename(reference_vcf)}"
     ln -s "~{reference_vcf_index}" "~{basename(reference_vcf_index)}"
 
-    # Use --recursive algorithm which may be more stable for small regions
     GLIMPSE2_chunk \
       --input "~{basename(reference_vcf)}" \
       --region "~{region}" \
@@ -57,7 +56,7 @@ task glimpse2_chunk {
       --window-cm ~{window_size_cm} \
       --buffer-cm ~{buffer_size_cm} \
       ~{if uniform_number_variants then "--uniform-number-variants" else ""} \
-      --recursive \
+      --sequential \
       --output "~{output_prefix}.chunks.txt" \
       --threads ~{cpu_cores}
   >>>
@@ -224,6 +223,7 @@ task glimpse2_phase_cram {
   parameter_meta {
     input_bams: "Array of input CRAM or BAM files"
     input_bam_indices: "Array of index files for input CRAM/BAM files"
+    sample_ids: "Array of sample IDs corresponding to each CRAM/BAM file"
     reference_fasta: "Reference genome FASTA file"
     reference_fasta_index: "Reference genome FASTA index file"
     reference_chunk: "Binary reference chunk from glimpse2_split_reference"
@@ -239,6 +239,7 @@ task glimpse2_phase_cram {
   input {
     Array[File] input_bams
     Array[File] input_bam_indices
+    Array[String] sample_ids
     File reference_fasta
     File reference_fasta_index
     File reference_chunk
@@ -257,11 +258,12 @@ task glimpse2_phase_cram {
     # Create local symlinks to ensure CRAM/BAM files and indices are co-located
     bams_array=(~{sep=' ' input_bams})
     indices_array=(~{sep=' ' input_bam_indices})
+    sample_ids_array=(~{sep=' ' sample_ids})
 
     for i in "${!bams_array[@]}"; do
       ln -s "${bams_array[$i]}" "$(basename "${bams_array[$i]}")"
       ln -s "${indices_array[$i]}" "$(basename "${indices_array[$i]}")"
-      echo "$(basename "${bams_array[$i]}")" >> bam_list.txt
+      echo "$(basename "${bams_array[$i]}")##idx##$(basename "${indices_array[$i]}") ${sample_ids_array[$i]}" >> bam_list.txt
     done
 
     # Create local symlinks for reference FASTA and index

--- a/modules/ww-glimpse2/ww-glimpse2.wdl
+++ b/modules/ww-glimpse2/ww-glimpse2.wdl
@@ -313,7 +313,7 @@ task glimpse2_ligate {
     imputed_chunks: "Array of imputed chunk BCF files from glimpse2_phase"
     imputed_chunks_indices: "Array of index files for imputed chunks"
     output_prefix: "Prefix for output files"
-    output_format: "Output format: bcf, vcf, or vcf.gz (default: bcf)"
+    output_format: "Output format: bcf or vcf.gz (default: bcf)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
   }

--- a/modules/ww-glimpse2/ww-glimpse2.wdl
+++ b/modules/ww-glimpse2/ww-glimpse2.wdl
@@ -66,7 +66,7 @@ task glimpse2_chunk {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1"
+    docker: "getwilds/glimpse2:2.0.1-infofix"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -131,7 +131,7 @@ task glimpse2_split_reference {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1"
+    docker: "getwilds/glimpse2:2.0.1-infofix"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -202,7 +202,7 @@ task glimpse2_phase {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1"
+    docker: "getwilds/glimpse2:2.0.1-infofix"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -291,7 +291,7 @@ task glimpse2_phase_cram {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1"
+    docker: "getwilds/glimpse2:2.0.1-infofix"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -366,7 +366,7 @@ task glimpse2_ligate {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1"
+    docker: "getwilds/glimpse2:2.0.1-infofix"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -436,7 +436,7 @@ task glimpse2_concordance {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1"
+    docker: "getwilds/glimpse2:2.0.1-infofix"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -481,7 +481,7 @@ task parse_chunks_file {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1"
+    docker: "getwilds/glimpse2:2.0.1-infofix"
     cpu: 1
     memory: "2 GB"
   }

--- a/modules/ww-glimpse2/ww-glimpse2.wdl
+++ b/modules/ww-glimpse2/ww-glimpse2.wdl
@@ -103,7 +103,7 @@ task glimpse2_split_reference {
     String input_region
     String output_region
     String output_prefix
-    Boolean keep_monomorphic_ref_sites = false
+    Boolean keep_monomorphic_ref_sites = true
     Int cpu_cores = 4
     Int memory_gb = 8
   }

--- a/pipelines/ww-imputation/.cirro/preprocess.py
+++ b/pipelines/ww-imputation/.cirro/preprocess.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import json
 from cirro.helpers.preprocess_dataset import PreprocessDataset
-import pandas as pd
 
 
 def main():
@@ -35,6 +34,7 @@ def setup_inputs(ds: PreprocessDataset):
         "imputation.chromosomes": format_chromosomes(ds),
         "imputation.input_crams": [v.strip() for v in ds.params["input_crams"].split(",")],
         "imputation.input_cram_indices": [v.strip() for v in ds.params["input_cram_indices"].split(",")],
+        "imputation.sample_ids": [v.strip() for v in ds.params["sample_ids"].split(",")],
         "imputation.reference_fasta": ds.params["reference_fasta"],
         "imputation.reference_fasta_index": ds.params["reference_fasta_index"],
         "imputation.output_prefix": ds.params["output_prefix"],

--- a/pipelines/ww-imputation/.cirro/process-form.json
+++ b/pipelines/ww-imputation/.cirro/process-form.json
@@ -18,6 +18,11 @@
         "pathType": "dataset",
         "file": "**/*.{crai,bai}"
       },
+      "sample_ids": {
+        "title": "Sample IDs",
+        "description": "Sample IDs for each input CRAM/BAM file (comma-separated, must match order of CRAM files)",
+        "type": "string"
+      },
       "reference_fasta": {
         "title": "Reference Genome (FASTA)",
         "description": "Reference genome FASTA file (must match CRAM reference)",
@@ -99,6 +104,7 @@
     "required": [
       "input_crams",
       "input_cram_indices",
+      "sample_ids",
       "reference_fasta",
       "reference_fasta_index",
       "output_prefix",

--- a/pipelines/ww-imputation/.cirro/process-input.json
+++ b/pipelines/ww-imputation/.cirro/process-input.json
@@ -2,6 +2,7 @@
   "out_dir": "$.dataset.dataPath",
   "input_crams": "$.dataset.params.input_crams",
   "input_cram_indices": "$.dataset.params.input_cram_indices",
+  "sample_ids": "$.dataset.params.sample_ids",
   "reference_fasta": "$.dataset.params.reference_fasta",
   "reference_fasta_index": "$.dataset.params.reference_fasta_index",
   "output_prefix": "$.dataset.params.output_prefix",

--- a/pipelines/ww-imputation/README.md
+++ b/pipelines/ww-imputation/README.md
@@ -154,7 +154,7 @@ Note: `input_crams`, `input_cram_indices`, and `sample_ids` must be parallel arr
 | Parameter | Description | Type | Default |
 |-----------|-------------|------|---------|
 | `output_prefix` | Prefix for output file names | String | "imputed" |
-| `output_format` | Output format (bcf, vcf, vcf.gz) | String | "bcf" |
+| `output_format` | Output format (`bcf` or `vcf.gz`) | String | "bcf" |
 | `impute_reference_only_variants` | Only impute variants in reference panel | Boolean | false |
 | `window_size_cm` | Chunk window size in centiMorgans | Float | 2.0 |
 | `buffer_size_cm` | Chunk buffer size in centiMorgans | Float | 0.2 |

--- a/pipelines/ww-imputation/README.md
+++ b/pipelines/ww-imputation/README.md
@@ -67,6 +67,10 @@ Create an inputs JSON file with your samples and reference data:
     "/path/to/sample001.cram.crai",
     "/path/to/sample002.cram.crai"
   ],
+  "imputation.sample_ids": [
+    "sample001",
+    "sample002"
+  ],
   "imputation.chromosomes": [
     {
       "chromosome": "chr1",
@@ -138,11 +142,12 @@ For detailed information on configuring and using Cirro pipelines, see the [offi
 |-----------|-------------|------|
 | `input_crams` | Array of input CRAM/BAM files for all samples | Array[File] |
 | `input_cram_indices` | Array of index files for input CRAMs/BAMs | Array[File] |
+| `sample_ids` | Array of sample IDs corresponding to each CRAM/BAM | Array[String] |
 | `chromosomes` | Array of ChromosomeData objects | Array[ChromosomeData] |
 | `reference_fasta` | Reference genome FASTA file | File |
 | `reference_fasta_index` | Reference genome FASTA index (.fai) | File |
 
-Note: `input_crams` and `input_cram_indices` must be parallel arrays (i.e., `input_cram_indices[i]` is the index for `input_crams[i]`). All samples are phased jointly in each imputation call.
+Note: `input_crams`, `input_cram_indices`, and `sample_ids` must be parallel arrays (i.e., `sample_ids[i]` is the sample ID for `input_crams[i]`). All samples are phased jointly in each imputation call.
 
 ### Optional Inputs
 

--- a/pipelines/ww-imputation/inputs.json
+++ b/pipelines/ww-imputation/inputs.json
@@ -7,6 +7,10 @@
     "/path/to/sample001.cram.crai",
     "/path/to/sample002.cram.crai"
   ],
+  "imputation.sample_ids": [
+    "sample001",
+    "sample002"
+  ],
   "imputation.chromosomes": [
     {
       "chromosome": "chr22",

--- a/pipelines/ww-imputation/testrun.wdl
+++ b/pipelines/ww-imputation/testrun.wdl
@@ -56,6 +56,7 @@ workflow imputation_testrun {
     input:
       input_crams = [download_cram.cram],
       input_cram_indices = [download_cram.crai],
+      sample_ids = ["NA12878"],
       chromosomes = [
         {
           "chromosome": test_chromosome,

--- a/pipelines/ww-imputation/testrun.wdl
+++ b/pipelines/ww-imputation/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-imputation/ww-imputation.wdl" as ww_imputation
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/fix-glimpse2-info-score/pipelines/ww-imputation/ww-imputation.wdl" as ww_imputation
 
 #### TEST WORKFLOW DEFINITION ####
 # This workflow demonstrates the ww-imputation pipeline with automatic test data download.

--- a/pipelines/ww-imputation/ww-imputation.wdl
+++ b/pipelines/ww-imputation/ww-imputation.wdl
@@ -7,7 +7,7 @@
 
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-glimpse2/ww-glimpse2.wdl" as glimpse2
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/fix-glimpse2-info-score/modules/ww-glimpse2/ww-glimpse2.wdl" as glimpse2
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bcftools/ww-bcftools.wdl" as bcftools
 
 struct ChromosomeData {

--- a/pipelines/ww-imputation/ww-imputation.wdl
+++ b/pipelines/ww-imputation/ww-imputation.wdl
@@ -33,6 +33,7 @@ workflow imputation {
   parameter_meta {
     input_crams: "Array of input CRAM/BAM files for all samples to impute"
     input_cram_indices: "Array of index files corresponding to input CRAMs/BAMs"
+    sample_ids: "Array of sample IDs corresponding to each input CRAM/BAM file"
     chromosomes: "Array of ChromosomeData objects containing chromosome name, reference panel VCF, index, and genetic map"
     reference_fasta: "Reference genome FASTA file (must match CRAM reference)"
     reference_fasta_index: "Reference genome FASTA index file (.fai)"
@@ -65,6 +66,7 @@ workflow imputation {
     # Required inputs
     Array[File] input_crams
     Array[File] input_cram_indices
+    Array[String] sample_ids
     Array[ChromosomeData] chromosomes
     File reference_fasta
     File reference_fasta_index
@@ -150,6 +152,7 @@ workflow imputation {
         input:
           input_bams = input_crams,
           input_bam_indices = input_cram_indices,
+          sample_ids = sample_ids,
           reference_fasta = reference_fasta,
           reference_fasta_index = reference_fasta_index,
           reference_chunk = chrom_reference_chunks[chrom_idx][chunk_idx],


### PR DESCRIPTION
## Type of Change

- Bug fix

## Description

Fixes inflated INFO scores (0.999+ for nearly all variants) in the `ww-glimpse2` module and `ww-imputation` pipeline. The root cause was a [known bug in GLIMPSE2 v2.0.0/v2.0.1](https://github.com/odelaneau/GLIMPSE/issues/144) where the INFO score denominator incorrectly uses total haplotypes (target + reference) instead of target haplotypes only. With a large reference panel (e.g., 6402 haplotypes) and few target samples, this makes the variance term ~1000x too small, pushing all INFO scores to ~1.0 regardless of actual imputation quality. The fix ([PR #175](https://github.com/odelaneau/GLIMPSE/pull/175)) has been merged to GLIMPSE2's `master` branch but is not yet in a tagged release.

### Changes

1. **New Docker image `getwilds/glimpse2:2.0.1-infofix`** — built from GLIMPSE2 `master` (commit `5fda8c09`) to include the INFO score calculation fix. A new `Dockerfile_2.0.1-infofix` was added and all tasks in `ww-glimpse2.wdl` were updated to use the new image.
2. **`keep_monomorphic_ref_sites` default flipped to `true`** in `glimpse2_split_reference` — matching the [Broad Institute's GLIMPSE Imputation Pipeline](https://github.com/broadinstitute/palantir-workflows/tree/main/GlimpseImputationPipeline) default, which retains monomorphic reference sites.
3. **Chunking algorithm switched from `--recursive` to `--sequential`** in `glimpse2_chunk` — matching the Broad's chunking behavior.
4. **Sample IDs and `##idx##` index linking added to the BAM list** in `glimpse2_phase_cram` — the Broad explicitly passes `path##idx##index_path sample_id` format to `GLIMPSE2_phase --bam-list`; our pipeline previously only wrote the file path, causing GLIMPSE2 to be unable to correctly identify samples.

Additionally, `sample_ids` was added as a required input to `glimpse2_phase_cram` (and propagated through `ww-imputation`) to support explicit sample identification when imputing from CRAM/BAM input. The `ww-glimpse2` testrun was updated to also exercise the `glimpse2_phase_cram` code path. Cirro configuration files for `ww-imputation` were updated to expose `sample_ids` as a user-facing field.

**Note:** Even with the fix, INFO scores are only meaningful with a large number of target samples ([GLIMPSE issue #69](https://github.com/odelaneau/GLIMPSE/issues/69)). For small cohorts, use `glimpse2_concordance` against truth genotypes instead.

## Related Issue

- Fixes #267 

## Testing

**How did you test these changes?**
Ran `testrun.wdl` for both `ww-glimpse2` and `ww-imputation`. Also ran `ww-imputation` manually on the HPC with three real low-coverage CRAMs (GRCh38-aligned 1000 Genomes samples HG02401, HG02402, HG02405 at ~6x coverage) to validate INFO score distribution. With the old image, INFO scores were 0.999+ for nearly all variants; with the new image, the distribution is bimodal (scores near 0 and near 1) as expected for a small target cohort.

**What workflow engine did you use?**
Cromwell (HPC via PROOF at Fred Hutch)

**Did the tests pass?**
Yes, HPC execution worked as expected, see GitHub Action test runs below as well.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~

## Additional Context

- The `sample_ids` input is now required in both `glimpse2_phase_cram` and `ww-imputation`. Users upgrading from a previous version will need to add this input.
- The `getwilds/glimpse2:2.0.1-infofix` image should be replaced with the next official GLIMPSE2 release once it includes the INFO score fix.