### PR TITLE
Switching import URL's for ww-deeptools test run back to `main`

### DIFF
--- a/modules/ww-deeptools/testrun.wdl
+++ b/modules/ww-deeptools/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "ww-deeptools.wdl" as ww_deeptools
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deeptools/ww-deeptools.wdl" as ww_deeptools
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 struct DeeptoolsSample {
     String name


### PR DESCRIPTION
## Type of Change

- Other: switching import URL's back to `main`

## Description

- No functional change, just switching import URL's back to `main` in `ww-deeptools` test run WDL
- See GitHub Action test runs below just in case