### PR TITLE
Updating import URL's for ww-trimgalore and ww-multiqc

### DIFF
--- a/modules/ww-multiqc/testrun.wdl
+++ b/modules/ww-multiqc/testrun.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
 # Import module under test and dependencies
-import "ww-multiqc.wdl" as ww_multiqc
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
-import "../ww-fastqc/ww-fastqc.wdl" as ww_fastqc
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as ww_multiqc
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-fastqc/ww-fastqc.wdl" as ww_fastqc
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-trimgalore/testrun.wdl
+++ b/modules/ww-trimgalore/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module in question as well as the testdata module for automatic demo functionality
-import "ww-trimgalore.wdl" as ww_trimgalore
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-trimgalore/ww-trimgalore.wdl" as ww_trimgalore
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 # Define data structure for paired-end sample inputs
 struct TrimGaloreSample {


### PR DESCRIPTION
## Type of Change

- Other: switching import URL's back to `main`

## Description

- No functional change, just switching import URL's back to the `main` branch
- See GitHub Action test runs below just in case