### PR TITLE
Enabling auto-DOI's in Dockstore

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -19,6 +19,7 @@ workflows:
         orcid: 0000-0003-4484-3336
     description: "WDL workflow to align sequencing data using BWA and perform QC steps with GATK"
     topic: variant-calling
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -43,6 +44,7 @@ workflows:
         orcid: 0009-0002-2052-1084
     description: "WDL workflow to download raw sequencing data from ENA and align using STAR two-pass methodology"
     topic: rna-seq
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -72,6 +74,7 @@ workflows:
         orcid: 0000-0003-4484-3336
     description: "Convert paired FASTQ files to unmapped CRAM format using WILDS WDL modules"
     topic: alignment
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -106,6 +109,7 @@ workflows:
         orcid: 0009-0005-2936-2405
     description: "WDL workflow for genotype imputation from low-coverage WGS data using GLIMPSE2. Processes CRAM/BAM files against a reference panel to produce imputed VCF files."
     topic: imputation
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -140,6 +144,7 @@ workflows:
         orcid: 0009-0009-0955-5954
     description: "WDL pipeline to calculate sunrise/sunset times and sun time differences across an array of geographic tiles as part of the SJL model pipeline"
     topic: geospatial
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -173,6 +178,7 @@ workflows:
         orcid: 0000-0001-6372-5170
     description: "Consensus variant calling workflow for human panel/PCR-based targeted DNA sequencing with focus on leukemia analysis - Refactored with WILDS modules"
     topic: variant-calling
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -206,6 +212,7 @@ workflows:
         affiliation: Fred Hutch Cancer Center
     description: "WDL workflow to analyze saturation mutagenesis data using BWA alignment and GATK AnalyzeSaturationMutagenesis"
     topic: saturation-mutagenesis
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -245,6 +252,7 @@ workflows:
         orcid: 0000-0001-8220-8427
     description: "WDL workflow to download raw sequencing data from SRA and quantify using Salmon quasi-mapping"
     topic: rna-seq
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -279,6 +287,7 @@ workflows:
         orcid: 0000-0001-8220-8427
     description: "WDL workflow to download raw sequencing data from SRA and align using STAR two-pass methodology"
     topic: rna-seq
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -303,6 +312,7 @@ workflows:
         orcid: 0009-0002-2052-1084
     description: "Batch ensemble generation pipeline that splits a large protein FASTA into chunks and processes them in parallel using STARLING"
     topic: protein-structure
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -335,6 +345,7 @@ workflows:
         affiliation: Fred Hutch Cancer Center
     description: "WDL workflow for RNA-seq alignment via STAR and DESeq2 differential expression analysis"
     topic: differential-expression
+    enableAutoDois: true
     filters:
       branches:
         - main
@@ -359,6 +370,7 @@ workflows:
         orcid: 0009-0002-2052-1084
     description: "WDL pipeline for alternative splicing proteomics: STAR alignment, rMATS differential splicing detection, and JCAST protein sequence translation"
     topic: proteogenomics
+    enableAutoDois: true
     filters:
       branches:
         - main


### PR DESCRIPTION
## Type of Change

- Other: Configuration update (Dockstore auto-DOI enablement)

## Description

Enables automatic DOI generation via Dockstore for all 12 registered pipelines by adding `enableAutoDois: true` to each workflow entry in `.dockstore.yml`. This allows each pipeline to automatically receive a DOI through Dockstore's Zenodo integration, improving citability and discoverability of the workflows.

## Testing

N/A - configuration-only change, no WDL testing needed.

## Documentation

N/A - configuration-only change, no documentation updates needed.

## Additional Context

This is a configuration-only change to `.dockstore.yml` — no WDL files or Docker images were modified. All 12 pipeline entries now have `enableAutoDois: true` set, which will enable automatic DOI minting through Dockstore's Zenodo integration.
