### PR TITLE
Adding modules as "tools" in Dockstore and updating author info

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -15,17 +15,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for structural variant annotation using AnnotSV"
-    topic: variant-calling
+    topic: WDL module for structural variant annotation using AnnotSV
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - structural-variants
-        - annotation
-        - annotsv
 
   - name: ww-annovar
     subclass: WDL
@@ -37,16 +31,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for variant annotation using Annovar"
-    topic: variant-calling
+    topic: WDL module for variant annotation using Annovar
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - variant-annotation
-        - annovar
 
   - name: ww-aws-sso
     subclass: WDL
@@ -58,16 +47,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for downloading files from S3 using AWS SSO authentication"
-    topic: data-transfer
+    topic: WDL module for downloading files from S3 using AWS SSO authentication
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - aws
-        - s3
-        - data-transfer
 
   - name: ww-bcftools
     subclass: WDL
@@ -79,16 +63,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for variant calling and VCF manipulation using bcftools"
-    topic: variant-calling
+    topic: WDL module for variant calling and VCF manipulation using bcftools
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - variant-calling
-        - bcftools
 
   - name: ww-bedparse
     subclass: WDL
@@ -100,16 +79,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for converting GTF annotation files to BED12 format using bedparse"
-    topic: genomics
+    topic: WDL module for converting GTF annotation files to BED12 format using bedparse
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - format-conversion
-        - bedparse
 
   - name: ww-bedtools
     subclass: WDL
@@ -121,16 +95,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for BAM coverage analysis using BEDTools"
-    topic: genomics
+    topic: WDL module for BAM coverage analysis using BEDTools
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - coverage
-        - bedtools
 
   - name: ww-bowtie
     subclass: WDL
@@ -142,16 +111,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for building Bowtie index files and aligning reads"
-    topic: alignment
+    topic: WDL module for building Bowtie index files and aligning reads
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - alignment
-        - bowtie
 
   - name: ww-bowtie2
     subclass: WDL
@@ -163,16 +127,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for building Bowtie 2 index files and aligning reads"
-    topic: alignment
+    topic: WDL module for building Bowtie 2 index files and aligning reads
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - alignment
-        - bowtie2
 
   - name: ww-bwa
     subclass: WDL
@@ -184,16 +143,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for building BWA index files and aligning reads"
-    topic: alignment
+    topic: WDL module for building BWA index files and aligning reads
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - alignment
-        - bwa
 
   - name: ww-cellranger
     subclass: WDL
@@ -205,16 +159,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for single-cell gene expression analysis using Cell Ranger"
-    topic: single-cell
+    topic: WDL module for single-cell gene expression analysis using Cell Ranger
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - single-cell
-        - cellranger
 
   - name: ww-cnvkit
     subclass: WDL
@@ -226,16 +175,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for copy number variant detection using CNVkit"
-    topic: variant-calling
+    topic: WDL module for copy number variant detection using CNVkit
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - copy-number
-        - cnvkit
 
   - name: ww-colabfold
     subclass: WDL
@@ -247,16 +191,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for protein structure prediction using ColabFold/AlphaFold2"
-    topic: protein-structure
+    topic: WDL module for protein structure prediction using ColabFold/AlphaFold2
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - protein-structure
-        - alphafold
-        - colabfold
 
   - name: ww-consensus
     subclass: WDL
@@ -268,16 +207,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for generating consensus variant calls from multiple variant callers"
-    topic: variant-calling
+    topic: WDL module for generating consensus variant calls from multiple variant callers
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - variant-calling
-        - consensus
 
   - name: ww-deeptools
     subclass: WDL
@@ -289,16 +223,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for generating normalized coverage tracks using deepTools"
-    topic: genomics
+    topic: WDL module for generating normalized coverage tracks using deepTools
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - coverage
-        - deeptools
 
   - name: ww-deepvariant
     subclass: WDL
@@ -310,16 +239,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for germline variant calling using DeepVariant"
-    topic: variant-calling
+    topic: WDL module for germline variant calling using DeepVariant
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - variant-calling
-        - deepvariant
 
   - name: ww-delly
     subclass: WDL
@@ -331,16 +255,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for structural variant calling using Delly"
-    topic: variant-calling
+    topic: WDL module for structural variant calling using Delly
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - structural-variants
-        - delly
 
   - name: ww-deseq2
     subclass: WDL
@@ -352,17 +271,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for differential expression analysis using DESeq2"
-    topic: differential-expression
+    topic: WDL module for differential expression analysis using DESeq2
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-seq
-        - differential-expression
-        - deseq2
 
   - name: ww-diamond
     subclass: WDL
@@ -374,16 +287,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for sequence alignment using DIAMOND"
-    topic: alignment
+    topic: WDL module for sequence alignment using DIAMOND
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - alignment
-        - diamond
 
   - name: ww-ena
     subclass: WDL
@@ -395,16 +303,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for downloading sequencing data from the European Nucleotide Archive"
-    topic: data-transfer
+    topic: WDL module for downloading sequencing data from the European Nucleotide Archive
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - data-transfer
-        - ena
-        - sequencing
 
   - name: ww-fastp
     subclass: WDL
@@ -416,16 +319,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for FASTQ quality filtering and adapter trimming using fastp"
-    topic: quality-control
+    topic: WDL module for FASTQ quality filtering and adapter trimming using fastp
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - quality-control
-        - fastp
 
   - name: ww-fastqc
     subclass: WDL
@@ -437,16 +335,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for FASTQ quality control analysis using FastQC"
-    topic: quality-control
+    topic: WDL module for FASTQ quality control analysis using FastQC
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - quality-control
-        - fastqc
 
   - name: ww-gatk
     subclass: WDL
@@ -463,16 +356,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for variant calling and genome preprocessing using GATK"
-    topic: variant-calling
+    topic: WDL module for variant calling and genome preprocessing using GATK
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - variant-calling
-        - gatk
 
   - name: ww-gdc
     subclass: WDL
@@ -484,16 +372,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for downloading files from the Genomic Data Commons"
-    topic: data-transfer
+    topic: WDL module for downloading files from the Genomic Data Commons
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - data-transfer
-        - gdc
-        - genomics
 
   - name: ww-glimpse2
     subclass: WDL
@@ -505,16 +388,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for genotype imputation using GLIMPSE2"
-    topic: imputation
+    topic: WDL module for genotype imputation using GLIMPSE2
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - imputation
-        - glimpse2
 
   - name: ww-ichorcna
     subclass: WDL
@@ -526,17 +404,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for tumor fraction estimation using ichorCNA"
-    topic: variant-calling
+    topic: WDL module for tumor fraction estimation using ichorCNA
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - copy-number
-        - ichorcna
-        - tumor-fraction
 
   - name: ww-jcast
     subclass: WDL
@@ -548,16 +420,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for translating alternative splicing events into protein sequences using JCAST"
-    topic: proteogenomics
+    topic: WDL module for translating alternative splicing events into protein sequences using JCAST
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - proteogenomics
-        - alternative-splicing
-        - jcast
 
   - name: ww-manta
     subclass: WDL
@@ -569,16 +436,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for structural variant calling using Manta"
-    topic: variant-calling
+    topic: WDL module for structural variant calling using Manta
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - structural-variants
-        - manta
 
   - name: ww-megahit
     subclass: WDL
@@ -590,16 +452,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for de novo metagenome assembly using MEGAHIT"
-    topic: metagenomics
+    topic: WDL module for de novo metagenome assembly using MEGAHIT
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - metagenomics
-        - assembly
-        - megahit
 
   - name: ww-multiqc
     subclass: WDL
@@ -611,16 +468,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for aggregating QC reports using MultiQC"
-    topic: quality-control
+    topic: WDL module for aggregating QC reports using MultiQC
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - quality-control
-        - multiqc
 
   - name: ww-rmats-turbo
     subclass: WDL
@@ -632,17 +484,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for differential alternative splicing analysis using rMATS"
-    topic: rna-seq
+    topic: WDL module for differential alternative splicing analysis using rMATS
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-seq
-        - alternative-splicing
-        - rmats
 
   - name: ww-rseqc
     subclass: WDL
@@ -654,17 +500,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for RNA-seq quality control using RSeQC"
-    topic: quality-control
+    topic: WDL module for RNA-seq quality control using RSeQC
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-seq
-        - quality-control
-        - rseqc
 
   - name: ww-salmon
     subclass: WDL
@@ -676,17 +516,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for RNA-seq quantification using Salmon"
-    topic: rna-seq
+    topic: WDL module for RNA-seq quantification using Salmon
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-seq
-        - quantification
-        - salmon
 
   - name: ww-samtools
     subclass: WDL
@@ -703,16 +537,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for processing genomic files with Samtools"
-    topic: genomics
+    topic: WDL module for processing genomic files with Samtools
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - samtools
-        - alignment
 
   - name: ww-shapemapper
     subclass: WDL
@@ -724,16 +553,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for RNA structure probing analysis using ShapeMapper"
-    topic: rna-seq
+    topic: WDL module for RNA structure probing analysis using ShapeMapper
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-structure
-        - shapemapper
 
   - name: ww-sjl
     subclass: WDL
@@ -745,16 +569,11 @@ tools:
         role: Research Assistant
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0009-0955-5954
-    description: "WDL module for calculating sunrise/sunset times and sun time differences for the SJL model"
-    topic: geospatial
+    topic: WDL module for calculating sunrise/sunset times and sun time differences for the SJL model
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - geospatial
-        - solar-jetlag
-        - environmental-health
 
   - name: ww-smoove
     subclass: WDL
@@ -766,16 +585,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for structural variant calling using Smoove"
-    topic: variant-calling
+    topic: WDL module for structural variant calling using Smoove
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - structural-variants
-        - smoove
 
   - name: ww-sourmash
     subclass: WDL
@@ -787,16 +601,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for sequence sketching and comparison using sourmash"
-    topic: metagenomics
+    topic: WDL module for sequence sketching and comparison using sourmash
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - metagenomics
-        - sourmash
-        - sketching
 
   - name: ww-spades
     subclass: WDL
@@ -808,16 +617,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for de novo metagenomic assembly using metaSPAdes"
-    topic: metagenomics
+    topic: WDL module for de novo metagenomic assembly using metaSPAdes
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - metagenomics
-        - assembly
-        - spades
 
   - name: ww-sra
     subclass: WDL
@@ -829,16 +633,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for downloading sequencing data from the Sequence Read Archive"
-    topic: data-transfer
+    topic: WDL module for downloading sequencing data from the Sequence Read Archive
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - data-transfer
-        - sra
-        - sequencing
 
   - name: ww-star
     subclass: WDL
@@ -850,17 +649,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for RNA-seq alignment using STAR two-pass methodology"
-    topic: rna-seq
+    topic: WDL module for RNA-seq alignment using STAR two-pass methodology
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-seq
-        - alignment
-        - star
 
   - name: ww-starling
     subclass: WDL
@@ -872,16 +665,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for structural ensemble generation using STARLING"
-    topic: protein-structure
+    topic: WDL module for structural ensemble generation using STARLING
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - protein-structure
-        - ensemble-generation
-        - starling
 
   - name: ww-strelka
     subclass: WDL
@@ -893,16 +681,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for germline variant calling using Strelka"
-    topic: variant-calling
+    topic: WDL module for germline variant calling using Strelka
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - variant-calling
-        - strelka
 
   - name: ww-trimgalore
     subclass: WDL
@@ -914,16 +697,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL module for adapter and quality trimming using Trim Galore"
-    topic: quality-control
+    topic: WDL module for adapter and quality trimming using Trim Galore
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - quality-control
-        - trimgalore
 
   - name: ww-tritonnp
     subclass: WDL
@@ -934,15 +712,11 @@ tools:
         email: clo2@fredhutch.org
         role: Data Science Trainer
         affiliation: Fred Hutch Cancer Center
-    description: "WDL module for running TritonNP analysis"
-    topic: protein-structure
+    topic: WDL module for running TritonNP analysis
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - protein-structure
-        - tritonnp
 
   - name: ww-testdata
     subclass: WDL
@@ -963,15 +737,11 @@ tools:
         email: clo2@fredhutch.org
         role: Data Science Trainer
         affiliation: Fred Hutch Cancer Center
-    description: "WDL module for downloading and provisioning test data used across WILDS WDL module and pipeline test runs"
-    topic: testing
+    topic: WDL module for downloading and provisioning test data used across WILDS WDL module and pipeline test runs
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - testing
-        - test-data
 
   - name: ww-varscan
     subclass: WDL
@@ -983,16 +753,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL module for somatic variant calling using VarScan"
-    topic: variant-calling
+    topic: WDL module for somatic variant calling using VarScan
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - variant-calling
-        - varscan
 
 workflows:
   # =============================================================================
@@ -1011,18 +776,11 @@ workflows:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "WDL workflow to align sequencing data using BWA and perform QC steps with GATK"
-    topic: variant-calling
+    topic: WDL workflow to align sequencing data using BWA and perform QC steps with GATK
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - alignment
-        - variant-calling
-        - bwa
-        - gatk
 
   - name: ww-ena-star
     subclass: WDL
@@ -1036,18 +794,11 @@ workflows:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL workflow to download raw sequencing data from ENA and align using STAR two-pass methodology"
-    topic: rna-seq
+    topic: WDL workflow to download raw sequencing data from ENA and align using STAR two-pass methodology
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-seq
-        - alignment
-        - star
-        - ena
 
   - name: ww-fastq-to-cram
     subclass: WDL
@@ -1066,18 +817,11 @@ workflows:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
-    description: "Convert paired FASTQ files to unmapped CRAM format using WILDS WDL modules"
-    topic: alignment
+    topic: Convert paired FASTQ files to unmapped CRAM format using WILDS WDL modules
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - format-conversion
-        - fastq
-        - cram
-        - samtools
 
   - name: ww-imputation
     subclass: WDL
@@ -1101,18 +845,11 @@ workflows:
         role: Research Associate
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0005-2936-2405
-    description: "WDL workflow for genotype imputation from low-coverage WGS data using GLIMPSE2. Processes CRAM/BAM files against a reference panel to produce imputed VCF files."
-    topic: imputation
+    topic: WDL workflow for genotype imputation from low-coverage WGS data using GLIMPSE2
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - imputation
-        - glimpse2
-        - low-coverage-wgs
-        - genotyping
 
   - name: ww-jetlag
     subclass: WDL
@@ -1136,17 +873,11 @@ workflows:
         role: Research Assistant
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0009-0955-5954
-    description: "WDL pipeline to calculate sunrise/sunset times and sun time differences across an array of geographic tiles as part of the SJL model pipeline"
-    topic: geospatial
+    topic: WDL pipeline to calculate sunrise/sunset times and sun time differences across geographic tiles
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - geospatial
-        - solar-jetlag
-        - environmental-health
-        - sunrise-sunset
 
   - name: ww-leukemia
     subclass: WDL
@@ -1170,18 +901,11 @@ workflows:
         role: Staff Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0001-6372-5170
-    description: "Consensus variant calling workflow for human panel/PCR-based targeted DNA sequencing with focus on leukemia analysis - Refactored with WILDS modules"
-    topic: variant-calling
+    topic: Consensus variant calling workflow for human panel/PCR-based targeted DNA sequencing for leukemia
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - variant-calling
-        - leukemia
-        - targeted-sequencing
-        - consensus-calling
 
   - name: ww-saturation
     subclass: WDL
@@ -1204,18 +928,11 @@ workflows:
         email: sobrien2@fredhutch.org
         role: Post-Doctoral Research Fellow
         affiliation: Fred Hutch Cancer Center
-    description: "WDL workflow to analyze saturation mutagenesis data using BWA alignment and GATK AnalyzeSaturationMutagenesis"
-    topic: saturation-mutagenesis
+    topic: WDL workflow to analyze saturation mutagenesis data using BWA alignment and GATK
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - saturation-mutagenesis
-        - bwa
-        - gatk
-        - functional-genomics
 
   - name: ww-sra-salmon
     subclass: WDL
@@ -1244,18 +961,11 @@ workflows:
         role: Staff Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0001-8220-8427
-    description: "WDL workflow to download raw sequencing data from SRA and quantify using Salmon quasi-mapping"
-    topic: rna-seq
+    topic: WDL workflow to download raw sequencing data from SRA and quantify using Salmon quasi-mapping
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-seq
-        - quantification
-        - salmon
-        - sra
 
   - name: ww-sra-star
     subclass: WDL
@@ -1279,18 +989,11 @@ workflows:
         role: Staff Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0001-8220-8427
-    description: "WDL workflow to download raw sequencing data from SRA and align using STAR two-pass methodology"
-    topic: rna-seq
+    topic: WDL workflow to download raw sequencing data from SRA and align using STAR two-pass methodology
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-seq
-        - alignment
-        - star
-        - sra
 
   - name: ww-starling-batch
     subclass: WDL
@@ -1304,17 +1007,11 @@ workflows:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "Batch ensemble generation pipeline that splits a large protein FASTA into chunks and processes them in parallel using STARLING"
-    topic: protein-structure
+    topic: Batch ensemble generation pipeline splitting a protein FASTA into chunks for parallel STARLING processing
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - protein-structure
-        - ensemble-generation
-        - starling
-        - structural-biology
 
   - name: ww-star-deseq2
     subclass: WDL
@@ -1337,18 +1034,11 @@ workflows:
         email: ebouvet@fredhutch.org
         role: Research Technician
         affiliation: Fred Hutch Cancer Center
-    description: "WDL workflow for RNA-seq alignment via STAR and DESeq2 differential expression analysis"
-    topic: differential-expression
+    topic: WDL workflow for RNA-seq alignment via STAR and DESeq2 differential expression analysis
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - rna-seq
-        - differential-expression
-        - star
-        - deseq2
 
   - name: ww-splicing-proteomics
     subclass: WDL
@@ -1362,16 +1052,8 @@ workflows:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    description: "WDL pipeline for alternative splicing proteomics: STAR alignment, rMATS differential splicing detection, and JCAST protein sequence translation"
-    topic: proteogenomics
+    topic: WDL pipeline for alternative splicing proteomics: STAR alignment, rMATS splicing, and JCAST translation
     enableAutoDois: true
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - proteogenomics
-        - alternative-splicing
-        - rmats
-        - jcast
-        - star

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,5 +1,999 @@
 version: 1.2
 
+tools:
+  # =============================================================================
+  # MODULES - Individual tool-specific task collections
+  # =============================================================================
+
+  - name: ww-annotsv
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-annotsv/ww-annotsv.wdl
+    readMePath: /modules/ww-annotsv/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for structural variant annotation using AnnotSV"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - structural-variants
+        - annotation
+        - annotsv
+
+  - name: ww-annovar
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-annovar/ww-annovar.wdl
+    readMePath: /modules/ww-annovar/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for variant annotation using Annovar"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - variant-annotation
+        - annovar
+
+  - name: ww-aws-sso
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-aws-sso/ww-aws-sso.wdl
+    readMePath: /modules/ww-aws-sso/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for downloading files from S3 using AWS SSO authentication"
+    topic: data-transfer
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - aws
+        - s3
+        - data-transfer
+
+  - name: ww-bcftools
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-bcftools/ww-bcftools.wdl
+    readMePath: /modules/ww-bcftools/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for variant calling and VCF manipulation using bcftools"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - variant-calling
+        - bcftools
+
+  - name: ww-bedparse
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-bedparse/ww-bedparse.wdl
+    readMePath: /modules/ww-bedparse/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for converting GTF annotation files to BED12 format using bedparse"
+    topic: genomics
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - format-conversion
+        - bedparse
+
+  - name: ww-bedtools
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-bedtools/ww-bedtools.wdl
+    readMePath: /modules/ww-bedtools/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for BAM coverage analysis using BEDTools"
+    topic: genomics
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - coverage
+        - bedtools
+
+  - name: ww-bowtie
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-bowtie/ww-bowtie.wdl
+    readMePath: /modules/ww-bowtie/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for building Bowtie index files and aligning reads"
+    topic: alignment
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - alignment
+        - bowtie
+
+  - name: ww-bowtie2
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-bowtie2/ww-bowtie2.wdl
+    readMePath: /modules/ww-bowtie2/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for building Bowtie 2 index files and aligning reads"
+    topic: alignment
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - alignment
+        - bowtie2
+
+  - name: ww-bwa
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-bwa/ww-bwa.wdl
+    readMePath: /modules/ww-bwa/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for building BWA index files and aligning reads"
+    topic: alignment
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - alignment
+        - bwa
+
+  - name: ww-cellranger
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-cellranger/ww-cellranger.wdl
+    readMePath: /modules/ww-cellranger/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for single-cell gene expression analysis using Cell Ranger"
+    topic: single-cell
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - single-cell
+        - cellranger
+
+  - name: ww-cnvkit
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-cnvkit/ww-cnvkit.wdl
+    readMePath: /modules/ww-cnvkit/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for copy number variant detection using CNVkit"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - copy-number
+        - cnvkit
+
+  - name: ww-colabfold
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-colabfold/ww-colabfold.wdl
+    readMePath: /modules/ww-colabfold/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for protein structure prediction using ColabFold/AlphaFold2"
+    topic: protein-structure
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - protein-structure
+        - alphafold
+        - colabfold
+
+  - name: ww-consensus
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-consensus/ww-consensus.wdl
+    readMePath: /modules/ww-consensus/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for generating consensus variant calls from multiple variant callers"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - variant-calling
+        - consensus
+
+  - name: ww-deeptools
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-deeptools/ww-deeptools.wdl
+    readMePath: /modules/ww-deeptools/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for generating normalized coverage tracks using deepTools"
+    topic: genomics
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - coverage
+        - deeptools
+
+  - name: ww-deepvariant
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-deepvariant/ww-deepvariant.wdl
+    readMePath: /modules/ww-deepvariant/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for germline variant calling using DeepVariant"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - variant-calling
+        - deepvariant
+
+  - name: ww-delly
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-delly/ww-delly.wdl
+    readMePath: /modules/ww-delly/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for structural variant calling using Delly"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - structural-variants
+        - delly
+
+  - name: ww-deseq2
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-deseq2/ww-deseq2.wdl
+    readMePath: /modules/ww-deseq2/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for differential expression analysis using DESeq2"
+    topic: differential-expression
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - rna-seq
+        - differential-expression
+        - deseq2
+
+  - name: ww-diamond
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-diamond/ww-diamond.wdl
+    readMePath: /modules/ww-diamond/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for sequence alignment using DIAMOND"
+    topic: alignment
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - alignment
+        - diamond
+
+  - name: ww-ena
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-ena/ww-ena.wdl
+    readMePath: /modules/ww-ena/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for downloading sequencing data from the European Nucleotide Archive"
+    topic: data-transfer
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - data-transfer
+        - ena
+        - sequencing
+
+  - name: ww-fastp
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-fastp/ww-fastp.wdl
+    readMePath: /modules/ww-fastp/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for FASTQ quality filtering and adapter trimming using fastp"
+    topic: quality-control
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - quality-control
+        - fastp
+
+  - name: ww-fastqc
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-fastqc/ww-fastqc.wdl
+    readMePath: /modules/ww-fastqc/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for FASTQ quality control analysis using FastQC"
+    topic: quality-control
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - quality-control
+        - fastqc
+
+  - name: ww-gatk
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-gatk/ww-gatk.wdl
+    readMePath: /modules/ww-gatk/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for variant calling and genome preprocessing using GATK"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - variant-calling
+        - gatk
+
+  - name: ww-gdc
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-gdc/ww-gdc.wdl
+    readMePath: /modules/ww-gdc/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for downloading files from the Genomic Data Commons"
+    topic: data-transfer
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - data-transfer
+        - gdc
+        - genomics
+
+  - name: ww-glimpse2
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-glimpse2/ww-glimpse2.wdl
+    readMePath: /modules/ww-glimpse2/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for genotype imputation using GLIMPSE2"
+    topic: imputation
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - imputation
+        - glimpse2
+
+  - name: ww-ichorcna
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-ichorcna/ww-ichorcna.wdl
+    readMePath: /modules/ww-ichorcna/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for tumor fraction estimation using ichorCNA"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - copy-number
+        - ichorcna
+        - tumor-fraction
+
+  - name: ww-jcast
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-jcast/ww-jcast.wdl
+    readMePath: /modules/ww-jcast/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for translating alternative splicing events into protein sequences using JCAST"
+    topic: proteogenomics
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - proteogenomics
+        - alternative-splicing
+        - jcast
+
+  - name: ww-manta
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-manta/ww-manta.wdl
+    readMePath: /modules/ww-manta/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for structural variant calling using Manta"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - structural-variants
+        - manta
+
+  - name: ww-megahit
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-megahit/ww-megahit.wdl
+    readMePath: /modules/ww-megahit/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for de novo metagenome assembly using MEGAHIT"
+    topic: metagenomics
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - metagenomics
+        - assembly
+        - megahit
+
+  - name: ww-multiqc
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-multiqc/ww-multiqc.wdl
+    readMePath: /modules/ww-multiqc/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for aggregating QC reports using MultiQC"
+    topic: quality-control
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - quality-control
+        - multiqc
+
+  - name: ww-rmats-turbo
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-rmats-turbo/ww-rmats-turbo.wdl
+    readMePath: /modules/ww-rmats-turbo/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for differential alternative splicing analysis using rMATS"
+    topic: rna-seq
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - rna-seq
+        - alternative-splicing
+        - rmats
+
+  - name: ww-rseqc
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-rseqc/ww-rseqc.wdl
+    readMePath: /modules/ww-rseqc/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for RNA-seq quality control using RSeQC"
+    topic: quality-control
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - rna-seq
+        - quality-control
+        - rseqc
+
+  - name: ww-salmon
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-salmon/ww-salmon.wdl
+    readMePath: /modules/ww-salmon/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for RNA-seq quantification using Salmon"
+    topic: rna-seq
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - rna-seq
+        - quantification
+        - salmon
+
+  - name: ww-samtools
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-samtools/ww-samtools.wdl
+    readMePath: /modules/ww-samtools/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for processing genomic files with Samtools"
+    topic: genomics
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - samtools
+        - alignment
+
+  - name: ww-shapemapper
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-shapemapper/ww-shapemapper.wdl
+    readMePath: /modules/ww-shapemapper/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for RNA structure probing analysis using ShapeMapper"
+    topic: rna-seq
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - rna-structure
+        - shapemapper
+
+  - name: ww-sjl
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-sjl/ww-sjl.wdl
+    readMePath: /modules/ww-sjl/README.md
+    authors:
+      - name: Caroline Nondin
+        email: cnondin@fredhutch.org
+        role: Research Assistant
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0009-0955-5954
+    description: "WDL module for calculating sunrise/sunset times and sun time differences for the SJL model"
+    topic: geospatial
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - geospatial
+        - solar-jetlag
+        - environmental-health
+
+  - name: ww-smoove
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-smoove/ww-smoove.wdl
+    readMePath: /modules/ww-smoove/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for structural variant calling using Smoove"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - structural-variants
+        - smoove
+
+  - name: ww-sourmash
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-sourmash/ww-sourmash.wdl
+    readMePath: /modules/ww-sourmash/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for sequence sketching and comparison using sourmash"
+    topic: metagenomics
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - metagenomics
+        - sourmash
+        - sketching
+
+  - name: ww-spades
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-spades/ww-spades.wdl
+    readMePath: /modules/ww-spades/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for de novo metagenomic assembly using metaSPAdes"
+    topic: metagenomics
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - metagenomics
+        - assembly
+        - spades
+
+  - name: ww-sra
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-sra/ww-sra.wdl
+    readMePath: /modules/ww-sra/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for downloading sequencing data from the Sequence Read Archive"
+    topic: data-transfer
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - data-transfer
+        - sra
+        - sequencing
+
+  - name: ww-star
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-star/ww-star.wdl
+    readMePath: /modules/ww-star/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for RNA-seq alignment using STAR two-pass methodology"
+    topic: rna-seq
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - rna-seq
+        - alignment
+        - star
+
+  - name: ww-starling
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-starling/ww-starling.wdl
+    readMePath: /modules/ww-starling/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for structural ensemble generation using STARLING"
+    topic: protein-structure
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - protein-structure
+        - ensemble-generation
+        - starling
+
+  - name: ww-strelka
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-strelka/ww-strelka.wdl
+    readMePath: /modules/ww-strelka/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for germline variant calling using Strelka"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - variant-calling
+        - strelka
+
+  - name: ww-trimgalore
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-trimgalore/ww-trimgalore.wdl
+    readMePath: /modules/ww-trimgalore/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "WDL module for adapter and quality trimming using Trim Galore"
+    topic: quality-control
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - quality-control
+        - trimgalore
+
+  - name: ww-tritonnp
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-tritonnp/ww-tritonnp.wdl
+    readMePath: /modules/ww-tritonnp/README.md
+    authors:
+      - name: Chris Lo
+        email: clo2@fredhutch.org
+        role: Data Science Trainer
+        affiliation: Fred Hutch Cancer Center
+    description: "WDL module for running TritonNP analysis"
+    topic: protein-structure
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - protein-structure
+        - tritonnp
+
+  - name: ww-testdata
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-testdata/ww-testdata.wdl
+    readMePath: /modules/ww-testdata/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+      - name: Chris Lo
+        email: clo2@fredhutch.org
+        role: Data Science Trainer
+        affiliation: Fred Hutch Cancer Center
+    description: "WDL module for downloading and provisioning test data used across WILDS WDL module and pipeline test runs"
+    topic: testing
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - testing
+        - test-data
+
+  - name: ww-varscan
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-varscan/ww-varscan.wdl
+    readMePath: /modules/ww-varscan/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+    description: "WDL module for somatic variant calling using VarScan"
+    topic: variant-calling
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - genomics
+        - variant-calling
+        - varscan
+
 workflows:
   # =============================================================================
   # PIPELINES - Complete analysis workflows combining multiple modules

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1034,6 +1034,7 @@ workflows:
         email: ebouvet@fredhutch.org
         role: Research Technician
         affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0006-6552-2522
     topic: WDL workflow for RNA-seq alignment via STAR and DESeq2 differential expression analysis
     enableAutoDois: true
     filters:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Thank you for your interest in contributing to the WILDS WDL Library! This docum
 - [Testing Requirements](#testing-requirements)
 - [Documentation Standards](#documentation-standards)
 - [Documentation Website](#documentation-website)
+- [Citation and Attribution](#citation-and-attribution)
+- [Dockstore Registration](#dockstore-registration)
 - [Pull Request Process](#pull-request-process)
 - [Code of Conduct](#code-of-conduct)
 
@@ -353,6 +355,74 @@ If you encounter issues with local documentation builds:
 - Review error messages - they often indicate issues with WDL syntax or README formatting
 
 For questions about documentation, please contact [wilds@fredhutch.org](mailto:wilds@fredhutch.org).
+
+## Citation and Attribution
+
+The repository includes a `CITATION.cff` file that provides structured citation metadata for the WILDS WDL Library. This file follows the [Citation File Format](https://citation-file-format.github.io/) standard and is used by GitHub, Zenodo, and other platforms to generate proper citations.
+
+### When to Update `CITATION.cff`
+
+If you are a new contributor making a significant contribution (e.g., a new module or pipeline), add yourself to the `authors:` list in `CITATION.cff`:
+
+```yaml
+authors:
+  - family-names: LastName
+    given-names: FirstName
+    affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0000-0000-0000-0000"  # optional but encouraged
+```
+
+Keep the ORCID in full URL format (`https://orcid.org/...`) in `CITATION.cff` — this differs from `.dockstore.yml` which uses just the numeric ID.
+
+### Keeping Author Info Consistent
+
+Author information appears in several places across the repo. When adding or updating author details, make sure the following are consistent:
+
+- **`CITATION.cff`** — the canonical source for contributor names, affiliations, and ORCIDs
+- **`.dockstore.yml`** — author entries for each module/pipeline (see [Dockstore Registration](#dockstore-registration))
+- **WDL `meta` blocks** — `author` and `email` fields in task/workflow metadata
+
+## Dockstore Registration
+
+All modules and pipelines in this library are published on [Dockstore](https://dockstore.org/), a platform for sharing and discovering bioinformatics workflows. When you contribute a new module or pipeline, you must add a corresponding entry to the `.dockstore.yml` file in the repository root.
+
+### Adding a Module Entry
+
+Modules are registered under the `tools:` section. Use an existing entry as a template:
+
+```yaml
+tools:
+  - name: ww-toolname
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-toolname/ww-toolname.wdl
+    readMePath: /modules/ww-toolname/README.md
+    authors:
+      - name: Your Name
+        email: your.email@fredhutch.org
+        role: Your Role
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0000-0000-0000  # optional but encouraged
+    description: "Brief description of what this module does"
+    topic: relevant-topic
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+      tags:
+        - relevant-tag-1
+        - relevant-tag-2
+```
+
+### Adding a Pipeline Entry
+
+Pipelines are registered under the `workflows:` section with the same structure, but with paths pointing to the `pipelines/` directory. If you have an `inputs.json`, include it in `testParameterFiles`.
+
+### Author Information
+
+- List all authors who contributed tasks to the module or steps to the pipeline
+- Include `orcid` if available (use the numeric ID only, e.g., `0009-0002-2052-1084`)
+- Keep entries in alphabetical order by module/pipeline name within their section
+- Author details should match the `CITATION.cff` file where applicable
 
 ## Pull Request Process
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -63,3 +63,4 @@ authors:
   - family-names: Bouvet
     given-names: Ethan
     affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0009-0006-6552-2522"

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ See our [Contributing Guidelines](.github/CONTRIBUTING.md) for detailed informat
 - **Documentation**: [Contributing Guidelines](.github/CONTRIBUTING.md)
 - **Fred Hutch Users**: [Scientific Computing Wiki](https://sciwiki.fredhutch.org/)
 
+## Dockstore
+
+All modules and pipelines in this library are published on [Dockstore](https://dockstore.org/), enabling discovery, import, and citation of individual workflows. Browse the library on Dockstore to find modules and pipelines with detailed descriptions, author information, and DOIs.
+
 ## Related Resources
 
 - **[WILDS Docker Library](https://github.com/getwilds/wilds-docker-library)**: Container images used by WDL workflows

--- a/modules/ww-annotsv/ww-annotsv.wdl
+++ b/modules/ww-annotsv/ww-annotsv.wdl
@@ -6,8 +6,8 @@ version 1.0
 
 task annotsv_annotate {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Annotate structural variants using AnnotSV with comprehensive genomic and clinical annotations"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-annotsv/ww-annotsv.wdl"
     outputs: {

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -1,7 +1,7 @@
 ## WILDS WDL Module: ww-deseq2
 ## Description: Module for differential expression analysis using DESeq2
-## Author: WILDS Team
-## Contact: wilds@fredhutch.org
+## Author: Taylor Firman
+## Contact: tfirman@fredhutch.org
 
 version 1.0
 

--- a/modules/ww-gdc/ww-gdc.wdl
+++ b/modules/ww-gdc/ww-gdc.wdl
@@ -123,8 +123,8 @@ task download_by_manifest {
 
 task download_by_uuids {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Download files from GDC using file UUIDs. Supports both controlled-access (with token) and open-access data."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gdc/ww-gdc.wdl"
     outputs: {

--- a/modules/ww-salmon/ww-salmon.wdl
+++ b/modules/ww-salmon/ww-salmon.wdl
@@ -1,14 +1,14 @@
 ## WILDS WDL Module: ww-salmon
 ## Description: Module for RNA-seq quantification using Salmon
-## Author: WILDS Team
-## Contact: wilds@fredhutch.org
+## Author: Taylor Firman
+## Contact: tfirman@fredhutch.org
 
 version 1.0
 
 task build_index {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Build Salmon index from reference transcriptome FASTA file"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-salmon/ww-salmon.wdl"
     outputs: {
@@ -64,8 +64,8 @@ task build_index {
 
 task quantify {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Quantify transcript expression from RNA-seq reads using Salmon. Supports both paired-end and single-end data."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-salmon/ww-salmon.wdl"
     outputs: {
@@ -136,8 +136,8 @@ task quantify {
 
 task merge_results {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Merge Salmon quantification results from multiple samples into count and TPM matrices"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-salmon/ww-salmon.wdl"
     outputs: {

--- a/modules/ww-template/ww-template.wdl
+++ b/modules/ww-template/ww-template.wdl
@@ -12,8 +12,8 @@ version 1.0
 task process_sample {
   # Provide metadata describing the purpose and authorship of the task
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Your Name"
+    email: "your.email@fredhutch.org"
     description: "Simple template processing task that creates a hello world output file"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-template/ww-template.wdl"
     outputs: {

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -6,8 +6,8 @@ version 1.0
 
 task download_ref_data {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads reference genome and index files for WILDS WDL test runs"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -105,8 +105,8 @@ task download_ref_data {
 
 task download_fastq_data {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads small example FASTQ files for WILDS WDL test runs. Renames to Illumina naming convention with optional gzip compression."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -164,8 +164,8 @@ task download_fastq_data {
 
 task interleave_fastq {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Emma Bishop"
+    email: "ebishop@fredhutch.org"
     description: "Interleaves a set of R1 and R2 FASTQ files"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -208,8 +208,8 @@ task interleave_fastq {
 
 task download_cram_data {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads small example CRAM files for WILDS WDL test runs"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -287,8 +287,8 @@ task download_cram_data {
 
 task download_bam_data {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads small example BAM files for WILDS WDL test runs"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -357,8 +357,8 @@ task download_bam_data {
 
 task download_ichor_data {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads reference data for ichorCNA analysis on hg38"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -406,8 +406,8 @@ task download_ichor_data {
 
 task download_tritonnp_data {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Chris Lo"
+    email: "clo2@fredhutch.org"
     description: "Downloads test data for TritonNP analysis"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -467,8 +467,8 @@ task download_tritonnp_data {
 
 task download_dbsnp_vcf {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads dbSNP VCF files for GATK workflows"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -547,8 +547,8 @@ task download_dbsnp_vcf {
 
 task download_known_indels_vcf {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads known indel VCF files for GATK workflows"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -596,8 +596,8 @@ task download_known_indels_vcf {
 
 task download_gnomad_vcf {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads gnomad VCF files for GATK workflows"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -1179,8 +1179,8 @@ FASTA
 
 task download_glimpse2_genetic_map {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads genetic map files for GLIMPSE2 imputation from the official GLIMPSE repository"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -1235,8 +1235,8 @@ task download_glimpse2_genetic_map {
 
 task download_glimpse2_reference_panel {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads and prepares a 1000 Genomes reference panel subset for GLIMPSE2 imputation. Downloads phased data for the specified chromosome and filters to a region."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
@@ -1440,8 +1440,8 @@ task generate_sjl_data {
 
 task download_glimpse2_test_gl_vcf {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Downloads low-coverage sequencing data from 1000 Genomes and generates a VCF with genotype likelihoods for GLIMPSE2 imputation testing."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {

--- a/pipelines/ww-fastq-to-cram/ww-fastq-to-cram.wdl
+++ b/pipelines/ww-fastq-to-cram/ww-fastq-to-cram.wdl
@@ -25,8 +25,16 @@ struct SampleData {
 
 workflow fastq_to_cram {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Emma Bishop",
+            email: "ebishop@fredhutch.org"
+        }
+    ]
     description: "Convert paired FASTQ files to unmapped CRAM format using WILDS WDL modules"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-fastq-to-cram/ww-fastq-to-cram.wdl"
     outputs: {

--- a/pipelines/ww-imputation/ww-imputation.wdl
+++ b/pipelines/ww-imputation/ww-imputation.wdl
@@ -19,8 +19,20 @@ struct ChromosomeData {
 
 workflow imputation {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Emma Bishop",
+            email: "ebishop@fredhutch.org"
+        },
+        {
+            name: "Louisa Goss",
+            email: "lgoss2@fredhutch.org"
+        }
+    ]
     description: "WDL workflow for genotype imputation from low-coverage WGS data using GLIMPSE2. Processes CRAM/BAM files against a reference panel to produce a multi-sample imputed VCF file."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-imputation/ww-imputation.wdl"
     outputs: {

--- a/pipelines/ww-jetlag/ww-jetlag.wdl
+++ b/pipelines/ww-jetlag/ww-jetlag.wdl
@@ -8,8 +8,20 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 
 workflow jetlag {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Emma Bishop",
+            email: "ebishop@fredhutch.org"
+        },
+        {
+            name: "Caroline Nondin",
+            email: "cnondin@fredhutch.org"
+        }
+    ]
     description: "WDL pipeline to calculate sunrise/sunset times and sun time differences across an array of geographic tiles as part of the SJL model pipeline"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-jetlag/ww-jetlag.wdl"
     outputs: {

--- a/pipelines/ww-leukemia/ww-leukemia.wdl
+++ b/pipelines/ww-leukemia/ww-leukemia.wdl
@@ -59,8 +59,20 @@ struct SampleDetails {
 
 workflow ww_leukemia {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Emma Bishop",
+            email: "ebishop@fredhutch.org"
+        },
+        {
+            name: "Sitapriya Moorthi",
+            email: "smoorthi@fredhutch.org"
+        }
+    ]
     description: "Consensus variant calling workflow for human panel/PCR-based targeted DNA sequencing with focus on leukemia analysis - Refactored with WILDS modules"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-leukemia/ww-leukemia.wdl"
     outputs: {

--- a/pipelines/ww-saturation/ww-saturation.wdl
+++ b/pipelines/ww-saturation/ww-saturation.wdl
@@ -11,8 +11,20 @@ struct SaturationSample {
 
 workflow saturation_mutagenesis {
     meta {
-        author: "Taylor Firman"
-        email: "tfirman@fredhutch.org"
+        author: [
+            {
+                name: "Taylor Firman",
+                email: "tfirman@fredhutch.org"
+            },
+            {
+                name: "Sitapriya Moorthi",
+                email: "smoorthi@fredhutch.org"
+            },
+            {
+                name: "Siobhan O'Brien",
+                email: "sobrien2@fredhutch.org"
+            }
+        ]
         description: "WDL workflow to analyze saturation mutagenesis data using BWA alignment and GATK AnalyzeSaturationMutagenesis"
         url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-saturation/ww-saturation.wdl"
         outputs: {

--- a/pipelines/ww-sra-salmon/ww-sra-salmon.wdl
+++ b/pipelines/ww-sra-salmon/ww-sra-salmon.wdl
@@ -11,8 +11,24 @@ struct SalmonSample {
 
 workflow sra_salmon {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Emma Bishop",
+            email: "ebishop@fredhutch.org"
+        },
+        {
+            name: "Alice Berger",
+            email: "aberger@fredhutch.org"
+        },
+        {
+            name: "Janet Young",
+            email: "jyoung@fredhutch.org"
+        }
+    ]
     description: "WDL workflow to download raw sequencing data from SRA and quantify using Salmon quasi-mapping"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-salmon/ww-sra-salmon.wdl"
     outputs: {

--- a/pipelines/ww-sra-star/ww-sra-star.wdl
+++ b/pipelines/ww-sra-star/ww-sra-star.wdl
@@ -11,8 +11,20 @@ struct RefGenome {
 
 workflow sra_star {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Alice Berger",
+            email: "aberger@fredhutch.org"
+        },
+        {
+            name: "Janet Young",
+            email: "jyoung@fredhutch.org"
+        }
+    ]
     description: "WDL workflow to download raw sequencing data from SRA and align using STAR two-pass methodology"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-star/ww-sra-star.wdl"
     outputs: {

--- a/pipelines/ww-star-deseq2/README.md
+++ b/pipelines/ww-star-deseq2/README.md
@@ -266,6 +266,10 @@ This pipeline can be extended by:
 - **ww-sra-star pipeline**: SRA download to alignment pipeline
 - **Other pipelines**: Additional integration examples
 
+## Acknowledgments
+
+Special thanks to [Ethan Bouvet](https://github.com/EthanB-no) for helping test this pipeline in realistic settings. Thank you for your contributions!
+
 ## Support
 
 For questions, bugs, and/or feature requests, reach out to the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).

--- a/pipelines/ww-star-deseq2/ww-star-deseq2.wdl
+++ b/pipelines/ww-star-deseq2/ww-star-deseq2.wdl
@@ -20,8 +20,20 @@ struct RefGenome {
 
 workflow star_deseq2 {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Emma Bishop",
+            email: "ebishop@fredhutch.org"
+        },
+        {
+            name: "Ethan Bouvet",
+            email: "ebouvet@fredhutch.org"
+        }
+    ]
     description: "WDL workflow for RNA-seq alignment via STAR and DESeq2 differential expression analysis"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-star-deseq2/ww-star-deseq2.wdl"
     outputs: {


### PR DESCRIPTION
## Type of Change

- Documentation updates
- Other: Author metadata cleanup and Dockstore module registration

## Description

Updates author metadata across the repo to ensure proper attribution, registers all modules as Dockstore tools, and adds documentation about Dockstore and CITATION.cff maintenance.

**Author metadata updates:**
- **Pipelines**: Added missing co-authors to 7 pipeline WDL workflow `meta` blocks (using array-of-objects format) based on the `.dockstore.yml` author lists. Replaced the generic "WILDS Team" placeholder in `ww-leukemia` with the actual authors.
- **Modules**: Replaced all "WILDS Team" placeholder authors in module task `meta` blocks with the actual contributors (determined via `git blame`). Updated `ww-template` to use `"Your Name"` / `"your.email@fredhutch.org"` as a clearer placeholder for new module authors.

**Dockstore configuration:**
- Added a new `tools:` section to `.dockstore.yml` registering all 46 modules (excluding `ww-template`) as individual Dockstore tools with proper author info, descriptions, topics, auto-DOIs, and tag filters.
- Multi-author modules (`ww-gatk`, `ww-samtools`, `ww-testdata`) list all contributors found in their WDL task `meta` blocks.

**Documentation:**
- Added "Citation and Attribution" section to `CONTRIBUTING.md` explaining `CITATION.cff` maintenance and when/how to update it.
- Added "Dockstore Registration" section to `CONTRIBUTING.md` with YAML templates for registering new modules and pipelines.
- Added "Dockstore" section to `README.md` describing the library's Dockstore presence.

## Testing

These changes are metadata-only (WDL `meta` blocks, `.dockstore.yml`, and documentation) — no functional code was modified. Verified that no "WILDS Team" placeholders remain in any `.wdl` files and that all module/pipeline paths in `.dockstore.yml` reference existing files.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs-preview` to check documentation rendering (if applicable)

## Additional Context

- Pipeline multi-author `meta` blocks use an array-of-objects format: `author: [{name: "...", email: "..."}, ...]`. Single-author pipelines retain the original string format.
- The `ww-template` module now uses `"Your Name"` / `"your.email@fredhutch.org"` instead of "WILDS Team" to make it clearer that new contributors should replace the placeholder.
- Author info is maintained in three places: `CITATION.cff`, `.dockstore.yml`, and WDL `meta` blocks — the new CONTRIBUTING.md sections document how to keep these in sync.