### PR TITLE
Adding initial draft of Clair3 WILDS WDL module

### DIFF
--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -164,9 +164,11 @@ java -jar cromwell.jar run testrun.wdl
 ### Automatic Demo Mode
 
 The test workflow automatically:
-1. Downloads reference genome (chr1) and BAM test data using `ww-testdata`
-2. Runs Clair3 variant calling on the test sample using the Illumina model (pileup-only mode for speed)
-3. Outputs a VCF file with germline variant calls
+1. Downloads reference genome (first 5 Mb of chr1) and BAM test data using `ww-testdata`
+2. Runs Clair3 variant calling in two modes using the Illumina model:
+   - **Pileup-only mode**: Fast variant calling producing a VCF
+   - **Full-alignment mode with gVCF**: Complete pipeline producing both VCF and gVCF outputs
+3. Outputs VCF and gVCF files with germline variant calls
 
 ## Docker Container
 

--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -1,0 +1,186 @@
+# ww-clair3 Module
+
+[![Project Status: Prototype – Useable, some support, open to feedback, unstable API.](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for [Clair3](https://github.com/HKU-BAL/Clair3), a deep learning-based germline small variant caller. Clair3 uses a two-stage pileup and full-alignment approach for high-accuracy SNP and indel calling from Oxford Nanopore (ONT), PacBio HiFi, and Illumina sequencing data.
+
+## Overview
+
+This module wraps Clair3's variant calling functionality for use in WILDS WDL workflows. Clair3 combines a fast pileup model for initial candidate identification with a more thorough full-alignment model for difficult regions, achieving high accuracy across different sequencing platforms and coverage depths.
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and follows the standard WILDS module structure:
+
+- **Main WDL file**: `ww-clair3.wdl` - Contains task definitions for the module
+- **Test workflow**: `testrun.wdl` - Demonstration workflow for testing and examples
+- **Documentation**: This README with usage examples and parameter descriptions
+
+## Available Tasks
+
+### `run_clair3`
+
+Runs Clair3 to call germline variants from aligned reads using deep learning pileup and full-alignment models.
+
+**Inputs:**
+- `sample_name` (String): Name identifier for the sample
+- `input_bam` (File): Aligned reads in BAM format (must be sorted and indexed)
+- `input_bam_index` (File): Index file for the input BAM
+- `ref_fasta` (File): Reference genome FASTA file (must be indexed with .fai)
+- `ref_fasta_index` (File): Index file for the reference FASTA
+- `platform` (String, default="ont"): Sequencing platform: `ont`, `hifi`, or `ilmn`
+- `model_path` (String, default="/opt/models/ont"): Path to Clair3 model directory
+- `gvcf_enabled` (Boolean, default=false): Whether to produce a gVCF file for joint genotyping
+- `bed_file` (File?, optional): BED file to restrict variant calling to specific regions
+- `ctg_name` (String?, optional): Contig/chromosome name to restrict calling
+- `include_all_ctgs` (Boolean, default=false): Call on all contigs (required for non-human species)
+- `cpu_cores` (Int, default=8): Number of CPU cores allocated for the task
+- `memory_gb` (Int, default=32): Memory allocated for the task in GB
+
+**Outputs:**
+- `output_vcf` (File): VCF file containing merged variant calls
+- `output_vcf_index` (File): Index file for the output VCF
+- `output_gvcf` (Array[File]): gVCF file for joint genotyping (empty when gvcf_enabled is false)
+- `output_gvcf_index` (Array[File]): gVCF index file (empty when gvcf_enabled is false)
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-clair3/ww-clair3.wdl" as clair3_tasks
+
+workflow my_variant_calling {
+  input {
+    String sample_name
+    File input_bam
+    File input_bam_index
+    File ref_fasta
+    File ref_fasta_index
+  }
+
+  call clair3_tasks.run_clair3 { input:
+    sample_name = sample_name,
+    input_bam = input_bam,
+    input_bam_index = input_bam_index,
+    ref_fasta = ref_fasta,
+    ref_fasta_index = ref_fasta_index,
+    platform = "ont"
+  }
+
+  output {
+    File variants = run_clair3.output_vcf
+    File variants_index = run_clair3.output_vcf_index
+  }
+}
+```
+
+### Advanced Usage Examples
+
+**PacBio HiFi variant calling with gVCF output:**
+```wdl
+call clair3_tasks.run_clair3 { input:
+  sample_name = "my_sample",
+  input_bam = hifi_bam,
+  input_bam_index = hifi_bam_index,
+  ref_fasta = reference_fasta,
+  ref_fasta_index = reference_fasta_index,
+  platform = "hifi",
+  model_path = "/opt/models/hifi",
+  gvcf_enabled = true,
+  cpu_cores = 16,
+  memory_gb = 64
+}
+```
+
+**Targeted variant calling with BED regions:**
+```wdl
+call clair3_tasks.run_clair3 { input:
+  sample_name = "targeted_sample",
+  input_bam = targeted_bam,
+  input_bam_index = targeted_bam_index,
+  ref_fasta = reference_fasta,
+  ref_fasta_index = reference_fasta_index,
+  platform = "ilmn",
+  model_path = "/opt/models/ilmn",
+  bed_file = target_regions_bed
+}
+```
+
+### Integration Examples
+
+This module integrates seamlessly with other WILDS components:
+- **ww-testdata**: Automatic provisioning of test BAM and reference data
+- **ww-gatk**: Can be used alongside GATK for comparison variant calling pipelines
+- **ww-deepvariant**: Alternative variant caller for benchmarking
+
+## Testing the Module
+
+The module includes a test workflow (`testrun.wdl`) that can be run independently:
+
+```bash
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl --entrypoint clair3_example
+
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+```
+
+### Automatic Demo Mode
+
+The test workflow automatically:
+1. Downloads reference genome (chr1) and BAM test data using `ww-testdata`
+2. Runs Clair3 variant calling on each test sample using the Illumina model
+3. Outputs VCF files with germline variant calls
+
+## Docker Container
+
+This module uses the `getwilds/clair3:2.0.0` container image, which includes:
+- Clair3 v2.0.0 (PyTorch-based)
+- Pre-trained models for ONT, PacBio HiFi, and Illumina at `/opt/models/`
+- Samtools and other required dependencies
+
+## Citation
+
+> Clair3: Symphonizing pileup and full-alignment for deep learning-based long-read variant calling
+> Zheng Z, Li S, Su J, Leung AW, Lam TW, Luo R.
+> Nature Computational Science (2022)
+> DOI: https://doi.org/10.1038/s43588-022-00387-x
+
+## Parameters and Resource Requirements
+
+### Default Resources
+- **CPU**: 8 cores
+- **Memory**: 32 GB
+- **Runtime**: Varies by data size and platform; typically 30-60 minutes for 30x WGS
+
+### Resource Scaling
+- `cpu_cores`: Clair3 parallelizes by splitting chromosomes into chunks (4 threads each)
+- `memory_gb`: Increase for high-coverage samples or when calling on many contigs
+- For targeted sequencing with BED files, lower resources may be sufficient
+
+## Contributing
+
+To improve this module or report issues:
+1. Fork the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library)
+2. Make your changes following WILDS conventions
+3. Test thoroughly with the demonstration workflow
+4. Submit a pull request with detailed documentation
+
+## Support and Feedback
+
+For questions about this module or to report issues:
+- Open an issue in the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library/issues)
+- Contact the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org
+- See the library's [Contributor Guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for detailed guidelines
+
+## Related Resources
+
+- **[Clair3 GitHub](https://github.com/HKU-BAL/Clair3)**: Official Clair3 repository with documentation
+- **[WILDS Docker Library](https://github.com/getwilds/wilds-docker-library)**: Container images used by WDL workflows
+- **[WILDS Documentation](https://getwilds.org/)**: Comprehensive guides and best practices
+- **[WDL Specification](https://openwdl.org/)**: Official WDL language documentation

--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -35,6 +35,7 @@ Runs Clair3 to call germline variants from aligned reads using deep learning pil
 - `bed_file` (File?, optional): BED file to restrict variant calling to specific regions
 - `ctg_name` (String?, optional): Contig/chromosome name to restrict calling
 - `include_all_ctgs` (Boolean, default=false): Call on all contigs (required for non-human species)
+- `pileup_only` (Boolean, default=false): Use only the pileup model for faster variant calling (skips full-alignment stage)
 - `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for Clair3 inference
 - `cpu_cores` (Int, default=8): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=32): Memory allocated for the task in GB
@@ -150,7 +151,7 @@ java -jar cromwell.jar run testrun.wdl
 
 The test workflow automatically:
 1. Downloads reference genome (chr1) and BAM test data using `ww-testdata`
-2. Runs Clair3 variant calling on the test sample using the Illumina model
+2. Runs Clair3 variant calling on the test sample using the Illumina model (pileup-only mode for speed)
 3. Outputs a VCF file with germline variant calls
 
 ## Docker Container

--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -50,7 +50,7 @@ Runs Clair3 to call germline variants from aligned reads using deep learning pil
 - `ctg_name` (String?, optional): Contig/chromosome name to restrict calling
 - `include_all_ctgs` (Boolean, default=false): Call on all contigs (required for non-human species)
 - `pileup_only` (Boolean, default=false): Use only the pileup model for faster variant calling (skips full-alignment stage)
-- `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for Clair3 inference
+- `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for Clair3 inference. Note: the `gpus` runtime attribute is specified as a string (e.g., `"1"`) rather than an integer, as required by Fred Hutch PROOF/Cromwell configuration, but can be adjusted as necessary.
 - `cpu_cores` (Int, default=8): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=32): Memory allocated for the task in GB
 

--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -35,6 +35,7 @@ Runs Clair3 to call germline variants from aligned reads using deep learning pil
 - `bed_file` (File?, optional): BED file to restrict variant calling to specific regions
 - `ctg_name` (String?, optional): Contig/chromosome name to restrict calling
 - `include_all_ctgs` (Boolean, default=false): Call on all contigs (required for non-human species)
+- `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for Clair3 inference
 - `cpu_cores` (Int, default=8): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=32): Memory allocated for the task in GB
 
@@ -94,6 +95,21 @@ call clair3_tasks.run_clair3 { input:
 }
 ```
 
+**GPU-accelerated variant calling:**
+```wdl
+call clair3_tasks.run_clair3 { input:
+  sample_name = "gpu_sample",
+  input_bam = ont_bam,
+  input_bam_index = ont_bam_index,
+  ref_fasta = reference_fasta,
+  ref_fasta_index = reference_fasta_index,
+  platform = "ont",
+  gpu_enabled = true,
+  cpu_cores = 8,
+  memory_gb = 32
+}
+```
+
 **Targeted variant calling with BED regions:**
 ```wdl
 call clair3_tasks.run_clair3 { input:
@@ -134,8 +150,8 @@ java -jar cromwell.jar run testrun.wdl
 
 The test workflow automatically:
 1. Downloads reference genome (chr1) and BAM test data using `ww-testdata`
-2. Runs Clair3 variant calling on each test sample using the Illumina model
-3. Outputs VCF files with germline variant calls
+2. Runs Clair3 variant calling on the test sample using the Illumina model
+3. Outputs a VCF file with germline variant calls
 
 ## Docker Container
 

--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -30,7 +30,21 @@ Runs Clair3 to call germline variants from aligned reads using deep learning pil
 - `ref_fasta` (File): Reference genome FASTA file (must be indexed with .fai)
 - `ref_fasta_index` (File): Index file for the reference FASTA
 - `platform` (String, default="ont"): Sequencing platform: `ont`, `hifi`, or `ilmn`
-- `model_path` (String, default="/opt/models/ont"): Path to Clair3 model directory
+- `model_path` (String, default="/opt/models/ont"): Path to Clair3 model directory. Available models:
+  - `/opt/models/ont` - Oxford Nanopore (default)
+  - `/opt/models/ont_guppy5` - ONT Guppy5 basecaller
+  - `/opt/models/r941_prom_hac_g360+g422` - ONT R9.4.1 PromethION HAC
+  - `/opt/models/r941_prom_sup_g5014` - ONT R9.4.1 PromethION SUP
+  - `/opt/models/r1041_e82_400bps_hac_v410` - ONT R10.4.1 HAC v4.1.0
+  - `/opt/models/r1041_e82_400bps_hac_v500` - ONT R10.4.1 HAC v5.0.0
+  - `/opt/models/r1041_e82_400bps_hac_with_mv` - ONT R10.4.1 HAC with modified bases
+  - `/opt/models/r1041_e82_400bps_sup_v410` - ONT R10.4.1 SUP v4.1.0
+  - `/opt/models/r1041_e82_400bps_sup_v430_bacteria_finetuned` - ONT R10.4.1 SUP bacteria-finetuned
+  - `/opt/models/r1041_e82_400bps_sup_v500` - ONT R10.4.1 SUP v5.0.0
+  - `/opt/models/hifi` - PacBio HiFi (default HiFi model)
+  - `/opt/models/hifi_revio` - PacBio HiFi Revio
+  - `/opt/models/hifi_sequel2` - PacBio HiFi Sequel II
+  - `/opt/models/ilmn` - Illumina
 - `gvcf_enabled` (Boolean, default=false): Whether to produce a gVCF file for joint genotyping
 - `bed_file` (File?, optional): BED file to restrict variant calling to specific regions
 - `ctg_name` (String?, optional): Contig/chromosome name to restrict calling

--- a/modules/ww-clair3/testrun.wdl
+++ b/modules/ww-clair3/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module in question as well as the testdata module for automatic demo functionality
-import "ww-clair3.wdl" as ww_clair3
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-clair3/modules/ww-clair3/ww-clair3.wdl" as ww_clair3
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-clair3/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-clair3/testrun.wdl
+++ b/modules/ww-clair3/testrun.wdl
@@ -1,0 +1,63 @@
+version 1.0
+
+# Import module in question as well as the testdata module for automatic demo functionality
+import "ww-clair3.wdl" as ww_clair3
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+
+struct Clair3Sample {
+    String name
+    File bam
+    File bai
+}
+
+#### TEST WORKFLOW DEFINITION ####
+
+workflow clair3_example {
+  # Download reference genome and BAM test data
+  call ww_testdata.download_ref_data as download_reference { input:
+    chromo = "chr1"
+  }
+
+  call ww_testdata.download_bam_data as download_bam_1 { input:
+    filename = "sample1.bam"
+  }
+
+  call ww_testdata.download_bam_data as download_bam_2 { input:
+    filename = "sample2.bam"
+  }
+
+  # Create samples array using test data
+  Array[Clair3Sample] samples = [
+    {
+      "name": "sample1",
+      "bam": download_bam_1.bam,
+      "bai": download_bam_1.bai
+    },
+    {
+      "name": "sample2",
+      "bam": download_bam_2.bam,
+      "bai": download_bam_2.bai
+    }
+  ]
+
+  # Call Clair3 on each sample using Illumina model (test data is Illumina short-read)
+  scatter (sample in samples) {
+    call ww_clair3.run_clair3 { input:
+      sample_name = sample.name,
+      input_bam = sample.bam,
+      input_bam_index = sample.bai,
+      ref_fasta = download_reference.fasta,
+      ref_fasta_index = download_reference.fasta_index,
+      platform = "ilmn",
+      model_path = "/opt/models/ilmn",
+      ctg_name = "chr1",
+      cpu_cores = 2,
+      memory_gb = 8
+    }
+  }
+
+  output {
+    Array[File] output_vcfs = run_clair3.output_vcf
+    Array[File] output_vcf_indices = run_clair3.output_vcf_index
+  }
+}

--- a/modules/ww-clair3/testrun.wdl
+++ b/modules/ww-clair3/testrun.wdl
@@ -31,8 +31,28 @@ workflow clair3_example {
     memory_gb = 8
   }
 
+  # Test gVCF output functionality
+  call ww_clair3.run_clair3 as run_clair3_gvcf { input:
+    sample_name = "sample1_gvcf",
+    input_bam = download_bam.bam,
+    input_bam_index = download_bam.bai,
+    ref_fasta = download_reference.fasta,
+    ref_fasta_index = download_reference.fasta_index,
+    platform = "ilmn",
+    model_path = "/opt/models/ilmn",
+    ctg_name = "chr1",
+    pileup_only = true,
+    gvcf_enabled = true,
+    cpu_cores = 2,
+    memory_gb = 8
+  }
+
   output {
     File output_vcf = run_clair3.output_vcf
     File output_vcf_index = run_clair3.output_vcf_index
+    File output_gvcf_vcf = run_clair3_gvcf.output_vcf
+    File output_gvcf_vcf_index = run_clair3_gvcf.output_vcf_index
+    Array[File] output_gvcf = run_clair3_gvcf.output_gvcf
+    Array[File] output_gvcf_index = run_clair3_gvcf.output_gvcf_index
   }
 }

--- a/modules/ww-clair3/testrun.wdl
+++ b/modules/ww-clair3/testrun.wdl
@@ -4,12 +4,6 @@ version 1.0
 import "ww-clair3.wdl" as ww_clair3
 import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
-struct Clair3Sample {
-    String name
-    File bam
-    File bai
-}
-
 #### TEST WORKFLOW DEFINITION ####
 
 workflow clair3_example {
@@ -18,46 +12,26 @@ workflow clair3_example {
     chromo = "chr1"
   }
 
-  call ww_testdata.download_bam_data as download_bam_1 { input:
+  call ww_testdata.download_bam_data as download_bam { input:
     filename = "sample1.bam"
   }
 
-  call ww_testdata.download_bam_data as download_bam_2 { input:
-    filename = "sample2.bam"
-  }
-
-  # Create samples array using test data
-  Array[Clair3Sample] samples = [
-    {
-      "name": "sample1",
-      "bam": download_bam_1.bam,
-      "bai": download_bam_1.bai
-    },
-    {
-      "name": "sample2",
-      "bam": download_bam_2.bam,
-      "bai": download_bam_2.bai
-    }
-  ]
-
-  # Call Clair3 on each sample using Illumina model (test data is Illumina short-read)
-  scatter (sample in samples) {
-    call ww_clair3.run_clair3 { input:
-      sample_name = sample.name,
-      input_bam = sample.bam,
-      input_bam_index = sample.bai,
-      ref_fasta = download_reference.fasta,
-      ref_fasta_index = download_reference.fasta_index,
-      platform = "ilmn",
-      model_path = "/opt/models/ilmn",
-      ctg_name = "chr1",
-      cpu_cores = 2,
-      memory_gb = 8
-    }
+  # Call Clair3 using Illumina model (test data is Illumina short-read)
+  call ww_clair3.run_clair3 { input:
+    sample_name = "sample1",
+    input_bam = download_bam.bam,
+    input_bam_index = download_bam.bai,
+    ref_fasta = download_reference.fasta,
+    ref_fasta_index = download_reference.fasta_index,
+    platform = "ilmn",
+    model_path = "/opt/models/ilmn",
+    ctg_name = "chr1",
+    cpu_cores = 2,
+    memory_gb = 8
   }
 
   output {
-    Array[File] output_vcfs = run_clair3.output_vcf
-    Array[File] output_vcf_indices = run_clair3.output_vcf_index
+    File output_vcf = run_clair3.output_vcf
+    File output_vcf_index = run_clair3.output_vcf_index
   }
 }

--- a/modules/ww-clair3/testrun.wdl
+++ b/modules/ww-clair3/testrun.wdl
@@ -7,16 +7,17 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 #### TEST WORKFLOW DEFINITION ####
 
 workflow clair3_example {
-  # Download reference genome and BAM test data
+  # Download reference genome (restricted to first 5 Mb for faster testing) and BAM test data
   call ww_testdata.download_ref_data as download_reference { input:
-    chromo = "chr1"
+    chromo = "chr1",
+    region = "1-5000000"
   }
 
   call ww_testdata.download_bam_data as download_bam { input:
     filename = "sample1.bam"
   }
 
-  # Call Clair3 using Illumina model (test data is Illumina short-read)
+  # Call Clair3 using Illumina model with pileup-only for speed (test data is Illumina short-read)
   call ww_clair3.run_clair3 { input:
     sample_name = "sample1",
     input_bam = download_bam.bam,
@@ -25,13 +26,13 @@ workflow clair3_example {
     ref_fasta_index = download_reference.fasta_index,
     platform = "ilmn",
     model_path = "/opt/models/ilmn",
-    ctg_name = "chr1",
+    bed_file = download_reference.bed,
     pileup_only = true,
     cpu_cores = 2,
     memory_gb = 8
   }
 
-  # Test gVCF output functionality
+  # Test gVCF output with full-alignment mode (pileup_only doesn't support gVCF)
   call ww_clair3.run_clair3 as run_clair3_gvcf { input:
     sample_name = "sample1_gvcf",
     input_bam = download_bam.bam,
@@ -40,8 +41,7 @@ workflow clair3_example {
     ref_fasta_index = download_reference.fasta_index,
     platform = "ilmn",
     model_path = "/opt/models/ilmn",
-    ctg_name = "chr1",
-    pileup_only = true,
+    bed_file = download_reference.bed,
     gvcf_enabled = true,
     cpu_cores = 2,
     memory_gb = 8

--- a/modules/ww-clair3/testrun.wdl
+++ b/modules/ww-clair3/testrun.wdl
@@ -26,6 +26,7 @@ workflow clair3_example {
     platform = "ilmn",
     model_path = "/opt/models/ilmn",
     ctg_name = "chr1",
+    pileup_only = true,
     cpu_cores = 2,
     memory_gb = 8
   }

--- a/modules/ww-clair3/ww-clair3.wdl
+++ b/modules/ww-clair3/ww-clair3.wdl
@@ -33,6 +33,7 @@ task run_clair3 {
     bed_file: "Optional BED file to restrict variant calling to specific regions"
     ctg_name: "Optional contig/chromosome name to restrict calling"
     include_all_ctgs: "Call variants on all contigs (required for non-human species, default calls chr1-22,X,Y only)"
+    pileup_only: "Use only the pileup model for faster variant calling (skips full-alignment stage)"
     gpu_enabled: "Enable GPU acceleration for Clair3 inference (requests GPU in runtime)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
@@ -50,6 +51,7 @@ task run_clair3 {
     File? bed_file
     String? ctg_name
     Boolean include_all_ctgs = false
+    Boolean pileup_only = false
     Boolean gpu_enabled = false
     Int cpu_cores = 8
     Int memory_gb = 32
@@ -70,6 +72,7 @@ task run_clair3 {
       ~{if defined(bed_file) then "--bed_fn=~{bed_file}" else ""} \
       ~{if defined(ctg_name) then "--ctg_name=~{ctg_name}" else ""} \
       ~{if include_all_ctgs then "--include_all_ctgs" else ""} \
+      ~{if pileup_only then "--pileup_only" else ""} \
       ~{if gpu_enabled then "--use_gpu" else ""}
 
     # Move final outputs to working directory with sample-specific names

--- a/modules/ww-clair3/ww-clair3.wdl
+++ b/modules/ww-clair3/ww-clair3.wdl
@@ -1,0 +1,98 @@
+## WILDS WDL module for Clair3 variant calling.
+## A deep learning-based germline small variant caller for long-read
+## sequencing data. Uses a two-stage pileup and full-alignment approach
+## for high-accuracy SNP and indel calling from ONT, PacBio, and Illumina reads.
+
+version 1.0
+
+#### TASK DEFINITIONS ####
+
+task run_clair3 {
+  meta {
+    author: "WILDS Team"
+    email: "wilds@fredhutch.org"
+    description: "Runs Clair3 to call germline variants from aligned reads using deep learning pileup and full-alignment models"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-clair3/ww-clair3.wdl"
+    outputs: {
+        output_vcf: "VCF file containing merged variant calls from pileup and full-alignment models",
+        output_vcf_index: "Index file for the output VCF",
+        output_gvcf: "Array containing the gVCF file for downstream joint genotyping (empty when gvcf_enabled is false)",
+        output_gvcf_index: "Array containing the gVCF index file (empty when gvcf_enabled is false)"
+    }
+  }
+
+  parameter_meta {
+    sample_name: "Name identifier for the sample"
+    input_bam: "Aligned reads in BAM format (must be sorted and indexed)"
+    input_bam_index: "Index file for the input BAM"
+    ref_fasta: "Reference genome FASTA file (must be indexed with .fai)"
+    ref_fasta_index: "Index file for the reference FASTA"
+    platform: "Sequencing platform: ont, hifi, or ilmn"
+    model_path: "Path to Clair3 model directory (default uses bundled ONT model)"
+    gvcf_enabled: "Whether to also produce a gVCF file for downstream joint genotyping"
+    bed_file: "Optional BED file to restrict variant calling to specific regions"
+    ctg_name: "Optional contig/chromosome name to restrict calling"
+    include_all_ctgs: "Call variants on all contigs (required for non-human species, default calls chr1-22,X,Y only)"
+    gpu_enabled: "Enable GPU acceleration for Clair3 inference (requests GPU in runtime)"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    String sample_name
+    File input_bam
+    File input_bam_index
+    File ref_fasta
+    File ref_fasta_index
+    String platform = "ont"
+    String model_path = "/opt/models/ont"
+    Boolean gvcf_enabled = false
+    File? bed_file
+    String? ctg_name
+    Boolean include_all_ctgs = false
+    Boolean gpu_enabled = false
+    Int cpu_cores = 8
+    Int memory_gb = 32
+  }
+
+  command <<<
+    set -eo pipefail
+
+    /opt/bin/run_clair3.sh \
+      --bam_fn=~{input_bam} \
+      --ref_fn=~{ref_fasta} \
+      --output=clair3_output \
+      --threads=~{cpu_cores} \
+      --platform=~{platform} \
+      --model_path=~{model_path} \
+      --sample_name=~{sample_name} \
+      ~{if gvcf_enabled then "--gvcf" else ""} \
+      ~{if defined(bed_file) then "--bed_fn=~{bed_file}" else ""} \
+      ~{if defined(ctg_name) then "--ctg_name=~{ctg_name}" else ""} \
+      ~{if include_all_ctgs then "--include_all_ctgs" else ""} \
+      ~{if gpu_enabled then "--use_gpu" else ""}
+
+    # Move final outputs to working directory with sample-specific names
+    cp clair3_output/merge_output.vcf.gz "~{sample_name}.clair3.vcf.gz"
+    cp clair3_output/merge_output.vcf.gz.tbi "~{sample_name}.clair3.vcf.gz.tbi"
+
+    if [ "~{gvcf_enabled}" = "true" ]; then
+      cp clair3_output/merge_output.gvcf.gz "~{sample_name}.clair3.g.vcf.gz"
+      cp clair3_output/merge_output.gvcf.gz.tbi "~{sample_name}.clair3.g.vcf.gz.tbi"
+    fi
+  >>>
+
+  output {
+    File output_vcf = "~{sample_name}.clair3.vcf.gz"
+    File output_vcf_index = "~{sample_name}.clair3.vcf.gz.tbi"
+    Array[File] output_gvcf = glob("*.g.vcf.gz")
+    Array[File] output_gvcf_index = glob("*.g.vcf.gz.tbi")
+  }
+
+  runtime {
+    docker: "getwilds/clair3:2.0.0"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+    gpus: if gpu_enabled then "1" else "0"
+  }
+}

--- a/modules/ww-clair3/ww-clair3.wdl
+++ b/modules/ww-clair3/ww-clair3.wdl
@@ -76,8 +76,14 @@ task run_clair3 {
       ~{if gpu_enabled then "--use_gpu" else ""}
 
     # Move final outputs to working directory with sample-specific names
-    cp clair3_output/merge_output.vcf.gz "~{sample_name}.clair3.vcf.gz"
-    cp clair3_output/merge_output.vcf.gz.tbi "~{sample_name}.clair3.vcf.gz.tbi"
+    # pileup_only mode outputs pileup.vcf.gz; full mode outputs merge_output.vcf.gz
+    if [ "~{pileup_only}" = "true" ]; then
+      cp clair3_output/pileup.vcf.gz "~{sample_name}.clair3.vcf.gz"
+      cp clair3_output/pileup.vcf.gz.tbi "~{sample_name}.clair3.vcf.gz.tbi"
+    else
+      cp clair3_output/merge_output.vcf.gz "~{sample_name}.clair3.vcf.gz"
+      cp clair3_output/merge_output.vcf.gz.tbi "~{sample_name}.clair3.vcf.gz.tbi"
+    fi
 
     if [ "~{gvcf_enabled}" = "true" ]; then
       cp clair3_output/merge_output.gvcf.gz "~{sample_name}.clair3.g.vcf.gz"

--- a/modules/ww-clair3/ww-clair3.wdl
+++ b/modules/ww-clair3/ww-clair3.wdl
@@ -9,8 +9,8 @@ version 1.0
 
 task run_clair3 {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Runs Clair3 to call germline variants from aligned reads using deep learning pileup and full-alignment models"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-clair3/ww-clair3.wdl"
     outputs: {
@@ -45,7 +45,7 @@ task run_clair3 {
     File input_bam_index
     File ref_fasta
     File ref_fasta_index
-    String platform = "ont"
+    String platform = "ilmn"
     String model_path = "/opt/models/ont"
     Boolean gvcf_enabled = false
     File? bed_file


### PR DESCRIPTION
## Type of Change

- New module

## Description

Adds a new `ww-clair3` module wrapping [Clair3](https://github.com/HKU-BAL/Clair3), a deep learning-based germline small variant caller from HKU-BAL. Clair3 uses a two-stage pileup and full-alignment approach for high-accuracy SNP and indel calling from ONT, PacBio HiFi, and Illumina sequencing data.

Key features of the module:
- Supports all three sequencing platforms (`ont`, `hifi`, `ilmn`) with platform-specific pre-trained models bundled in the Docker image
- Optional gVCF output for downstream joint genotyping
- GPU acceleration support via `gpu_enabled` parameter
- Region restriction via BED file or contig name

## Related Issue

- Fixes #162 

## Testing

**How did you test these changes?**
Ran linting with `make lint NAME=ww-clair3` (sprocket, miniwdl, WOMtool all pass). Attempting test run currently...

**What workflow engine did you use?**
Sprocket

**Did the tests pass?**
Linting passes on all three engines. Full test run in progress...

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [ ] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- Uses the newly built `getwilds/clair3:2.0.0` Docker image which bundles all 14 pre-trained models at `/opt/models/` (ONT r9/r10 chemistries, PacBio HiFi Revio/Sequel II, Illumina, and bacteria-finetuned)
- Test workflow uses `platform = "ilmn"` since the `ww-testdata` BAM files are Illumina short-read data
- Dockstore registration in `.dockstore.yml` still needed