### PR TITLE
Fixing ww-testdata import URL

### DIFF
--- a/modules/ww-testdata/testrun.wdl
+++ b/modules/ww-testdata/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/glimpse2-multichromo/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow testdata_example {
   # Pull down reference genome and index files for chr1

--- a/pipelines/ww-imputation/README.md
+++ b/pipelines/ww-imputation/README.md
@@ -156,7 +156,7 @@ Note: `input_crams`, `input_cram_indices`, and `sample_ids` must be parallel arr
 | `output_prefix` | Prefix for output file names | String | "imputed" |
 | `output_format` | Output format (`bcf` or `vcf.gz`) | String | "bcf" |
 | `impute_reference_only_variants` | Only impute variants in reference panel | Boolean | false |
-| `window_size_cm` | Chunk window size in centiMorgans | Float | 4.0 |
+| `window_size_cm` | Chunk window size in centiMorgans | Float | 8.0 |
 | `buffer_size_cm` | Chunk buffer size in centiMorgans | Float | 0.1 |
 | `n_burnin` | MCMC burn-in iterations | Int | 5 |
 | `n_main` | MCMC main iterations | Int | 15 |
@@ -248,6 +248,16 @@ Genetic maps can be downloaded from:
 >   ```
 >   Cromwell will attempt each strategy in order, falling back to copy only if linking
 >   is not possible.
+
+### Apptainer Compatibility
+
+> **Note**: Older versions of Apptainer (specifically 1.1.x) have a known bug where
+> container execution fails with `FATAL: aborting failed to close file descriptor: bad
+> file descriptor` when a large number of input files are bind-mounted into the container.
+> This can affect the ligation step when processing chromosomes that produce many chunks
+> (e.g., chr1 with ~67 chunks at `window_size_cm = 4.0`). The default `window_size_cm`
+> has been increased from 4.0 to 8.0 cM to reduce chunk counts and avoid this issue.
+> Upgrading to Apptainer 1.3+ is recommended if available on your system.
 
 ### Scaling
 - All samples are phased jointly per chunk (leveraging GLIMPSE2's multi-sample mode)

--- a/pipelines/ww-imputation/inputs.json
+++ b/pipelines/ww-imputation/inputs.json
@@ -24,7 +24,7 @@
   "imputation.output_prefix": "imputed",
   "imputation.output_format": "bcf",
   "imputation.impute_reference_only_variants": false,
-  "imputation.window_size_cm": 4.0,
+  "imputation.window_size_cm": 8.0,
   "imputation.buffer_size_cm": 0.1,
   "imputation.n_burnin": 5,
   "imputation.n_main": 15,

--- a/pipelines/ww-imputation/ww-imputation.wdl
+++ b/pipelines/ww-imputation/ww-imputation.wdl
@@ -77,7 +77,7 @@ workflow imputation {
 
     # Imputation parameters
     Boolean impute_reference_only_variants = false
-    Float window_size_cm = 4.0
+    Float window_size_cm = 8.0
     Float buffer_size_cm = 0.1
     Int n_burnin = 5
     Int n_main = 15


### PR DESCRIPTION
## Type of Change

- Other: switching import URL's back to `main`

## Description

- No functional change, just switching back ww-testdata import URL's to the `main` branch.
- Updating window size default to 8cM based on testing, but very minor.
- See GitHub Action test runs below just in case.