### PR TITLE
Adding initial version of ViennaRNA WILDS WDL module

### DIFF
--- a/modules/ww-viennarna/README.md
+++ b/modules/ww-viennarna/README.md
@@ -1,0 +1,198 @@
+# ww-viennarna Module
+
+[![Project Status: Prototype – Useable, some support, open to feedback, unstable API.](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for RNA secondary structure prediction and analysis using the [ViennaRNA](https://www.tbi.univie.ac.at/RNA/) package.
+
+## Overview
+
+This module wraps key tools from the ViennaRNA package for predicting and analyzing RNA secondary structures. ViennaRNA provides algorithms for minimum free energy (MFE) structure prediction, partition function computation, suboptimal structure enumeration, RNA-RNA interaction prediction, and local base pair probability calculations.
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and follows the standard WILDS module structure:
+
+- **Main WDL file**: `ww-viennarna.wdl` - Contains task definitions for ViennaRNA tools
+- **Test workflow**: `testrun.wdl` - Demonstration workflow for testing and examples
+- **Documentation**: This README with usage examples and parameter descriptions
+
+## Available Tasks
+
+### `rnafold`
+
+Predict minimum free energy (MFE) secondary structures and optionally compute partition function for RNA sequences.
+
+**Inputs:**
+- `input_fasta` (File): FASTA file containing RNA sequences to fold
+- `partition_function` (Boolean, default=false): Compute partition function and base pair probabilities
+- `no_lp` (Boolean, default=false): Disallow lonely base pairs
+- `temperature` (Float, default=37.0): Temperature in degrees Celsius
+- `extra_args` (String, default=""): Additional command-line arguments
+- `cpu_cores` (Int, default=1): Number of CPU cores
+- `memory_gb` (Int, default=4): Memory in GB
+
+**Outputs:**
+- `structure_output` (File): Predicted MFE structures in dot-bracket notation with free energies
+- `postscript_plots` (Array[File]): PostScript secondary structure plots
+
+### `rnasubopt`
+
+Enumerate suboptimal secondary structures within an energy range of the MFE.
+
+**Inputs:**
+- `input_fasta` (File): FASTA file containing an RNA sequence
+- `energy_range` (Float, default=5.0): Energy range above MFE in kcal/mol
+- `no_lp` (Boolean, default=false): Disallow lonely base pairs
+- `temperature` (Float, default=37.0): Temperature in degrees Celsius
+- `extra_args` (String, default=""): Additional command-line arguments
+- `cpu_cores` (Int, default=1): Number of CPU cores
+- `memory_gb` (Int, default=4): Memory in GB
+
+**Outputs:**
+- `subopt_output` (File): Suboptimal structures in dot-bracket notation with energies
+
+### `rnacofold`
+
+Predict the joint secondary structure and hybridization energy of two interacting RNA molecules.
+
+**Inputs:**
+- `sequence_a` (String): First RNA sequence
+- `sequence_b` (String): Second RNA sequence
+- `partition_function` (Boolean, default=false): Compute partition function
+- `temperature` (Float, default=37.0): Temperature in degrees Celsius
+- `extra_args` (String, default=""): Additional command-line arguments
+- `cpu_cores` (Int, default=1): Number of CPU cores
+- `memory_gb` (Int, default=4): Memory in GB
+
+**Outputs:**
+- `cofold_output` (File): Predicted joint MFE structure with interaction energy
+- `postscript_plots` (Array[File]): PostScript plots of the joint structure
+
+### `rnaplfold`
+
+Compute local base pair probabilities using a sliding window approach, useful for predicting accessibility of RNA regions.
+
+**Inputs:**
+- `input_fasta` (File): FASTA file containing RNA sequences
+- `window_size` (Int, default=70): Window size for sliding window
+- `span` (Int, default=40): Maximum base pair span
+- `unpaired_length` (Int, default=4): Length of unpaired region for accessibility
+- `temperature` (Float, default=37.0): Temperature in degrees Celsius
+- `extra_args` (String, default=""): Additional command-line arguments
+- `cpu_cores` (Int, default=1): Number of CPU cores
+- `memory_gb` (Int, default=4): Memory in GB
+
+**Outputs:**
+- `accessibility_profiles` (Array[File]): Accessibility profile files with unpaired probabilities
+- `dp_plots` (Array[File]): Dot plot PostScript files with local pair probabilities
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-viennarna/ww-viennarna.wdl" as viennarna_tasks
+
+workflow rna_structure_analysis {
+  input {
+    File rna_sequences
+  }
+
+  call viennarna_tasks.rnafold {
+    input:
+      input_fasta = rna_sequences,
+      partition_function = true
+  }
+
+  output {
+    File structures = rnafold.structure_output
+    Array[File] plots = rnafold.postscript_plots
+  }
+}
+```
+
+### Advanced Usage Examples
+
+**Suboptimal structure sampling with constrained energy range:**
+```wdl
+call viennarna_tasks.rnasubopt {
+  input:
+    input_fasta = rna_sequences,
+    energy_range = 2.0,
+    no_lp = true
+}
+```
+
+**RNA-RNA interaction prediction:**
+```wdl
+call viennarna_tasks.rnacofold {
+  input:
+    sequence_a = "GGGAAAUCCC",
+    sequence_b = "GGGAUUUCCCC",
+    partition_function = true
+}
+```
+
+## Testing the Module
+
+The module includes a test workflow (`testrun.wdl`) that can be run independently:
+
+```bash
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl --entrypoint viennarna_example
+
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+```
+
+### Automatic Demo Mode
+
+The test workflow automatically:
+1. Generates test RNA sequences (tRNA, hairpin, ribozyme) using `ww-testdata`
+2. Runs MFE structure prediction with partition function
+3. Enumerates suboptimal structures
+4. Predicts RNA-RNA interaction between two short sequences
+5. Computes local base pair probabilities
+
+## Docker Container
+
+This module uses the `getwilds/viennarna:2.7.2` container image, which includes:
+- ViennaRNA Package 2.7.2
+- RNAfold, RNAsubopt, RNAcofold, RNAplfold, and other ViennaRNA tools
+- All necessary dependencies for RNA structure prediction
+
+## Citation
+
+> Lorenz, R., Bernhart, S.H., Honer zu Siederdissen, C., Tafer, H., Flamm, C., Stadler, P.F. and Hofacker, I.L. (2011),
+> "ViennaRNA Package 2.0", Algorithms for Molecular Biology, 6:26
+> DOI: [10.1186/1748-7188-6-26](https://doi.org/10.1186/1748-7188-6-26)
+
+## Parameters and Resource Requirements
+
+### Default Resources
+- **CPU**: 1 core
+- **Memory**: 4 GB
+- **Runtime**: Seconds to minutes depending on sequence length and task
+
+### Resource Scaling
+- `cpu_cores`: ViennaRNA tools are primarily single-threaded; increase only for very large batch jobs
+- `memory_gb`: Increase for very long sequences (>10,000 nt) or large suboptimal structure enumerations
+- RNAsubopt with large energy ranges can produce very large output files
+
+## Support and Feedback
+
+For questions or to report issues:
+- Open an issue in the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library/issues)
+- Contact the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org
+- See the library's [Contributor Guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md)
+
+## Related Resources
+
+- **[ViennaRNA Documentation](https://www.tbi.univie.ac.at/RNA/documentation.html)**: Official ViennaRNA documentation
+- **[WILDS Docker Library](https://github.com/getwilds/wilds-docker-library)**: Container images used by WDL workflows
+- **[WILDS Documentation](https://getwilds.org/)**: Comprehensive guides and best practices
+- **[WDL Specification](https://openwdl.org/)**: Official WDL language documentation

--- a/modules/ww-viennarna/testrun.wdl
+++ b/modules/ww-viennarna/testrun.wdl
@@ -6,20 +6,20 @@ import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 #### TEST WORKFLOW DEFINITION ####
 
 workflow viennarna_example {
-  # Generate test RNA sequences
-  call ww_testdata.create_test_rna_fasta as download_demo_data { }
+  # Download ShapeMapper example data (TPP riboswitch RNA FASTA)
+  call ww_testdata.download_shapemapper_data as download_demo_data { }
 
-  # Predict MFE structures for all sequences in the FASTA
+  # Predict MFE structures for the TPP riboswitch sequence
   call ww_viennarna.rnafold { input:
-      input_fasta = download_demo_data.test_fasta,
+      input_fasta = download_demo_data.target_fa,
       partition_function = true,
       cpu_cores = 1,
       memory_gb = 4
   }
 
-  # Enumerate suboptimal structures for the test sequences
+  # Enumerate suboptimal structures for the test sequence
   call ww_viennarna.rnasubopt { input:
-      input_fasta = download_demo_data.test_fasta,
+      input_fasta = download_demo_data.target_fa,
       energy_range = 3.0,
       cpu_cores = 1,
       memory_gb = 4
@@ -35,7 +35,7 @@ workflow viennarna_example {
 
   # Compute local base pair probabilities
   call ww_viennarna.rnaplfold { input:
-      input_fasta = download_demo_data.test_fasta,
+      input_fasta = download_demo_data.target_fa,
       cpu_cores = 1,
       memory_gb = 4
   }

--- a/modules/ww-viennarna/testrun.wdl
+++ b/modules/ww-viennarna/testrun.wdl
@@ -1,0 +1,52 @@
+version 1.0
+
+import "ww-viennarna.wdl" as ww_viennarna
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+
+#### TEST WORKFLOW DEFINITION ####
+
+workflow viennarna_example {
+  # Generate test RNA sequences
+  call ww_testdata.create_test_rna_fasta as download_demo_data { }
+
+  # Predict MFE structures for all sequences in the FASTA
+  call ww_viennarna.rnafold { input:
+      input_fasta = download_demo_data.test_fasta,
+      partition_function = true,
+      cpu_cores = 1,
+      memory_gb = 4
+  }
+
+  # Enumerate suboptimal structures for the test sequences
+  call ww_viennarna.rnasubopt { input:
+      input_fasta = download_demo_data.test_fasta,
+      energy_range = 3.0,
+      cpu_cores = 1,
+      memory_gb = 4
+  }
+
+  # Predict RNA-RNA interaction between two short sequences
+  call ww_viennarna.rnacofold { input:
+      sequence_a = "GGGAAAUCCC",
+      sequence_b = "GGGAUUUCCCC",
+      cpu_cores = 1,
+      memory_gb = 4
+  }
+
+  # Compute local base pair probabilities
+  call ww_viennarna.rnaplfold { input:
+      input_fasta = download_demo_data.test_fasta,
+      cpu_cores = 1,
+      memory_gb = 4
+  }
+
+  output {
+    File rnafold_output = rnafold.structure_output
+    Array[File] rnafold_plots = rnafold.postscript_plots
+    File rnasubopt_output = rnasubopt.subopt_output
+    File rnacofold_output = rnacofold.cofold_output
+    Array[File] rnacofold_plots = rnacofold.postscript_plots
+    Array[File] rnaplfold_profiles = rnaplfold.accessibility_profiles
+    Array[File] rnaplfold_plots = rnaplfold.dp_plots
+  }
+}

--- a/modules/ww-viennarna/ww-viennarna.wdl
+++ b/modules/ww-viennarna/ww-viennarna.wdl
@@ -1,0 +1,231 @@
+## WILDS WDL module for ViennaRNA
+## Provides tasks for RNA secondary structure prediction and analysis using the
+## ViennaRNA package, including minimum free energy folding, suboptimal structure
+## enumeration, and RNA-RNA interaction prediction.
+
+version 1.0
+
+#### TASK DEFINITIONS ####
+
+task rnafold {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Predict minimum free energy (MFE) secondary structures and partition function for RNA sequences using RNAfold"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-viennarna/ww-viennarna.wdl"
+    outputs: {
+        structure_output: "Text file containing predicted MFE structures in dot-bracket notation with free energies",
+        postscript_plots: "Array of PostScript secondary structure plots (one per sequence)"
+    }
+  }
+
+  parameter_meta {
+    input_fasta: "FASTA file containing RNA sequences to fold"
+    partition_function: "Compute partition function and base pair probabilities in addition to MFE structure"
+    no_lp: "Disallow lonely base pairs (isolated pairs with no adjacent pairs)"
+    temperature: "Temperature in degrees Celsius for energy calculations"
+    extra_args: "Additional command-line arguments to pass to RNAfold"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    File input_fasta
+    Boolean partition_function = false
+    Boolean no_lp = false
+    Float temperature = 37.0
+    String extra_args = ""
+    Int cpu_cores = 1
+    Int memory_gb = 4
+  }
+
+  command <<<
+    set -eo pipefail
+
+    RNAfold \
+      --infile=~{input_fasta} \
+      --temp=~{temperature} \
+      ~{if partition_function then "--partfunc" else ""} \
+      ~{if no_lp then "--noLP" else ""} \
+      ~{extra_args} \
+      > rnafold_output.txt
+  >>>
+
+  output {
+    File structure_output = "rnafold_output.txt"
+    Array[File] postscript_plots = glob("*_ss.ps")
+  }
+
+  runtime {
+    docker: "getwilds/viennarna:2.7.2"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}
+
+task rnasubopt {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Enumerate suboptimal secondary structures within an energy range of the MFE using RNAsubopt"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-viennarna/ww-viennarna.wdl"
+    outputs: {
+        subopt_output: "Text file containing suboptimal structures in dot-bracket notation with energies"
+    }
+  }
+
+  parameter_meta {
+    input_fasta: "FASTA file containing an RNA sequence"
+    energy_range: "Energy range above MFE in kcal/mol for suboptimal structure enumeration"
+    no_lp: "Disallow lonely base pairs (isolated pairs with no adjacent pairs)"
+    temperature: "Temperature in degrees Celsius for energy calculations"
+    extra_args: "Additional command-line arguments to pass to RNAsubopt"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    File input_fasta
+    Float energy_range = 5.0
+    Boolean no_lp = false
+    Float temperature = 37.0
+    String extra_args = ""
+    Int cpu_cores = 1
+    Int memory_gb = 4
+  }
+
+  command <<<
+    set -eo pipefail
+
+    RNAsubopt \
+      --infile=~{input_fasta} \
+      --deltaEnergy=~{energy_range} \
+      --temp=~{temperature} \
+      ~{if no_lp then "--noLP" else ""} \
+      ~{extra_args} \
+      > rnasubopt_output.txt
+  >>>
+
+  output {
+    File subopt_output = "rnasubopt_output.txt"
+  }
+
+  runtime {
+    docker: "getwilds/viennarna:2.7.2"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}
+
+task rnacofold {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Predict the joint secondary structure and hybridization energy of two RNA molecules using RNAcofold"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-viennarna/ww-viennarna.wdl"
+    outputs: {
+        cofold_output: "Text file containing predicted joint MFE structure with interaction energy",
+        postscript_plots: "Array of PostScript plots of the joint secondary structure"
+    }
+  }
+
+  parameter_meta {
+    sequence_a: "First RNA sequence"
+    sequence_b: "Second RNA sequence"
+    partition_function: "Compute partition function in addition to MFE structure"
+    temperature: "Temperature in degrees Celsius for energy calculations"
+    extra_args: "Additional command-line arguments to pass to RNAcofold"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    String sequence_a
+    String sequence_b
+    Boolean partition_function = false
+    Float temperature = 37.0
+    String extra_args = ""
+    Int cpu_cores = 1
+    Int memory_gb = 4
+  }
+
+  command <<<
+    set -eo pipefail
+
+    # RNAcofold expects two sequences joined by '&'
+    echo "~{sequence_a}&~{sequence_b}" | RNAcofold \
+      --temp=~{temperature} \
+      ~{if partition_function then "--partfunc" else ""} \
+      ~{extra_args} \
+      > rnacofold_output.txt
+  >>>
+
+  output {
+    File cofold_output = "rnacofold_output.txt"
+    Array[File] postscript_plots = glob("*_ss.ps")
+  }
+
+  runtime {
+    docker: "getwilds/viennarna:2.7.2"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}
+
+task rnaplfold {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Compute local base pair probabilities for RNA sequences using a sliding window approach with RNAplfold"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-viennarna/ww-viennarna.wdl"
+    outputs: {
+        accessibility_profiles: "Array of accessibility profile files with unpaired probabilities",
+        dp_plots: "Array of dot plot PostScript files with local pair probabilities"
+    }
+  }
+
+  parameter_meta {
+    input_fasta: "FASTA file containing RNA sequences"
+    window_size: "Window size for the sliding window approach"
+    span: "Maximum span (distance) of a base pair"
+    unpaired_length: "Length of the unpaired region for accessibility computation"
+    temperature: "Temperature in degrees Celsius for energy calculations"
+    extra_args: "Additional command-line arguments to pass to RNAplfold"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    File input_fasta
+    Int window_size = 70
+    Int span = 40
+    Int unpaired_length = 4
+    Float temperature = 37.0
+    String extra_args = ""
+    Int cpu_cores = 1
+    Int memory_gb = 4
+  }
+
+  command <<<
+    set -eo pipefail
+
+    RNAplfold \
+      --winsize=~{window_size} \
+      --span=~{span} \
+      --ulength=~{unpaired_length} \
+      --temp=~{temperature} \
+      ~{extra_args} \
+      < ~{input_fasta}
+  >>>
+
+  output {
+    Array[File] accessibility_profiles = glob("*_lunp")
+    Array[File] dp_plots = glob("*_dp.ps")
+  }
+
+  runtime {
+    docker: "getwilds/viennarna:2.7.2"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}


### PR DESCRIPTION
## Type of Change

- New module

## Description

Adds a new `ww-viennarna` module wrapping key tools from the [ViennaRNA](https://www.tbi.univie.ac.at/RNA/) package for RNA secondary structure prediction and analysis.

**Tasks included:**
- **`rnafold`** — Predict minimum free energy (MFE) structures with optional partition function computation
- **`rnasubopt`** — Enumerate suboptimal secondary structures within an energy range of the MFE
- **`rnacofold`** — Predict joint secondary structure and hybridization energy of two interacting RNA molecules
- **`rnaplfold`** — Compute local base pair probabilities using a sliding window approach

Uses the `getwilds/viennarna:2.7.2` Docker image. Test workflow reuses the existing `download_shapemapper_data` task (TPP riboswitch FASTA) from `ww-testdata`.

## Testing

**How did you test these changes?**
Ran linting (`make lint NAME=ww-viennarna`) and the test workflow (`make run_sprocket NAME=ww-viennarna`). All 4 tasks (rnafold, rnasubopt, rnacofold, rnaplfold) completed successfully, producing structure predictions, PostScript plots, and accessibility profiles. See GitHub Action CI/CD below as well.

**What workflow engine did you use?**
Sprocket

**Did the tests pass?**
Yes — all linting (sprocket, miniwdl, WOMtool) and execution tests passed.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- The `getwilds/viennarna:2.7.2` Docker image exists on Docker Hub but the corresponding Dockerfile has not yet been added to `wilds-docker-library`.
- The module could be expanded in the future with additional ViennaRNA tools (RNAalifold, RNAduplex, RNAinverse, etc.).