### PR TITLE
Fixing `ww-rnaseq` GTF Processing

### DIFF
--- a/modules/ww-gffread/README.md
+++ b/modules/ww-gffread/README.md
@@ -1,0 +1,161 @@
+# ww-gffread Module
+
+[![Project Status: Prototype – Useable, some support, open to feedback, unstable API.](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module wrapping the [`gffread`](https://github.com/gpertea/gffread) tool for GTF/GFF3 annotation manipulation. The primary purpose is normalizing bacterial NCBI GTFs so they work in eukaryotic-style RNA-seq pipelines.
+
+## Overview
+
+`gffread` is a small, fast utility from the Cufflinks/StringTie ecosystem for parsing, filtering, converting, and normalizing GTF and GFF3 annotation files. This module exposes the subset of `gffread` functionality most relevant to WILDS pipelines.
+
+### Why this module exists: the bacterial GTF problem
+
+NCBI RefSeq bacterial GTFs are structurally different from eukaryotic GTFs in a way that silently breaks standard RNA-seq pipelines. A typical NCBI bacterial GTF for *Pseudomonas aeruginosa* PAO1 contains:
+
+- ~5500 `CDS` rows (one per protein-coding gene)
+- ~5700 `gene` rows
+- ~100 `exon` rows (only for tRNAs/rRNAs)
+
+Tools like STAR (in GeneCounts mode) and RSeQC only consider `exon` features when building gene-level count tables and annotation summaries. When fed a bacterial GTF, these tools silently report per-gene counts for only the ~100 non-coding RNAs — dropping 98% of protein-coding genes from the results. Downstream DESeq2 then produces differential expression output for only ~100 genes instead of the ~5500 you expect.
+
+The `normalize_gtf` task in this module fixes this by synthesizing `exon` features from `CDS` records using `gffread --force-exons`. The normalized GTF then works correctly with any downstream tool that expects eukaryotic-style exon annotations, with no user-visible changes or configuration required.
+
+The task is safe to apply to any GTF: well-formed eukaryotic GTFs that already have proper `exon` annotations pass through effectively unchanged.
+
+### A note on gffread + NCBI bacterial GTFs
+
+`gffread` 0.12.7 cannot parse NCBI bacterial GTFs directly — it reports `Error: no valid ID found for GFF record` because NCBI GTFs have `transcript_id ""` (empty string) on `gene`-type rows. The `normalize_gtf` task handles this automatically by stripping `gene`-type rows before invoking `gffread`. These rows are redundant with the corresponding `CDS` rows for coordinate and identifier information, so nothing is lost.
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and follows the standard WILDS module structure:
+
+- **Main WDL file**: `ww-gffread.wdl` - Contains task definitions
+- **Test workflow**: `testrun.wdl` - Zero-config demonstration workflow
+- **Documentation**: This README
+
+## Available Tasks
+
+### `normalize_gtf`
+
+Normalizes a GTF file so downstream tools see exon features for every transcript. Synthesizes exon features from CDS records for GTFs that lack them (typical of NCBI bacterial GTFs). Eukaryotic GTFs with proper exon annotations pass through effectively unchanged.
+
+**Inputs:**
+- `input_gtf` (File): Input GTF file to normalize. Can be any GTF — bacterial or eukaryotic.
+- `output_prefix` (String, default=`"normalized"`): Prefix used for output filenames
+- `cpu_cores` (Int, default=1): Number of CPU cores allocated for the task
+- `memory_gb` (Int, default=2): Memory allocated for the task in GB
+
+**Outputs:**
+- `normalized_gtf` (File): GTF file with exon features synthesized from CDS records where needed
+- `feature_counts` (File): Text report comparing feature counts before and after normalization (useful for debugging)
+
+### `gff3_to_gtf`
+
+Converts a GFF3 annotation file to GTF format. Useful when an upstream source (e.g. some Ensembl Bacteria releases) only publishes GFF3 but downstream tools expect GTF.
+
+**Inputs:**
+- `input_gff3` (File): Input GFF3 file to convert
+- `output_prefix` (String, default=`"converted"`): Prefix used for output filenames
+- `cpu_cores` (Int, default=1): Number of CPU cores allocated for the task
+- `memory_gb` (Int, default=2): Memory allocated for the task in GB
+
+**Outputs:**
+- `gtf_file` (File): GTF-format annotation converted from the input GFF3
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
+
+workflow my_rnaseq_pipeline {
+  input {
+    File reference_gtf
+    # ... other inputs
+  }
+
+  # Ensure the GTF has proper exon features before handing it to STAR / RSeQC / etc.
+  call gffread_tasks.normalize_gtf { input:
+      input_gtf = reference_gtf
+  }
+
+  # Downstream tasks then use normalize_gtf.normalized_gtf instead of reference_gtf
+  # ...
+}
+```
+
+### Integration Example: fixing bacterial RNA-seq in a STAR-based pipeline
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
+
+workflow bacterial_rnaseq {
+  input {
+    File reference_fasta
+    File reference_gtf  # e.g. NCBI PAO1 GTF
+    # ...
+  }
+
+  call gffread_tasks.normalize_gtf { input:
+      input_gtf = reference_gtf
+  }
+
+  call star_tasks.build_index { input:
+      reference_fasta = reference_fasta,
+      reference_gtf = normalize_gtf.normalized_gtf
+  }
+
+  # ... alignment, counting, DE analysis
+}
+```
+
+## Testing the Module
+
+### Automatic Demo Mode
+
+The `testrun.wdl` workflow runs `normalize_gtf` against two contrasting inputs with no user configuration:
+
+1. **Bacterial case**: the NCBI PAO1 GTF (via `ww-testdata.download_pao1_ref`). Exercises the CDS→exon synthesis path.
+2. **Eukaryotic case**: the Ensembl human chromosome 15 GTF (via `ww-testdata.download_jcast_test_data`). Exercises the pass-through path.
+
+Run locally with:
+
+```bash
+make run_sprocket NAME=ww-gffread
+# or
+make run_miniwdl NAME=ww-gffread
+```
+
+After the run completes, inspect the `feature_counts` output files to verify:
+- The bacterial case shows a dramatic increase in `exon` rows (hundreds → thousands).
+- The eukaryotic case shows roughly the same number of `exon` rows before and after.
+
+## Docker Container
+
+This module currently uses the `quay.io/biocontainers/gffread:0.12.7--hdcf5f25_4` image. It will be migrated to `getwilds/gffread:0.12.7` once that image is built and published to the WILDS Docker library.
+
+## Citation
+
+If you use `gffread` in your work, please cite:
+
+> Pertea G and Pertea M. GFF Utilities: GffRead and GffCompare. *F1000Research* 2020, 9:304 (https://doi.org/10.12688/f1000research.23297.2)
+
+## Parameters and Resource Requirements
+
+### Default Resources
+
+Both tasks default to 1 CPU and 2 GB memory, which is ample for typical annotation files (bacterial GTFs are ~5 MB, a human GTF is ~1 GB). Increase `memory_gb` only if processing extraordinarily large annotations.
+
+## Support and Feedback
+
+Report issues or request features at the [wilds-wdl-library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+## Related Resources
+
+- [gffread GitHub](https://github.com/gpertea/gffread)
+- [gffread documentation](https://ccb.jhu.edu/software/stringtie/gff.shtml#gffread)
+- [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library)

--- a/modules/ww-gffread/README.md
+++ b/modules/ww-gffread/README.md
@@ -23,10 +23,6 @@ The `normalize_gtf` task in this module fixes this by synthesizing `exon` featur
 
 The task is safe to apply to any GTF: well-formed eukaryotic GTFs that already have proper `exon` annotations pass through effectively unchanged.
 
-### A note on gffread + NCBI bacterial GTFs
-
-`gffread` 0.12.7 cannot parse NCBI bacterial GTFs directly — it reports `Error: no valid ID found for GFF record` because NCBI GTFs have `transcript_id ""` (empty string) on `gene`-type rows. The `normalize_gtf` task handles this automatically by stripping `gene`-type rows before invoking `gffread`. These rows are redundant with the corresponding `CDS` rows for coordinate and identifier information, so nothing is lost.
-
 ## Module Structure
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and follows the standard WILDS module structure:
@@ -49,6 +45,8 @@ Normalizes a GTF file so downstream tools see exon features for every transcript
 
 **Outputs:**
 - `normalized_gtf` (File): GTF file with exon features synthesized from CDS records where needed
+
+**A note on gffread + NCBI bacterial GTFs:** `gffread` 0.12.7 cannot parse NCBI bacterial GTFs directly — it reports `Error: no valid ID found for GFF record` because NCBI GTFs have `transcript_id ""` (empty string) on `gene`-type rows. The `normalize_gtf` task handles this automatically by stripping `gene`-type rows before invoking `gffread`. These rows are redundant with the corresponding `CDS` rows for coordinate and identifier information, so nothing is lost.
 
 ### `gff3_to_gtf`
 

--- a/modules/ww-gffread/README.md
+++ b/modules/ww-gffread/README.md
@@ -9,19 +9,6 @@ A WILDS WDL module wrapping the [`gffread`](https://github.com/gpertea/gffread) 
 
 `gffread` is a small, fast utility from the Cufflinks/StringTie ecosystem for parsing, filtering, converting, and normalizing GTF and GFF3 annotation files. This module exposes the subset of `gffread` functionality most relevant to WILDS pipelines.
 
-### Why this module exists: the bacterial GTF problem
-
-NCBI RefSeq bacterial GTFs are structurally different from eukaryotic GTFs in a way that silently breaks standard RNA-seq pipelines. A typical NCBI bacterial GTF for *Pseudomonas aeruginosa* PAO1 contains:
-
-- ~5500 `CDS` rows (one per protein-coding gene)
-- ~5700 `gene` rows
-- ~100 `exon` rows (only for tRNAs/rRNAs)
-
-Tools like STAR (in GeneCounts mode) and RSeQC only consider `exon` features when building gene-level count tables and annotation summaries. When fed a bacterial GTF, these tools silently report per-gene counts for only the ~100 non-coding RNAs — dropping 98% of protein-coding genes from the results. Downstream DESeq2 then produces differential expression output for only ~100 genes instead of the ~5500 you expect.
-
-The `normalize_gtf` task in this module fixes this by synthesizing `exon` features from `CDS` records using `gffread --force-exons`. The normalized GTF then works correctly with any downstream tool that expects eukaryotic-style exon annotations, with no user-visible changes or configuration required.
-
-The task is safe to apply to any GTF: well-formed eukaryotic GTFs that already have proper `exon` annotations pass through effectively unchanged.
 
 ### A note on gffread + NCBI bacterial GTFs
 

--- a/modules/ww-gffread/README.md
+++ b/modules/ww-gffread/README.md
@@ -135,7 +135,7 @@ After the run completes, inspect the normalized GTF output files to verify:
 
 ## Docker Container
 
-This module currently uses the `quay.io/biocontainers/gffread:0.12.7--hdcf5f25_4` image. It will be migrated to `getwilds/gffread:0.12.7` once that image is built and published to the WILDS Docker library.
+This module uses the **`getwilds/gffread:0.12.7`** container image from the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library), which includes gffread version 0.12.7.
 
 ## Citation
 

--- a/modules/ww-gffread/README.md
+++ b/modules/ww-gffread/README.md
@@ -49,7 +49,6 @@ Normalizes a GTF file so downstream tools see exon features for every transcript
 
 **Outputs:**
 - `normalized_gtf` (File): GTF file with exon features synthesized from CDS records where needed
-- `feature_counts` (File): Text report comparing feature counts before and after normalization (useful for debugging)
 
 ### `gff3_to_gtf`
 
@@ -130,9 +129,9 @@ make run_sprocket NAME=ww-gffread
 make run_miniwdl NAME=ww-gffread
 ```
 
-After the run completes, inspect the `feature_counts` output files to verify:
-- The bacterial case shows a dramatic increase in `exon` rows (hundreds → thousands).
-- The eukaryotic case shows roughly the same number of `exon` rows before and after.
+After the run completes, inspect the normalized GTF output files to verify:
+- The bacterial case has ~5500 `exon` rows (up from ~100 in the input).
+- The eukaryotic case has roughly the same number of `exon` rows as the input.
 
 ## Docker Container
 

--- a/modules/ww-gffread/testrun.wdl
+++ b/modules/ww-gffread/testrun.wdl
@@ -22,8 +22,6 @@ workflow gffread_example {
 
   output {
     File bacterial_normalized_gtf = normalize_bacterial.normalized_gtf
-    File bacterial_feature_counts = normalize_bacterial.feature_counts
     File eukaryotic_normalized_gtf = normalize_eukaryotic.normalized_gtf
-    File eukaryotic_feature_counts = normalize_eukaryotic.feature_counts
   }
 }

--- a/modules/ww-gffread/testrun.wdl
+++ b/modules/ww-gffread/testrun.wdl
@@ -1,17 +1,7 @@
 version 1.0
 
-# Import the module under test and ww-testdata for auto-provisioned test inputs.
-# TODO: switch both imports to refs/heads/main before merging
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-gffread/ww-gffread.wdl" as ww_gffread
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-
-#### TEST WORKFLOW DEFINITION ####
-# Exercises normalize_gtf on two very different inputs:
-#   1. The NCBI PAO1 GTF (bacterial layout: mostly CDS, ~100 exon rows).
-#      Expected behavior: normalize_gtf synthesizes ~5500 exon features.
-#   2. The Ensembl human chromosome 15 GTF (well-formed eukaryotic layout).
-#      Expected behavior: pass-through — exon features already exist and
-#      the feature count is largely unchanged.
 
 workflow gffread_example {
   # Case 1: Bacterial NCBI GTF (the primary use case for this module)

--- a/modules/ww-gffread/testrun.wdl
+++ b/modules/ww-gffread/testrun.wdl
@@ -1,0 +1,39 @@
+version 1.0
+
+# Import the module under test and ww-testdata for auto-provisioned test inputs.
+# TODO: switch both imports to refs/heads/main before merging
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-gffread/ww-gffread.wdl" as ww_gffread
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+
+#### TEST WORKFLOW DEFINITION ####
+# Exercises normalize_gtf on two very different inputs:
+#   1. The NCBI PAO1 GTF (bacterial layout: mostly CDS, ~100 exon rows).
+#      Expected behavior: normalize_gtf synthesizes ~5500 exon features.
+#   2. The Ensembl human chromosome 15 GTF (well-formed eukaryotic layout).
+#      Expected behavior: pass-through — exon features already exist and
+#      the feature count is largely unchanged.
+
+workflow gffread_example {
+  # Case 1: Bacterial NCBI GTF (the primary use case for this module)
+  call ww_testdata.download_pao1_ref { }
+
+  call ww_gffread.normalize_gtf as normalize_bacterial { input:
+      input_gtf = download_pao1_ref.gtf,
+      output_prefix = "pao1_normalized"
+  }
+
+  # Case 2: Eukaryotic Ensembl GTF (pass-through sanity check)
+  call ww_testdata.download_jcast_test_data { }
+
+  call ww_gffread.normalize_gtf as normalize_eukaryotic { input:
+      input_gtf = download_jcast_test_data.gtf_file,
+      output_prefix = "ensembl_chr15_normalized"
+  }
+
+  output {
+    File bacterial_normalized_gtf = normalize_bacterial.normalized_gtf
+    File bacterial_feature_counts = normalize_bacterial.feature_counts
+    File eukaryotic_normalized_gtf = normalize_eukaryotic.normalized_gtf
+    File eukaryotic_feature_counts = normalize_eukaryotic.feature_counts
+  }
+}

--- a/modules/ww-gffread/ww-gffread.wdl
+++ b/modules/ww-gffread/ww-gffread.wdl
@@ -19,8 +19,7 @@ task normalize_gtf {
     description: "Normalizes a GTF file so downstream tools see exon features for every transcript. Synthesizes exon features from CDS records for GTFs that lack them (typical of NCBI bacterial GTFs). Eukaryotic GTFs with proper exon annotations pass through unchanged."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl"
     outputs: {
-        normalized_gtf: "GTF file with exon features synthesized from CDS records where needed",
-        feature_counts: "Text report comparing feature counts before and after normalization"
+        normalized_gtf: "GTF file with exon features synthesized from CDS records where needed"
     }
   }
 
@@ -51,7 +50,6 @@ task normalize_gtf {
 
   output {
     File normalized_gtf = "~{output_prefix}.gtf"
-    File feature_counts = "~{output_prefix}.feature_counts.txt"
   }
 
   runtime {

--- a/modules/ww-gffread/ww-gffread.wdl
+++ b/modules/ww-gffread/ww-gffread.wdl
@@ -1,0 +1,133 @@
+## WILDS WDL Module: ww-gffread
+## Wraps the `gffread` tool for GTF/GFF3 manipulation and normalization.
+##
+## Primary use case: bacterial GTFs from NCBI RefSeq contain mostly CDS rows
+## with very few `exon` rows (typically only tRNAs/rRNAs). Downstream tools
+## like STAR (GeneCounts mode) and RSeQC only consider `exon` features, so
+## these bacterial GTFs silently cause 98% of protein-coding genes to drop
+## out of RNA-seq results. This module's `normalize_gtf` task uses gffread
+## with `--force-exons` to synthesize the missing exon features, making the
+## same pipeline work for both bacterial and eukaryotic references without
+## any user configuration.
+
+version 1.0
+
+task normalize_gtf {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Normalizes a GTF file so downstream tools see exon features for every transcript. Synthesizes exon features from CDS records for GTFs that lack them (typical of NCBI bacterial GTFs). Eukaryotic GTFs with proper exon annotations pass through unchanged."
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl"
+    outputs: {
+        normalized_gtf: "GTF file with exon features synthesized from CDS records where needed",
+        feature_counts: "Text report comparing feature counts before and after normalization"
+    }
+  }
+
+  parameter_meta {
+    input_gtf: "Input GTF file to normalize. Can be any GTF - bacterial or eukaryotic."
+    output_prefix: "Prefix used for output filenames"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    File input_gtf
+    String output_prefix = "normalized"
+    Int cpu_cores = 1
+    Int memory_gb = 2
+  }
+
+  command <<<
+    set -eo pipefail
+
+    # Report feature counts from the input GTF so debugging is easy
+    echo "=== Input GTF feature counts ===" | tee "~{output_prefix}.feature_counts.txt"
+    awk -F'\t' '$0 !~ /^#/ {print $3}' "~{input_gtf}" \
+      | sort \
+      | uniq -c \
+      | tee -a "~{output_prefix}.feature_counts.txt"
+
+    # gffread 0.12.7 cannot parse NCBI bacterial GTFs directly because those
+    # GTFs have `transcript_id ""` (empty string) on `gene`-type rows, which
+    # trips gffread's record ID validation with:
+    #     Error: no valid ID found for GFF record
+    # Strip `gene`-type rows before feeding to gffread. This is safe for both
+    # bacterial and eukaryotic GTFs: the coordinate and gene_id information
+    # on `gene` rows is redundant with the corresponding transcript/CDS/exon
+    # rows, and gffread reconstructs the gene-level structure from those.
+    awk -F'\t' '/^#/ || $3 != "gene"' "~{input_gtf}" > stripped.gtf
+
+    # Run gffread with --force-exons to synthesize exon features from CDS
+    # records for any transcript that lacks them. For already-well-formed
+    # eukaryotic GTFs this is effectively a pass-through since exon features
+    # already exist. The -T flag emits GTF (rather than gffread's default GFF3).
+    gffread stripped.gtf -T --force-exons -o "~{output_prefix}.gtf"
+
+    # Report feature counts from the normalized GTF
+    {
+      echo ""
+      echo "=== Normalized GTF feature counts ==="
+    } | tee -a "~{output_prefix}.feature_counts.txt"
+    awk -F'\t' '$0 !~ /^#/ {print $3}' "~{output_prefix}.gtf" \
+      | sort \
+      | uniq -c \
+      | tee -a "~{output_prefix}.feature_counts.txt"
+  >>>
+
+  output {
+    File normalized_gtf = "~{output_prefix}.gtf"
+    File feature_counts = "~{output_prefix}.feature_counts.txt"
+  }
+
+  runtime {
+    # TODO: switch to getwilds/gffread:0.12.7 once that image is built and pushed
+    docker: "quay.io/biocontainers/gffread:0.12.7--hdcf5f25_4"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}
+
+task gff3_to_gtf {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Converts a GFF3 annotation file to GTF format using gffread. Useful when an upstream source (e.g. Ensembl Bacteria) only publishes GFF3 but downstream tools expect GTF."
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl"
+    outputs: {
+        gtf_file: "GTF-format annotation converted from the input GFF3"
+    }
+  }
+
+  parameter_meta {
+    input_gff3: "Input GFF3 file to convert"
+    output_prefix: "Prefix used for output filenames"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    File input_gff3
+    String output_prefix = "converted"
+    Int cpu_cores = 1
+    Int memory_gb = 2
+  }
+
+  command <<<
+    set -eo pipefail
+
+    # -T emits GTF instead of the default GFF3
+    gffread "~{input_gff3}" -T -o "~{output_prefix}.gtf"
+  >>>
+
+  output {
+    File gtf_file = "~{output_prefix}.gtf"
+  }
+
+  runtime {
+    # TODO: switch to getwilds/gffread:0.12.7 once that image is built and pushed
+    docker: "quay.io/biocontainers/gffread:0.12.7--hdcf5f25_4"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/modules/ww-gffread/ww-gffread.wdl
+++ b/modules/ww-gffread/ww-gffread.wdl
@@ -4,7 +4,7 @@
 ## Primary use case: bacterial GTFs from NCBI RefSeq contain mostly CDS rows
 ## with very few `exon` rows (typically only tRNAs/rRNAs). Downstream tools
 ## like STAR (GeneCounts mode) and RSeQC only consider `exon` features, so
-## these bacterial GTFs silently cause 98% of protein-coding genes to drop
+## these bacterial GTFs silently cause a majority of protein-coding genes to drop
 ## out of RNA-seq results. This module's `normalize_gtf` task uses gffread
 ## with `--force-exons` to synthesize the missing exon features, making the
 ## same pipeline work for both bacterial and eukaryotic references without
@@ -16,7 +16,7 @@ task normalize_gtf {
   meta {
     author: "Taylor Firman"
     email: "tfirman@fredhutch.org"
-    description: "Normalizes a GTF file so downstream tools see exon features for every transcript. Synthesizes exon features from CDS records for GTFs that lack them (typical of NCBI bacterial GTFs). Eukaryotic GTFs with proper exon annotations pass through unchanged."
+    description: "Creates exon features from CDS records for GTFs that lack them (e.g. bacterial GTFs). Eukaryotic GTFs with proper exon annotations are unchanged."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl"
     outputs: {
         normalized_gtf: "GTF file with exon features synthesized from CDS records where needed"
@@ -24,7 +24,7 @@ task normalize_gtf {
   }
 
   parameter_meta {
-    input_gtf: "Input GTF file to normalize. Can be any GTF - bacterial or eukaryotic."
+    input_gtf: "Input GTF file to normalize."
     output_prefix: "Prefix used for output filenames"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
@@ -63,7 +63,7 @@ task gff3_to_gtf {
   meta {
     author: "Taylor Firman"
     email: "tfirman@fredhutch.org"
-    description: "Converts a GFF3 annotation file to GTF format using gffread. Useful when an upstream source (e.g. Ensembl Bacteria) only publishes GFF3 but downstream tools expect GTF."
+    description: "Converts a GFF3 file to GTF using gffread."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl"
     outputs: {
         gtf_file: "GTF-format annotation converted from the input GFF3"

--- a/modules/ww-gffread/ww-gffread.wdl
+++ b/modules/ww-gffread/ww-gffread.wdl
@@ -53,8 +53,7 @@ task normalize_gtf {
   }
 
   runtime {
-    # TODO: switch to getwilds/gffread:0.12.7 once that image is built and pushed
-    docker: "quay.io/biocontainers/gffread:0.12.7--hdcf5f25_4"
+    docker: "getwilds/gffread:0.12.7"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -97,8 +96,7 @@ task gff3_to_gtf {
   }
 
   runtime {
-    # TODO: switch to getwilds/gffread:0.12.7 once that image is built and pushed
-    docker: "quay.io/biocontainers/gffread:0.12.7--hdcf5f25_4"
+    docker: "getwilds/gffread:0.12.7"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-gffread/ww-gffread.wdl
+++ b/modules/ww-gffread/ww-gffread.wdl
@@ -41,38 +41,12 @@ task normalize_gtf {
   command <<<
     set -eo pipefail
 
-    # Report feature counts from the input GTF so debugging is easy
-    echo "=== Input GTF feature counts ===" | tee "~{output_prefix}.feature_counts.txt"
-    awk -F'\t' '$0 !~ /^#/ {print $3}' "~{input_gtf}" \
-      | sort \
-      | uniq -c \
-      | tee -a "~{output_prefix}.feature_counts.txt"
-
-    # gffread 0.12.7 cannot parse NCBI bacterial GTFs directly because those
-    # GTFs have `transcript_id ""` (empty string) on `gene`-type rows, which
-    # trips gffread's record ID validation with:
-    #     Error: no valid ID found for GFF record
-    # Strip `gene`-type rows before feeding to gffread. This is safe for both
-    # bacterial and eukaryotic GTFs: the coordinate and gene_id information
-    # on `gene` rows is redundant with the corresponding transcript/CDS/exon
-    # rows, and gffread reconstructs the gene-level structure from those.
+    # Strip `gene`-type rows before feeding to gffread.
     awk -F'\t' '/^#/ || $3 != "gene"' "~{input_gtf}" > stripped.gtf
 
     # Run gffread with --force-exons to synthesize exon features from CDS
-    # records for any transcript that lacks them. For already-well-formed
-    # eukaryotic GTFs this is effectively a pass-through since exon features
-    # already exist. The -T flag emits GTF (rather than gffread's default GFF3).
+    # -T flag emits GTF (rather than gffread's default GFF3)
     gffread stripped.gtf -T --force-exons -o "~{output_prefix}.gtf"
-
-    # Report feature counts from the normalized GTF
-    {
-      echo ""
-      echo "=== Normalized GTF feature counts ==="
-    } | tee -a "~{output_prefix}.feature_counts.txt"
-    awk -F'\t' '$0 !~ /^#/ {print $3}' "~{output_prefix}.gtf" \
-      | sort \
-      | uniq -c \
-      | tee -a "~{output_prefix}.feature_counts.txt"
   >>>
 
   output {

--- a/modules/ww-rseqc/README.md
+++ b/modules/ww-rseqc/README.md
@@ -28,6 +28,7 @@ Run comprehensive RSeQC quality control metrics on aligned RNA-seq data.
 - `bam_index` (File): Index file for the aligned BAM file
 - `ref_bed` (File): Reference genome annotation in BED format (12-column)
 - `sample_name` (String): Sample name for output files
+- `skip_gene_body_cov` (Boolean, default=true): Whether to skip the `geneBody_coverage.py` analysis (see [Gene Body Coverage](#2-gene-body-coverage) for details)
 - `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=4): Memory allocated for the task in GB
 
@@ -187,6 +188,8 @@ Assesses the uniformity of coverage along gene bodies:
 - Important for assessing RNA degradation
 - Generates coverage curve plots
 
+**Skipped by default** (`skip_gene_body_cov = true`). The `geneBody_coverage.py` analysis is single-threaded and can take hours on large BAMs or bacterial genomes. To enable gene body coverage, set `skip_gene_body_cov = false`. When skipped, a placeholder file is written so downstream tools that expect the output file (e.g. MultiQC) do not error.
+
 ### 3. Infer Experiment
 Determines the strand-specificity of the RNA-seq library:
 - Unstranded
@@ -212,7 +215,7 @@ Classifies and analyzes splice junctions:
 ### Default Resources
 - **CPU**: 2 cores
 - **Memory**: 4 GB
-- **Runtime**: ~5-15 minutes per sample depending on BAM size
+- **Runtime**: ~1-5 minutes per sample with default settings (gene body coverage skipped). Enabling gene body coverage (`skip_gene_body_cov = false`) can add significant runtime depending on BAM size and annotation complexity.
 
 ### Resource Scaling
 For larger datasets, consider increasing resources:

--- a/modules/ww-rseqc/testrun.wdl
+++ b/modules/ww-rseqc/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rseqc/ww-rseqc.wdl" as ww_rseqc
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-rseqc/ww-rseqc.wdl" as ww_rseqc
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bedparse/ww-bedparse.wdl" as ww_bedparse
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow rseqc_example {
   # Auto-download test reference data for testing purposes

--- a/modules/ww-rseqc/ww-rseqc.wdl
+++ b/modules/ww-rseqc/ww-rseqc.wdl
@@ -26,6 +26,7 @@ task run_rseqc {
     bam_index: "Index file for the aligned BAM file"
     ref_bed: "Reference genome annotation in BED format (12-column)"
     sample_name: "Sample name for output files"
+    skip_gene_body_cov: "Whether to skip the geneBody_coverage.py analysis (default: true)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
   }
@@ -35,6 +36,7 @@ task run_rseqc {
     File bam_index
     File ref_bed
     String sample_name
+    Boolean skip_gene_body_cov = true
     Int cpu_cores = 2
     Int memory_gb = 4
   }
@@ -49,8 +51,15 @@ task run_rseqc {
     read_distribution.py -i "~{bam_file}" -r "~{ref_bed}" > "~{sample_name}.read_distribution.txt"
 
     # Gene body coverage (5' to 3' bias)
-    echo "2. Analyzing gene body coverage..."
-    geneBody_coverage.py -i "~{bam_file}" -r "~{ref_bed}" -o "~{sample_name}"
+    # This analysis can take hours on large BAMs or bacterial genomes and is
+    # most useful for eukaryotic polyA-selected libraries, so it is off by default.
+    if [ "~{skip_gene_body_cov}" = "true" ]; then
+      echo "2. Skipping gene body coverage (skip_gene_body_cov = true)"
+      echo "Gene body coverage was not calculated." > "~{sample_name}.geneBodyCoverage.txt"
+    else
+      echo "2. Analyzing gene body coverage..."
+      geneBody_coverage.py -i "~{bam_file}" -r "~{ref_bed}" -o "~{sample_name}"
+    fi
 
     # Infer experiment (strand specificity)
     echo "3. Inferring strand specificity..."
@@ -75,7 +84,7 @@ Date: $(date)
 ANALYSES PERFORMED:
 ================================================================================
 1. Read Distribution - Distribution of reads across genomic features
-2. Gene Body Coverage - 5' to 3' coverage bias assessment
+2. Gene Body Coverage - 5' to 3' coverage bias assessment (~{if skip_gene_body_cov then "SKIPPED" else "PERFORMED"})
 3. Infer Experiment - Strand specificity determination
 4. BAM Statistics - Basic alignment statistics
 5. Junction Annotation - Splice junction classification

--- a/modules/ww-testdata/README.md
+++ b/modules/ww-testdata/README.md
@@ -702,6 +702,21 @@ Generates synthetic tile and border points data for testing the `ww-sjl` module 
 - `tile_rds` (File): Synthetic tile RDS file with 5 geographic points across two timezones
 - `border_points_csv` (File): Synthetic border points CSV with matching timezone/latitude entries and sunrise/sunset averages in seconds from midnight
 
+### download_pao1_ref
+
+Downloads the Pseudomonas aeruginosa PAO1 reference genome (FASTA + GTF) from NCBI RefSeq (assembly GCF_000006765.1 / ASM676v1) for use in bacterial RNA-seq test runs. The downloaded GTF uses the classic NCBI bacterial layout (~5573 CDS rows, ~5697 gene rows, only ~106 exon rows for tRNAs/rRNAs), making it the canonical input for testing the `ww-gffread` `normalize_gtf` task.
+
+**Inputs**:
+- `output_prefix` (String): Prefix used for output filenames (default: "pao1")
+- `cpu_cores` (Int): CPU allocation (default: 1)
+- `memory_gb` (Int): Memory allocation (default: 4)
+
+**Outputs**:
+- `fasta` (File): PAO1 reference genome FASTA (sequence: NC_002516.2)
+- `fasta_index` (File): Samtools FASTA index (.fai)
+- `dict` (File): Samtools FASTA dictionary file (.dict)
+- `gtf` (File): NCBI RefSeq GTF annotation for PAO1
+
 ## Data Sources
 
 All reference data is downloaded from authoritative public repositories:
@@ -722,6 +737,7 @@ All reference data is downloaded from authoritative public repositories:
 - **Swiss Institute of Bioinformatics**: Minimal Cell Ranger reference (chr21/22) for single-cell testing
 - **UniProt**: E. coli K-12 reference proteome for DIAMOND protein alignment testing
 - **JCAST Repository**: rMATS output test files for alternative splicing proteomics testing
+- **NCBI RefSeq**: Pseudomonas aeruginosa PAO1 reference assembly (GCF_000006765.1) for bacterial RNA-seq testing
 
 Data integrity is maintained through the use of stable URLs and version-pinned resources.
 

--- a/modules/ww-testdata/testrun.wdl
+++ b/modules/ww-testdata/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow testdata_example {
   # Pull down reference genome and index files for chr1
@@ -75,6 +75,8 @@ workflow testdata_example {
 
   call ww_testdata.download_jcast_test_data { }
 
+  call ww_testdata.download_pao1_ref { }
+
   call validate_outputs { input:
     ref_fasta = download_ref_data.fasta,
     ref_fasta_index = download_ref_data.fasta_index,
@@ -128,7 +130,11 @@ workflow testdata_example {
     sjl_border_points_csv = generate_sjl_data.border_points_csv,
     jcast_rmats_output = download_jcast_test_data.rmats_output,
     jcast_gtf_file = download_jcast_test_data.gtf_file,
-    jcast_genome_fasta = download_jcast_test_data.genome_fasta
+    jcast_genome_fasta = download_jcast_test_data.genome_fasta,
+    pao1_fasta = download_pao1_ref.fasta,
+    pao1_fasta_index = download_pao1_ref.fasta_index,
+    pao1_dict = download_pao1_ref.dict,
+    pao1_gtf = download_pao1_ref.gtf
   }
 
   output {
@@ -201,6 +207,11 @@ workflow testdata_example {
     File jcast_rmats_output = download_jcast_test_data.rmats_output
     File jcast_gtf_file = download_jcast_test_data.gtf_file
     File jcast_genome_fasta = download_jcast_test_data.genome_fasta
+    # Outputs from PAO1 reference download
+    File pao1_fasta = download_pao1_ref.fasta
+    File pao1_fasta_index = download_pao1_ref.fasta_index
+    File pao1_dict = download_pao1_ref.dict
+    File pao1_gtf = download_pao1_ref.gtf
     # Validation report summarizing all outputs
     File validation_report = validate_outputs.report
   }
@@ -268,6 +279,10 @@ task validate_outputs {
     jcast_rmats_output: "JCAST rMATS output tarball to validate"
     jcast_gtf_file: "JCAST Ensembl GTF annotation file to validate"
     jcast_genome_fasta: "JCAST Ensembl genome FASTA file to validate"
+    pao1_fasta: "PAO1 reference FASTA file to validate"
+    pao1_fasta_index: "PAO1 reference FASTA index file to validate"
+    pao1_dict: "PAO1 reference FASTA dictionary file to validate"
+    pao1_gtf: "PAO1 NCBI RefSeq GTF annotation file to validate"
     cpu_cores: "Number of CPU cores to use for validation"
     memory_gb: "Memory allocation in GB for the task"
   }
@@ -326,6 +341,10 @@ task validate_outputs {
     File jcast_rmats_output
     File jcast_gtf_file
     File jcast_genome_fasta
+    File pao1_fasta
+    File pao1_fasta_index
+    File pao1_dict
+    File pao1_gtf
     Int cpu_cores = 1
     Int memory_gb = 2
   }
@@ -412,6 +431,10 @@ task validate_outputs {
     validate_file "~{jcast_rmats_output}" "JCAST rMATS output tarball" || validation_passed=false
     validate_file "~{jcast_gtf_file}" "JCAST Ensembl GTF file" || validation_passed=false
     validate_file "~{jcast_genome_fasta}" "JCAST Ensembl genome FASTA" || validation_passed=false
+    validate_file "~{pao1_fasta}" "PAO1 reference FASTA" || validation_passed=false
+    validate_file "~{pao1_fasta_index}" "PAO1 reference FASTA index" || validation_passed=false
+    validate_file "~{pao1_dict}" "PAO1 reference FASTA dict" || validation_passed=false
+    validate_file "~{pao1_gtf}" "PAO1 NCBI RefSeq GTF" || validation_passed=false
 
     # Additional check: Verify no N bases in clean amplicon
     echo "" >> validation_report.txt
@@ -427,7 +450,7 @@ task validate_outputs {
     {
       echo ""
       echo "=== Validation Summary ==="
-      echo "Total files validated: 51"
+      echo "Total files validated: 55"
     } >> validation_report.txt
 
     if [[ "$validation_passed" == "true" ]]; then

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -1659,8 +1659,13 @@ task download_pao1_ref {
 
     BASE_URL="https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/006/765/GCF_000006765.1_ASM676v1"
 
+    # Note: --no-check-certificate is required because the getwilds/samtools:1.11
+    # container's CA bundle is older than the intermediate CA that NCBI's FTP
+    # endpoint presents, so strict TLS verification fails. This matches the
+    # approach already used by download_jcast_test_data above for the same reason.
+
     # Download PAO1 reference FASTA from NCBI RefSeq
-    wget -q -O "~{output_prefix}.fa.gz" "${BASE_URL}/GCF_000006765.1_ASM676v1_genomic.fna.gz"
+    wget -q --no-check-certificate -O "~{output_prefix}.fa.gz" "${BASE_URL}/GCF_000006765.1_ASM676v1_genomic.fna.gz"
     gunzip "~{output_prefix}.fa.gz"
 
     # Create FASTA index (.fai) and dictionary (.dict) alongside the FASTA
@@ -1671,7 +1676,7 @@ task download_pao1_ref {
     # Note: this GTF has the classic bacterial layout (~5573 CDS rows,
     # ~5697 gene rows, only ~106 exon rows for tRNAs/rRNAs) which is exactly
     # the case the ww-gffread normalize_gtf task is designed to handle.
-    wget -q -O "~{output_prefix}.gtf.gz" "${BASE_URL}/GCF_000006765.1_ASM676v1_genomic.gtf.gz"
+    wget -q --no-check-certificate -O "~{output_prefix}.gtf.gz" "${BASE_URL}/GCF_000006765.1_ASM676v1_genomic.gtf.gz"
     gunzip "~{output_prefix}.gtf.gz"
   >>>
 

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -1627,3 +1627,64 @@ FASTA
     memory: "~{memory_gb} GB"
   }
 }
+
+task download_pao1_ref {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Downloads the Pseudomonas aeruginosa PAO1 reference genome (FASTA and GTF) from NCBI RefSeq for bacterial RNA-seq test runs"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
+    outputs: {
+        fasta: "Pseudomonas aeruginosa PAO1 reference genome FASTA (NC_002516.2)",
+        fasta_index: "Index file for the PAO1 reference FASTA",
+        dict: "Dictionary file for the PAO1 reference FASTA",
+        gtf: "NCBI RefSeq GTF annotation for PAO1 (bacterial layout: mostly CDS rows with only tRNA/rRNA exons)"
+    }
+  }
+
+  parameter_meta {
+    output_prefix: "Prefix used for output filenames"
+    cpu_cores: "Number of CPU cores to use for downloading and processing"
+    memory_gb: "Memory allocation in GB for the task"
+  }
+
+  input {
+    String output_prefix = "pao1"
+    Int cpu_cores = 1
+    Int memory_gb = 4
+  }
+
+  command <<<
+    set -eo pipefail
+
+    BASE_URL="https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/006/765/GCF_000006765.1_ASM676v1"
+
+    # Download PAO1 reference FASTA from NCBI RefSeq
+    wget -q -O "~{output_prefix}.fa.gz" "${BASE_URL}/GCF_000006765.1_ASM676v1_genomic.fna.gz"
+    gunzip "~{output_prefix}.fa.gz"
+
+    # Create FASTA index (.fai) and dictionary (.dict) alongside the FASTA
+    samtools faidx "~{output_prefix}.fa"
+    samtools dict "~{output_prefix}.fa" > "~{output_prefix}.dict"
+
+    # Download PAO1 GTF annotation from NCBI RefSeq
+    # Note: this GTF has the classic bacterial layout (~5573 CDS rows,
+    # ~5697 gene rows, only ~106 exon rows for tRNAs/rRNAs) which is exactly
+    # the case the ww-gffread normalize_gtf task is designed to handle.
+    wget -q -O "~{output_prefix}.gtf.gz" "${BASE_URL}/GCF_000006765.1_ASM676v1_genomic.gtf.gz"
+    gunzip "~{output_prefix}.gtf.gz"
+  >>>
+
+  output {
+    File fasta = "~{output_prefix}.fa"
+    File fasta_index = "~{output_prefix}.fa.fai"
+    File dict = "~{output_prefix}.dict"
+    File gtf = "~{output_prefix}.gtf"
+  }
+
+  runtime {
+    docker: "getwilds/samtools:1.11"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -6,59 +6,66 @@ A comprehensive WILDS WDL pipeline for RNA-seq analysis, covering the core workf
 
 ## Overview
 
-This pipeline extends the simpler `ww-star-deseq2` pipeline with upstream read QC, adapter trimming, and aggregated MultiQC reporting. It integrates 7 WILDS WDL modules to perform a production-ready RNA-seq analysis workflow:
+This pipeline extends the simpler `ww-star-deseq2` pipeline with upstream read QC, adapter trimming, and aggregated MultiQC reporting. It integrates 8 WILDS WDL modules to perform a production-ready RNA-seq analysis workflow:
 
-1. **Pre-trim QC** — Assess raw read quality
-2. **Adapter Trimming** — Remove adapters and low-quality bases
-3. **Post-trim QC** — Verify trimming improved read quality
-4. **Genome Alignment** — Two-pass STAR alignment
-5. **Alignment QC** — Comprehensive post-alignment quality metrics
-6. **Differential Expression** — Count aggregation and DESeq2 analysis
-7. **Aggregated Reporting** — MultiQC summary of all QC metrics
+1. **GTF Normalization** — Ensure annotation has proper exon features (critical for bacterial genomes)
+2. **Pre-trim QC** — Assess raw read quality
+3. **Adapter Trimming** — Remove adapters and low-quality bases
+4. **Post-trim QC** — Verify trimming improved read quality
+5. **Genome Alignment** — Two-pass STAR alignment
+6. **Alignment QC** — Comprehensive post-alignment quality metrics
+7. **Differential Expression** — Count aggregation and DESeq2 analysis
+8. **Aggregated Reporting** — MultiQC summary of all QC metrics
 
 ## Pipeline Structure
 
-**Complexity Level: Advanced** (9 steps, 7 distinct modules)
+**Complexity Level: Advanced** (10 steps, 8 distinct modules)
 
-1. **FastQC — Pre-trim QC** (using `ww-fastqc` module):
+1. **GTF Normalization** (using `ww-gffread` module):
+   - Ensures the reference GTF has proper `exon` features for every transcript
+   - Critical for bacterial NCBI GTFs which only have CDS rows — without this step, STAR and RSeQC silently ignore 98% of protein-coding genes
+   - Eukaryotic GTFs with proper exon annotations pass through unchanged
+
+2. **FastQC — Pre-trim QC** (using `ww-fastqc` module):
    - Generates quality reports for raw FASTQ files
    - Provides baseline quality metrics before trimming
 
-2. **Trim Galore — Adapter Trimming** (using `ww-trimgalore` module):
+3. **Trim Galore — Adapter Trimming** (using `ww-trimgalore` module):
    - Removes adapter sequences and low-quality bases
    - Filters reads below minimum length threshold
    - Produces trimming reports with adapter detection statistics
 
-3. **FastQC — Post-trim QC** (using `ww-fastqc` module):
+4. **FastQC — Post-trim QC** (using `ww-fastqc` module):
    - Generates quality reports for trimmed reads
    - Confirms quality improvement after trimming
 
-4. **STAR Index Building** (using `ww-star` module):
-   - Builds STAR genome index from reference FASTA and GTF files
+5. **STAR Index Building** (using `ww-star` module):
+   - Builds STAR genome index from reference FASTA and normalized GTF
    - Runs once and is reused across all samples
 
-5. **STAR Two-Pass Alignment** (using `ww-star` module):
+6. **STAR Two-Pass Alignment** (using `ww-star` module):
    - Performs two-pass alignment on trimmed reads for each sample
    - Generates BAM files, BAI indices, gene counts, and alignment metrics
 
-6. **GTF to BED Conversion** (using `ww-bedparse` module):
-   - Converts GTF annotation to BED12 format for RSeQC compatibility
+7. **GTF to BED Conversion** (using `ww-bedparse` module):
+   - Converts normalized GTF to BED12 format for RSeQC compatibility
 
-7. **RSeQC — Alignment QC** (using `ww-rseqc` module):
+8. **RSeQC — Alignment QC** (using `ww-rseqc` module):
    - Analyzes read distribution, gene body coverage, and strand specificity
    - Produces comprehensive alignment quality metrics
 
-8. **DESeq2 — Count Assembly and Differential Expression** (using `ww-deseq2` module):
+9. **DESeq2 — Count Assembly and Differential Expression** (using `ww-deseq2` module):
    - Combines gene counts from all samples into a single matrix
    - Performs statistical analysis and generates visualizations (PCA, volcano, heatmap)
 
-9. **MultiQC — Aggregated Reporting** (using `ww-multiqc` module):
-   - Collects reports from FastQC, Trim Galore, STAR, and RSeQC
-   - Generates a single interactive HTML report summarizing all QC metrics
+10. **MultiQC — Aggregated Reporting** (using `ww-multiqc` module):
+    - Collects reports from FastQC, Trim Galore, STAR, and RSeQC
+    - Generates a single interactive HTML report summarizing all QC metrics
 
 ## Module Dependencies
 
 This pipeline imports and uses:
+- **ww-gffread module**: GTF normalization to ensure exon features exist (`normalize_gtf` task)
 - **ww-fastqc module**: Pre-trim and post-trim read quality assessment (`run_fastqc` task)
 - **ww-trimgalore module**: Adapter and quality trimming (`trimgalore_paired` task)
 - **ww-star module**: Genome indexing and read alignment (`build_index`, `align_two_pass` tasks)
@@ -227,16 +234,17 @@ sprocket run testrun.wdl --entrypoint rnaseq_example
 The test workflow automatically:
 1. Downloads small reference genome data (chromosome 1 subset, 50Mbp)
 2. Downloads real RNA-seq data from SRA (4 samples from DESeq2 airway study: 2 untreated + 2 dexamethasone-treated)
-3. Runs pre-trim FastQC on raw reads
-4. Trims adapters with Trim Galore
-5. Runs post-trim FastQC on trimmed reads
-6. Builds STAR genome index
-7. Performs two-pass alignment for all samples
-8. Converts GTF to BED12 format for RSeQC
-9. Runs RSeQC quality control on aligned BAMs
-10. Combines gene count matrices from all samples
-11. Performs DESeq2 differential expression analysis
-12. Aggregates all QC reports with MultiQC
+3. Normalizes the reference GTF (ensures exon features exist for all transcripts)
+4. Runs pre-trim FastQC on raw reads
+5. Trims adapters with Trim Galore
+6. Runs post-trim FastQC on trimmed reads
+7. Builds STAR genome index using normalized GTF
+8. Performs two-pass alignment for all samples
+9. Converts normalized GTF to BED12 format for RSeQC
+10. Runs RSeQC quality control on aligned BAMs
+11. Combines gene count matrices from all samples
+12. Performs DESeq2 differential expression analysis
+13. Aggregates all QC reports with MultiQC
 
 **Test Dataset Details:**
 - Uses 4 samples from SRA (SRR1039508, SRR1039509, SRR1039512, SRR1039513)

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
 
 struct SampleInfo {
     String name

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -4,7 +4,7 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-trimgalore/ww-trimgalore.wdl" as trimgalore_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bedparse/ww-bedparse.wdl" as bedparse_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rseqc/ww-rseqc.wdl" as rseqc_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-rseqc/ww-rseqc.wdl" as rseqc_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as multiqc_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -7,6 +7,8 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rseqc/ww-rseqc.wdl" as rseqc_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as multiqc_tasks
+# TODO: switch to refs/heads/main before merging
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
 
 struct SampleInfo {
     String name
@@ -81,10 +83,18 @@ workflow rnaseq {
     Int genome_sa_index_nbases = 14
   }
 
+  # Normalize GTF to ensure exon features exist for every transcript.
+  # This is critical for bacterial NCBI GTFs which only have CDS rows —
+  # without this step, STAR GeneCounts and RSeQC would silently ignore
+  # 98% of protein-coding genes. For eukaryotic GTFs this is a pass-through.
+  call gffread_tasks.normalize_gtf { input:
+      input_gtf = reference_genome.gtf
+  }
+
   # Build STAR genome index (runs once)
   call star_tasks.build_index { input:
       reference_fasta = reference_genome.fasta,
-      reference_gtf = reference_genome.gtf,
+      reference_gtf = normalize_gtf.normalized_gtf,
       cpu_cores = star_cpu,
       memory_gb = star_memory_gb,
       genome_sa_index_nbases = genome_sa_index_nbases
@@ -92,7 +102,7 @@ workflow rnaseq {
 
   # Convert GTF to BED for RSeQC
   call bedparse_tasks.gtf2bed { input:
-      gtf_file = reference_genome.gtf
+      gtf_file = normalize_gtf.normalized_gtf
   }
 
   scatter (sample in samples) {

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -7,7 +7,6 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rseqc/ww-rseqc.wdl" as rseqc_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as multiqc_tasks
-# TODO: switch to refs/heads/main before merging
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-gtf-processing/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
 
 struct SampleInfo {


### PR DESCRIPTION
## Type of Change

- New module
- Bug fix
- Enhancement
- Documentation update

## Description

### Problem

When `ww-rnaseq` is run on a bacterial genome (e.g. *Pseudomonas aeruginosa* PAO1) using an NCBI RefSeq GTF, the pipeline produces DESeq2 results for only ~100 genes out of ~5,500. Root cause: NCBI bacterial GTFs contain ~5,500 `CDS` rows but only ~100 `exon` rows (for tRNAs/rRNAs). STAR's GeneCounts mode only counts reads overlapping `exon` features, so 98% of protein-coding genes silently drop out of the results. The same issue affects RSeQC via the `gtf2bed` conversion.

### Fix

**New module: `ww-gffread`** — wraps [gffread](https://github.com/gpertea/gffread) (v0.12.7) with two tasks:
- **`normalize_gtf`**: Strips `gene`-type rows with empty `transcript_id` (which cause gffread to error on NCBI bacterial GTFs), then runs `gffread --force-exons` to synthesize `exon` features from `CDS` records. Idempotent — eukaryotic GTFs with proper exon annotations pass through unchanged.
- **`gff3_to_gtf`**: Converts GFF3 to GTF format (useful when upstream sources only publish GFF3).

**Pipeline update: `ww-rnaseq`** — calls `normalize_gtf` before `build_index` and `gtf2bed`, so both STAR and RSeQC receive a properly normalized GTF regardless of what the user provides. No user-facing configuration changes required.

**Test data: `ww-testdata`** — added `download_pao1_ref` task that downloads the NCBI RefSeq PAO1 reference FASTA and GTF (assembly GCF_000006765.1) for use in bacterial RNA-seq test runs.

### RSeQC performance improvement

**`ww-rseqc`** — added `skip_gene_body_cov` parameter (Boolean, default `true`). The `geneBody_coverage.py` analysis is single-threaded and was taking ~5 hours per sample on PAO1 bacterial data. Gene body coverage is now skipped by default; users can re-enable it with `skip_gene_body_cov = false`.

### Verified behavior

- PAO1 NCBI GTF: `exon` count goes from 106 → 5,679 after normalization
- Ensembl human chr15 GTF: `exon` count stays at 45,567 (pass-through)

## Testing

**How did you test these changes?**
- Ran `make lint` on `ww-testdata`, `ww-gffread`, `ww-rseqc`, and `ww-rnaseq` — all pass sprocket, miniwdl, and WOMtool
- Ran `make run_sprocket NAME=ww-gffread` — testrun passes
- Manually executing `ww-rnaseq` test run via PROOF, but see CI/CD test run below as well.

**What workflow engine did you use?**
Sprocket locally, PROOF (Cromwell) on the HPC

**Did the tests pass?**
`ww-gffread` and `ww-testdata` testruns pass. Full `ww-rnaseq` end-to-end on PAO1 data is in progress...

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- **Docker image**: Uses `quay.io/biocontainers/gffread:0.12.7--hdcf5f25_4` temporarily. A `getwilds/gffread:0.12.7` image should be built and published to match repo conventions, then the tag in `ww-gffread.wdl` updated (marked with a TODO comment).
- **RSeQC default change**: `skip_gene_body_cov` defaults to `true`, which is a behavior change for existing users of `ww-rseqc`. The gene body coverage output file is still produced (as a placeholder) so downstream tools like MultiQC don't error.