### PR TITLE
Adding AI disclosure to README and CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -367,6 +367,10 @@ After meeting the requirements above, submit a PR to merge your forked repo into
 
 4. **Request reviews**: Tag Emma Bishop (@emjbishop) or Taylor Firman (@tefirman)
 
+### AI-Assisted Development
+
+We occasionally use large language models (primarily [Claude](https://www.anthropic.com/claude)) to assist with prototyping modules and pipelines, and contributors are welcome to do the same. However, all AI-generated code must go through the same review, testing, and linting process as any other contribution. Please review and understand any AI-generated code before submitting it in a PR.
+
 ### Review Criteria
 
 Your PR will be evaluated on:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -369,7 +369,7 @@ After meeting the requirements above, submit a PR to merge your forked repo into
 
 ### AI-Assisted Development
 
-We occasionally use large language models (primarily [Claude](https://www.anthropic.com/claude)) to assist with prototyping modules and pipelines, and contributors are welcome to do the same. However, all AI-generated code must go through the same review, testing, and linting process as any other contribution. Please review and understand any AI-generated code before submitting it in a PR.
+We occasionally use large language models (primarily [Claude](https://www.anthropic.com/claude)) to assist with prototyping modules and pipelines, and contributors are welcome to do the same. However, all AI-generated code must go through the same testing, linting, and human review process as any other contribution. Please ensure you review and understand any AI-generated code before submitting it in a PR.
 
 ### Review Criteria
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Fred Hutch researchers can use [PROOF](https://sciwiki.fredhutch.org/datademos/p
 - **Documentation Standards**: Comprehensive README files and inline documentation
 - **Version Control**: Semantic versioning and careful dependency management
 
+## AI Disclosure
+
+Large language models (primarily [Claude](https://www.anthropic.com/claude)) have been used to assist with prototyping new modules and pipelines in this repository, including initial drafts of task scaffolding, command structures, and test workflows. All AI-generated code is reviewed, validated, and modified as necessary by human researchers through linting tools, multi-executor test runs (Cromwell, miniWDL, Sprocket), and peer code review. No architectural or scientific decisions are made by AI tools.
+
 ## Contributing
 
 We welcome contributions at all levels:

--- a/docs-README.md
+++ b/docs-README.md
@@ -129,6 +129,12 @@ All tasks use versioned, tested Docker images from the [WILDS Docker Library](ht
 
 ---
 
+## AI Disclosure
+
+Large language models (primarily [Claude](https://www.anthropic.com/claude)) have been used to assist with prototyping new modules and pipelines in this repository, including initial drafts of task scaffolding, command structures, and test workflows. All AI-generated code is reviewed, validated, and modified as necessary by human researchers through linting tools, multi-executor test runs (Cromwell, miniWDL, Sprocket), and peer code review. No architectural or scientific decisions are made by AI tools.
+
+---
+
 ## Getting Help
 
 - **Documentation Issues**: Found something unclear or incorrect? [Report an issue](https://github.com/getwilds/wilds-wdl-library/issues)


### PR DESCRIPTION
## Type of Change

- Documentation update

## Description

Adds an AI disclosure section to the repository's public-facing documentation:
- **[README.md](README.md)**: New "AI Disclosure" section acknowledging use of LLMs (primarily [Claude](https://www.anthropic.com/claude)) for prototyping modules and pipelines
- **[docs-README.md](docs-README.md)**: Matching disclosure on the documentation website
- **[CONTRIBUTING.md](.github/CONTRIBUTING.md)**: New "AI-Assisted Development" subsection under Pull Request Process, clarifying that contributors may use AI tools but all generated code must pass the same review, testing, and linting standards

## Testing

**How did you test these changes?**
Documentation-only changes — no WDL code was modified.

## Documentation

- [x] I updated the README (if applicable)
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~
- [x] I ran `make docs-preview` to check documentation rendering (if applicable)

## Additional Context

This disclosure aligns with the AI usage statement submitted for the BOSC 2025 conference abstract. The language is consistent across all three files.