### PR TITLE
Switching ww-clair3 import URL back to main

### DIFF
--- a/modules/ww-clair3/testrun.wdl
+++ b/modules/ww-clair3/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module in question as well as the testdata module for automatic demo functionality
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-clair3/modules/ww-clair3/ww-clair3.wdl" as ww_clair3
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-clair3/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-clair3/ww-clair3.wdl" as ww_clair3
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 


### PR DESCRIPTION
## Type of Change

- Other: switching import URL back to the `main` branch

## Description

- No functional change, just switching import URL's back to `main`
- See GitHub Action test run below just in case