### PR TITLE
Adding `ww-esmfold` module with CI exclusion support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -275,6 +275,15 @@ All contributions must pass our automated testing pipeline which executes on a P
 - **Integration testing**: Cross-module compatibility testing
 - **Cirro validation**: Validates `.cirro/` configurations for pipelines that include them
 
+#### CI-Excluded Modules
+
+Some modules require more memory than GitHub Actions runners provide (~16 GB) and are excluded from CI test runs. These modules are listed in the `CI_EXCLUDED_ITEMS` dictionary in [`.github/scripts/discover_wdls.py`](.github/scripts/discover_wdls.py). Linting still runs for these modules in CI, and their test workflows are validated on the Fred Hutch HPC on a monthly basis.
+
+Currently excluded:
+- **ww-esmfold**: Requires ~24 GB to load the 3B-parameter ESM-2 model
+
+If your module exceeds GitHub Actions resource limits, add it to `CI_EXCLUDED_ITEMS` and document the exclusion in your module's README. Be sure to verify that the test workflow runs successfully on an HPC or local machine with sufficient resources.
+
 ## Documentation Website
 
 The WILDS WDL Library includes an automatically-generated documentation website that provides comprehensive technical documentation for all modules and pipelines. Understanding how this documentation works is important for contributors.

--- a/.github/scripts/discover_wdls.py
+++ b/.github/scripts/discover_wdls.py
@@ -18,6 +18,12 @@ from pathlib import Path
 # Valid item types
 VALID_TYPES = ['modules', 'pipelines']
 
+# Items excluded from CI test runs (e.g., require more memory than GitHub Actions runners provide)
+CI_EXCLUDED_ITEMS = {
+    'modules': ['ww-esmfold'],
+    'pipelines': [],
+}
+
 def get_changed_files():
     """Get list of changed files in PR, or None for workflow_dispatch"""
     if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request':
@@ -149,6 +155,13 @@ def main():
         # Handle PR - filter by changes
         changed_files = get_changed_files()
         final_items = filter_items_by_changes(all_items, changed_files, item_type)
+
+    # Remove items excluded from CI (e.g., too memory-intensive for GitHub Actions)
+    excluded = CI_EXCLUDED_ITEMS.get(item_type, [])
+    excluded_items = [item for item in final_items if item in excluded]
+    final_items = [item for item in final_items if item not in excluded]
+    for item in excluded_items:
+        print(f"Excluding {item} from CI (in CI_EXCLUDED_ITEMS)")
 
     print(f"\nFinal selection: {len(final_items)} {item_type}")
     for item in final_items:

--- a/.github/workflows/testrun-reusable.yml
+++ b/.github/workflows/testrun-reusable.yml
@@ -34,7 +34,8 @@ jobs:
 
   miniwdl-test:
     needs: [discover]
-    # Test runs at the workflow level become difficult to run due to large collection 
+    if: ${{ needs.discover.outputs.items != '[]' }}
+    # Test runs at the workflow level become difficult to run due to large collection
     # of Docker images that need to be pulled down (see ww-leukemia for example).
     # Consider using larger runners in the future, e.g. ubuntu-latest-4-cores (4-core, 16GB RAM, 150GB disk)
     # https://docs.github.com/en/enterprise-cloud@latest/actions/concepts/runners/larger-runners
@@ -67,7 +68,8 @@ jobs:
 
   cromwell-test:
     needs: [discover]
-    # Test runs at the workflow level become difficult to run due to large collection 
+    if: ${{ needs.discover.outputs.items != '[]' }}
+    # Test runs at the workflow level become difficult to run due to large collection
     # of Docker images that need to be pulled down (see ww-leukemia for example).
     # Consider using larger runners in the future, e.g. ubuntu-latest-4-cores (4-core, 16GB RAM, 150GB disk)
     # https://docs.github.com/en/enterprise-cloud@latest/actions/concepts/runners/larger-runners
@@ -100,7 +102,8 @@ jobs:
 
   sprocket-test:
     needs: [discover]
-    # Test runs at the workflow level become difficult to run due to large collection 
+    if: ${{ needs.discover.outputs.items != '[]' }}
+    # Test runs at the workflow level become difficult to run due to large collection
     # of Docker images that need to be pulled down (see ww-leukemia for example).
     # Consider using larger runners in the future, e.g. ubuntu-latest-4-cores (4-core, 16GB RAM, 150GB disk)
     # https://docs.github.com/en/enterprise-cloud@latest/actions/concepts/runners/larger-runners

--- a/modules/ww-esmfold/README.md
+++ b/modules/ww-esmfold/README.md
@@ -100,7 +100,9 @@ This module integrates seamlessly with other WILDS components:
 
 ## Testing the Module
 
-The module includes a test workflow (`testrun.wdl`) that can be run independently:
+> **Note:** The ESMFold test workflow requires **24 GB of memory** to load the full 3B-parameter ESM-2 model, which exceeds the resources available on GitHub Actions runners (~16 GB). As a result, **this module's `testrun.wdl` is excluded from GitHub CI/CD** and is instead validated on the Fred Hutch HPC on a monthly basis. Linting checks still run in CI as normal.
+
+The module includes a test workflow (`testrun.wdl`) that can be run on an HPC or local machine with sufficient memory:
 
 ```bash
 # Using miniWDL

--- a/modules/ww-esmfold/README.md
+++ b/modules/ww-esmfold/README.md
@@ -1,0 +1,163 @@
+# ww-esmfold Module
+
+[![Project Status: Prototype – Useable, some support, open to feedback, unstable API.](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for predicting protein 3D structures using ESMFold. ESMFold leverages the ESM-2 protein language model for fast, single-sequence structure prediction without requiring multiple sequence alignments (MSAs), making it approximately 60x faster than AlphaFold2-based methods.
+
+## Overview
+
+ESMFold predicts protein structures directly from amino acid sequences using a large protein language model. Unlike AlphaFold2, it does not require MSA computation, which dramatically reduces prediction time. The predicted structures include pLDDT confidence scores in the B-factor column of the output PDB files.
+
+**Key advantages over MSA-based methods:**
+- No MSA or template database required
+- Much faster inference (~60x compared to AlphaFold2)
+- Single-sequence input is sufficient
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and follows the standard WILDS module structure:
+
+- **Main WDL file**: `ww-esmfold.wdl` - Contains task definitions for ESMFold prediction
+- **Test workflow**: `testrun.wdl` - Demonstration workflow for testing and examples
+- **Documentation**: This README with usage examples and parameter descriptions
+
+## Available Tasks
+
+### `esmfold_predict`
+
+Predict protein 3D structures from amino acid sequences using ESMFold.
+
+**Inputs:**
+- `fasta_file` (File): Input FASTA file containing one or more protein sequences to predict
+- `output_prefix` (String): Prefix for naming the output tarball
+- `num_recycles` (Int, default=4): Number of recycling iterations for structure refinement
+- `chunk_size` (Int, default=128): Chunk size for memory-efficient inference on long sequences (0 to disable)
+- `cpu_only` (Boolean, default=false): Run inference on CPU instead of GPU
+- `cpu_offload` (Boolean, default=false): Enable CPU offloading for longer sequences with limited GPU memory
+- `max_tokens_per_batch` (Int, default=0): Maximum tokens per batch for GPU inference (0 for automatic)
+- `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
+- `memory_gb` (Int, default=16): Memory allocated for the task in GB
+- `gpu_enabled` (Boolean, default=true): Enable GPU for prediction
+
+**Outputs:**
+- `pdb_output` (File): Compressed tarball containing predicted PDB structure files with pLDDT confidence scores
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-esmfold/ww-esmfold.wdl" as esmfold_tasks
+
+workflow my_structure_prediction {
+  input {
+    File protein_fasta
+  }
+
+  call esmfold_tasks.esmfold_predict { input:
+      fasta_file = protein_fasta,
+      output_prefix = "my_prediction"
+  }
+
+  output {
+    File predicted_structures = esmfold_predict.pdb_output
+  }
+}
+```
+
+### Advanced Usage Examples
+
+**CPU-only prediction for testing:**
+```wdl
+call esmfold_tasks.esmfold_predict { input:
+    fasta_file = protein_fasta,
+    output_prefix = "cpu_test",
+    cpu_only = true,
+    gpu_enabled = false,
+    num_recycles = 1,
+    cpu_cores = 4,
+    memory_gb = 16
+}
+```
+
+**Long sequence prediction with memory optimization:**
+```wdl
+call esmfold_tasks.esmfold_predict { input:
+    fasta_file = long_protein_fasta,
+    output_prefix = "long_sequence",
+    chunk_size = 64,
+    cpu_offload = true,
+    memory_gb = 32
+}
+```
+
+### Integration Examples
+
+This module integrates seamlessly with other WILDS components:
+- **ww-testdata**: Automatic provisioning of test protein sequences for demonstrations
+- **ww-colabfold**: Alternative structure prediction using AlphaFold2 + MMseqs2
+
+## Testing the Module
+
+The module includes a test workflow (`testrun.wdl`) that can be run independently:
+
+```bash
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl --entrypoint esmfold_example
+
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+```
+
+### Automatic Demo Mode
+
+The test workflow automatically:
+1. Creates a minimal test protein FASTA (Trp-cage miniprotein, 20 residues) using `ww-testdata`
+2. Runs ESMFold prediction with minimal settings (CPU-only, 1 recycle)
+3. Validates that PDB output files were generated
+
+## Docker Container
+
+This module uses the `getwilds/esmfold:2.0.0` container image, which includes:
+- ESM-2 protein language model via the `fair-esm` package
+- OpenFold dependencies for structure module
+- All necessary Python dependencies for inference
+
+## Citation
+
+> Lin, Z., Akin, H., Rao, R., Hie, B., Zhu, Z., Lu, W., ... & Rives, A. (2023).
+> Evolutionary-scale prediction of atomic-level protein structure with a language model.
+> Science, 379(6637), 1123-1130.
+> DOI: https://doi.org/10.1126/science.ade2574
+
+## Parameters and Resource Requirements
+
+### Default Resources
+- **CPU**: 4 cores
+- **Memory**: 16 GB
+- **GPU**: 1 GPU recommended for production use
+
+### Resource Scaling
+- `cpu_cores`: Increase for CPU-only mode or parallel processing
+- `memory_gb`: Increase for longer protein sequences (>500 residues may need 32+ GB)
+- `gpu_enabled`: Set to `true` for production use; `false` for testing
+- `chunk_size`: Reduce (64 or 32) for very long sequences to manage memory usage
+- `cpu_offload`: Enable for sequences that exceed GPU memory
+
+## Support and Feedback
+
+For questions about this module or to report issues:
+- Open an issue in the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library/issues)
+- Contact the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org
+- See the library's [Contributor Guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for detailed guidelines
+
+## Related Resources
+
+- **[WILDS Docker Library](https://github.com/getwilds/wilds-docker-library)**: Container images used by WDL workflows
+- **[WILDS Documentation](https://getwilds.org/)**: Comprehensive guides and best practices
+- **[WDL Specification](https://openwdl.org/)**: Official WDL language documentation
+- **[ESMFold GitHub](https://github.com/facebookresearch/esm)**: Official ESMFold source code and documentation

--- a/modules/ww-esmfold/README.md
+++ b/modules/ww-esmfold/README.md
@@ -9,11 +9,6 @@ A WILDS WDL module for predicting protein 3D structures using ESMFold. ESMFold l
 
 ESMFold predicts protein structures directly from amino acid sequences using a large protein language model. Unlike AlphaFold2, it does not require MSA computation, which dramatically reduces prediction time. The predicted structures include pLDDT confidence scores in the B-factor column of the output PDB files.
 
-**Key advantages over MSA-based methods:**
-- No MSA or template database required
-- Much faster inference (~60x compared to AlphaFold2)
-- Single-sequence input is sufficient
-
 ## Module Structure
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and follows the standard WILDS module structure:
@@ -96,7 +91,7 @@ call esmfold_tasks.esmfold_predict { input:
 
 This module integrates seamlessly with other WILDS components:
 - **ww-testdata**: Automatic provisioning of test protein sequences for demonstrations
-- **ww-colabfold**: Alternative structure prediction using AlphaFold2 + MMseqs2
+- **ww-colabfold**: An alternative structure prediction module using AlphaFold2 + MMseqs2
 
 ## Testing the Module
 

--- a/modules/ww-esmfold/testrun.wdl
+++ b/modules/ww-esmfold/testrun.wdl
@@ -22,7 +22,7 @@ workflow esmfold_example {
       cpu_offload = false,
       max_tokens_per_batch = 0,
       cpu_cores = 2,
-      memory_gb = 24,
+      memory_gb = 12,
       gpu_enabled = false
   }
 

--- a/modules/ww-esmfold/testrun.wdl
+++ b/modules/ww-esmfold/testrun.wdl
@@ -22,7 +22,7 @@ workflow esmfold_example {
       cpu_offload = false,
       max_tokens_per_batch = 0,
       cpu_cores = 2,
-      memory_gb = 12,
+      memory_gb = 24,
       gpu_enabled = false
   }
 

--- a/modules/ww-esmfold/testrun.wdl
+++ b/modules/ww-esmfold/testrun.wdl
@@ -1,0 +1,111 @@
+version 1.0
+
+import "ww-esmfold.wdl" as ww_esmfold
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+
+#### TEST WORKFLOW DEFINITION ####
+# Tests ESMFold structure prediction with a tiny protein sequence on CPU.
+# Uses the Trp-cage miniprotein (20 residues) for fast execution.
+# Note: Production use requires GPU; this test demonstrates the workflow on CPU.
+
+workflow esmfold_example {
+  # Create a minimal test FASTA with a short peptide sequence
+  call ww_testdata.create_test_protein_fasta { }
+
+  # Run ESMFold prediction with minimal settings for CI testing
+  call ww_esmfold.esmfold_predict { input:
+      fasta_file = create_test_protein_fasta.test_fasta,
+      output_prefix = "test_protein",
+      num_recycles = 1,
+      chunk_size = 0,
+      cpu_only = true,
+      cpu_offload = false,
+      max_tokens_per_batch = 0,
+      cpu_cores = 2,
+      memory_gb = 24,
+      gpu_enabled = false
+  }
+
+  # Validate that prediction outputs were generated
+  call validate_outputs { input:
+      results_tarball = esmfold_predict.pdb_output
+  }
+
+  output {
+    File esmfold_results = esmfold_predict.pdb_output
+    File validation_report = validate_outputs.report
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that ESMFold prediction generated expected output files"
+    outputs: {
+        report: "Validation report summarizing file checks and prediction results"
+    }
+  }
+
+  parameter_meta {
+    results_tarball: "Compressed tarball of ESMFold prediction results to validate"
+  }
+
+  input {
+    File results_tarball
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== ESMFold Prediction Validation Report ===" > validation_report.txt
+    echo "" >> validation_report.txt
+
+    # Extract results
+    tar -xzf ~{results_tarball}
+
+    validation_passed=true
+
+    # Check that the output directory exists and has files
+    if [ -d "pdb_output" ]; then
+      file_count=$(find pdb_output/ -type f | wc -l)
+      echo "Output directory: found ${file_count} files" >> validation_report.txt
+    else
+      echo "Output directory: MISSING" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    # Check for PDB structure files
+    pdb_count=$(find pdb_output/ -name "*.pdb" 2>/dev/null | wc -l)
+    echo "PDB structure files: ${pdb_count}" >> validation_report.txt
+    if [ "${pdb_count}" -eq 0 ]; then
+      echo "WARNING: No PDB files found" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    # List all output files
+    echo "" >> validation_report.txt
+    echo "--- Output Files ---" >> validation_report.txt
+    find pdb_output/ -type f -exec ls -lh {} \; >> validation_report.txt 2>/dev/null || true
+
+    # Summary
+    echo "" >> validation_report.txt
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [ "${validation_passed}" = "true" ]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    cpu: 1
+    memory: "2 GB"
+  }
+}

--- a/modules/ww-esmfold/testrun.wdl
+++ b/modules/ww-esmfold/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "ww-esmfold.wdl" as ww_esmfold
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-esmfold/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-esmfold/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 # Tests ESMFold structure prediction with a tiny protein sequence on CPU.

--- a/modules/ww-esmfold/ww-esmfold.wdl
+++ b/modules/ww-esmfold/ww-esmfold.wdl
@@ -1,0 +1,77 @@
+## WILDS WDL for predicting protein structures using ESMFold.
+## ESMFold uses the ESM-2 protein language model for fast, single-sequence
+## protein structure prediction without requiring multiple sequence alignments.
+## Designed to be a modular component within the WILDS ecosystem that can be used
+## independently or integrated with other WILDS workflows.
+
+version 1.0
+
+#### TASK DEFINITIONS ####
+
+task esmfold_predict {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Predict protein 3D structures from amino acid sequences using ESMFold (ESM-2 language model)"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-esmfold/ww-esmfold.wdl"
+    outputs: {
+        pdb_output: "Directory of predicted PDB structure files with pLDDT confidence scores in the B-factor column"
+    }
+  }
+
+  parameter_meta {
+    fasta_file: "Input FASTA file containing one or more protein sequences to predict"
+    output_prefix: "Prefix for naming the output tarball"
+    num_recycles: "Number of recycling iterations for structure refinement (higher may improve accuracy)"
+    chunk_size: "Chunk size for memory-efficient inference on long sequences (e.g., 128, 64, 32). Set to 0 to disable chunking."
+    cpu_only: "Run inference on CPU instead of GPU"
+    cpu_offload: "Enable CPU offloading to handle longer sequences with limited GPU memory"
+    max_tokens_per_batch: "Maximum tokens per batch for GPU inference (0 for automatic batching)"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+    gpu_enabled: "Enable GPU for prediction (recommended for production use)"
+  }
+
+  input {
+    File fasta_file
+    String output_prefix
+    Int num_recycles = 4
+    Int chunk_size = 128
+    Boolean cpu_only = false
+    Boolean cpu_offload = false
+    Int max_tokens_per_batch = 0
+    Int cpu_cores = 4
+    Int memory_gb = 16
+    Boolean gpu_enabled = true
+  }
+
+  command <<<
+    set -eo pipefail
+
+    mkdir -p pdb_output
+
+    # Build the esm-fold command
+    esm-fold \
+      -i ~{fasta_file} \
+      -o pdb_output/ \
+      --num-recycles ~{num_recycles} \
+      ~{if chunk_size > 0 then "--chunk-size " + chunk_size else ""} \
+      ~{if cpu_only then "--cpu-only" else ""} \
+      ~{if cpu_offload then "--cpu-offload" else ""} \
+      ~{if max_tokens_per_batch > 0 then "--max-tokens-per-batch " + max_tokens_per_batch else ""}
+
+    # Package all PDB outputs into a compressed tarball
+    tar -czf "~{output_prefix}_esmfold_results.tar.gz" pdb_output/
+  >>>
+
+  output {
+    File pdb_output = "~{output_prefix}_esmfold_results.tar.gz"
+  }
+
+  runtime {
+    docker: "getwilds/esmfold:2.0.0"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+    gpus: if gpu_enabled then "1" else "0"
+  }
+}


### PR DESCRIPTION
## Type of Change

- New module
- Documentation update

## Description

Adds a new `ww-esmfold` module for predicting protein 3D structures using [ESMFold](https://github.com/facebookresearch/esm), which leverages the ESM-2 protein language model for fast, single-sequence structure prediction without requiring multiple sequence alignments.

Because the ESM-2 model requires ~24 GB of memory to load, the `ww-esmfold` testrun exceeds GitHub Actions runner limits (~16 GB). To address this:

- **CI exclusion**: Added `CI_EXCLUDED_ITEMS` to `discover_wdls.py` to skip resource-intensive modules in GitHub Actions while still running linting.
- **CONTRIBUTING.md**: Documented the CI exclusion process so future contributors know how to handle resource-intensive modules.
- **`testrun-reusable.yml`** — Handles the case where no WDLs are discovered for a given category (e.g., when all items are CI-excluded).

## Related PR

- Addresses part of #307
- See #327 for the companion HPC test run infrastructure that validates CI-excluded modules on the Fred Hutch HPC.

## Testing

**How did you test these changes?**
Ran `testrun.wdl` on the Fred Hutch HPC with sprocket using the Slurm + Apptainer backend. The test workflow predicts the structure of a small protein sequence (Trp-cage miniprotein, 20 residues) on CPU and validates that PDB output files are generated.

**What workflow engine did you use?**
PROOF (Cromwell) via Fred Hutch HPC

**Did the tests pass?**
Yes — the test run completed successfully on the HPC.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs-preview` to check documentation rendering (if applicable)

## Additional Context

- The `getwilds/esmfold:2.0.0` Docker image required a rebuild with `PYTHONNOUSERSITE=1` and a numpy `PIP_CONSTRAINT` to fix a NumPy 1.x vs 2.x incompatibility. The Dockerfile changes were applied in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library).
