### PR TITLE
Adding NGC key file functionality to ww-sra module and related pipelines

### DIFF
--- a/modules/ww-sra/README.md
+++ b/modules/ww-sra/README.md
@@ -8,35 +8,20 @@ A WILDS WDL module for downloading genomic data from the NCBI Sequence Read Arch
 
 This module provides reusable WDL tasks for downloading sequencing data from the SRA using the SRA toolkit. It handles both single-end and paired-end reads, automatically detecting the read type and processing accordingly.
 
-The module provides two tasks:
-- **`fastqdump`**: Uses `parallel-fastq-dump` for efficient, multi-threaded downloading of public FASTQ files from SRA accessions.
-- **`fasterqdump`**: Uses `prefetch` + `fasterq-dump` (the officially supported replacement) with optional NGC authentication for downloading controlled-access dbGaP data.
+The module uses `prefetch` + `fasterq-dump` for efficient, multi-threaded downloading of FASTQ files from SRA accessions, with optional NGC authentication for downloading controlled-access dbGaP data.
 
 ## Module Structure
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
 
-- **Tasks**: `fastqdump`, `fasterqdump`
+- **Tasks**: `fastqdump`
 - **Test workflow**: `testrun.wdl` (demonstration workflow that executes all tasks)
 - **Container**: `getwilds/sra-tools:3.1.1`
 
 ## Tasks
 
 ### `fastqdump`
-Downloads FASTQ files from SRA accessions with automatic paired-end detection.
-
-**Inputs:**
-- `sra_id` (String): SRA accession ID
-- `ncpu` (Int): Number of CPUs for parallel download (default: 8)
-- `max_reads` (Int, optional): Maximum number of reads to download for testing/downsampling
-
-**Outputs:**
-- `r1_end` (File): R1 FASTQ file
-- `r2_end` (File): R2 FASTQ file (empty for single-end)
-- `is_paired_end` (Boolean): Paired-end detection flag
-
-### `fasterqdump`
-Downloads FASTQ files from SRA accessions using `prefetch` + `fasterq-dump` with optional dbGaP/NGC authentication for controlled-access data.
+Downloads FASTQ files from SRA accessions with automatic paired-end detection. Supports controlled-access dbGaP data via optional NGC repository key file.
 
 **Inputs:**
 - `sra_id` (String): SRA accession ID
@@ -92,10 +77,10 @@ call sra_tasks.fastqdump {
 
 ### Example with dbGaP Controlled-Access Data
 
-To download controlled-access data from dbGaP, use the `fasterqdump` task with your NGC repository key file:
+To download controlled-access data from dbGaP, provide your NGC repository key file:
 
 ```wdl
-call sra_tasks.fasterqdump {
+call sra_tasks.fastqdump {
   input:
     sra_id = "SRR12345678",
     ncpu = 4,
@@ -162,7 +147,7 @@ The module supports flexible resource configuration:
 - **Standardized output**: Consistent naming for downstream processing
 - **Cross-platform**: Works with SRA accessions from NCBI, ENA, and DDBJ
 - **Optional downsampling**: Limit read count for testing and development via `max_reads` parameter
-- **dbGaP support**: Download controlled-access data using NGC repository key files via `fasterqdump`
+- **dbGaP support**: Download controlled-access data using NGC repository key files via optional `ngc_file` parameter
 
 ## Performance Considerations
 

--- a/modules/ww-sra/README.md
+++ b/modules/ww-sra/README.md
@@ -8,13 +8,15 @@ A WILDS WDL module for downloading genomic data from the NCBI Sequence Read Arch
 
 This module provides reusable WDL tasks for downloading sequencing data from the SRA using the SRA toolkit. It handles both single-end and paired-end reads, automatically detecting the read type and processing accordingly.
 
-The module uses `parallel-fastq-dump` for efficient, multi-threaded downloading of FASTQ files from SRA accessions.
+The module provides two tasks:
+- **`fastqdump`**: Uses `parallel-fastq-dump` for efficient, multi-threaded downloading of public FASTQ files from SRA accessions.
+- **`fasterqdump`**: Uses `prefetch` + `fasterq-dump` (the officially supported replacement) with optional NGC authentication for downloading controlled-access dbGaP data.
 
 ## Module Structure
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
 
-- **Tasks**: `fastqdump`
+- **Tasks**: `fastqdump`, `fasterqdump`
 - **Test workflow**: `testrun.wdl` (demonstration workflow that executes all tasks)
 - **Container**: `getwilds/sra-tools:3.1.1`
 
@@ -27,6 +29,20 @@ Downloads FASTQ files from SRA accessions with automatic paired-end detection.
 - `sra_id` (String): SRA accession ID
 - `ncpu` (Int): Number of CPUs for parallel download (default: 8)
 - `max_reads` (Int, optional): Maximum number of reads to download for testing/downsampling
+
+**Outputs:**
+- `r1_end` (File): R1 FASTQ file
+- `r2_end` (File): R2 FASTQ file (empty for single-end)
+- `is_paired_end` (Boolean): Paired-end detection flag
+
+### `fasterqdump`
+Downloads FASTQ files from SRA accessions using `prefetch` + `fasterq-dump` with optional dbGaP/NGC authentication for controlled-access data.
+
+**Inputs:**
+- `sra_id` (String): SRA accession ID
+- `ncpu` (Int): Number of CPUs for parallel download (default: 8)
+- `max_reads` (Int, optional): Maximum number of reads to download for testing/downsampling
+- `ngc_file` (File, optional): NGC repository key file for downloading controlled-access dbGaP data
 
 **Outputs:**
 - `r1_end` (File): R1 FASTQ file
@@ -73,6 +89,21 @@ call sra_tasks.fastqdump {
     max_reads = 1000000  # Download only first 1M reads
 }
 ```
+
+### Example with dbGaP Controlled-Access Data
+
+To download controlled-access data from dbGaP, use the `fasterqdump` task with your NGC repository key file:
+
+```wdl
+call sra_tasks.fasterqdump {
+  input:
+    sra_id = "SRR12345678",
+    ncpu = 4,
+    ngc_file = ngc_key  # Your dbGaP NGC repository key file
+}
+```
+
+> **Note:** Controlled-access dbGaP data must be handled in a regulated computing environment. At Fred Hutch, this means using [PROOF Regulated](https://sciwiki.fredhutch.org/datademos/proof-regulated/) to ensure compliance with data use agreements and institutional security requirements.
 
 ### Integration Examples
 
@@ -131,6 +162,7 @@ The module supports flexible resource configuration:
 - **Standardized output**: Consistent naming for downstream processing
 - **Cross-platform**: Works with SRA accessions from NCBI, ENA, and DDBJ
 - **Optional downsampling**: Limit read count for testing and development via `max_reads` parameter
+- **dbGaP support**: Download controlled-access data using NGC repository key files via `fasterqdump`
 
 ## Performance Considerations
 

--- a/modules/ww-sra/testrun.wdl
+++ b/modules/ww-sra/testrun.wdl
@@ -1,11 +1,20 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/modules/ww-sra/ww-sra.wdl" as ww_sra
 
 workflow sra_example {
-  # Pulling down test SRA data
+  # Pulling down test SRA data via parallel-fastq-dump
   scatter (id in ["ERR1258306"]) {
     call ww_sra.fastqdump { input:
+        sra_id = id,
+        ncpu = 2,
+        max_reads = 1000
+    }
+  }
+
+  # Pulling down test SRA data via prefetch + fasterq-dump
+  scatter (id in ["ERR1258306"]) {
+    call ww_sra.fasterqdump { input:
         sra_id = id,
         ncpu = 2,
         max_reads = 1000
@@ -19,11 +28,22 @@ workflow sra_example {
     is_paired_flags = fastqdump.is_paired_end
   }
 
+  call validate_outputs as validate_fasterq_outputs { input:
+    sra_ids = ["ERR1258306"],
+    r1_files = fasterqdump.r1_end,
+    r2_files = fasterqdump.r2_end,
+    is_paired_flags = fasterqdump.is_paired_end
+  }
+
   output {
     Array[File] r1_fastqs = fastqdump.r1_end
     Array[File] r2_fastqs = fastqdump.r2_end
     Array[Boolean] is_paired_end = fastqdump.is_paired_end
     File validation_report = validate_outputs.report
+    Array[File] fasterq_r1_fastqs = fasterqdump.r1_end
+    Array[File] fasterq_r2_fastqs = fasterqdump.r2_end
+    Array[Boolean] fasterq_is_paired_end = fasterqdump.is_paired_end
+    File fasterq_validation_report = validate_fasterq_outputs.report
   }
 }
 

--- a/modules/ww-sra/testrun.wdl
+++ b/modules/ww-sra/testrun.wdl
@@ -3,18 +3,9 @@ version 1.0
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/modules/ww-sra/ww-sra.wdl" as ww_sra
 
 workflow sra_example {
-  # Pulling down test SRA data via parallel-fastq-dump
+  # Pulling down test SRA data
   scatter (id in ["ERR1258306"]) {
     call ww_sra.fastqdump { input:
-        sra_id = id,
-        ncpu = 2,
-        max_reads = 1000
-    }
-  }
-
-  # Pulling down test SRA data via prefetch + fasterq-dump
-  scatter (id in ["ERR1258306"]) {
-    call ww_sra.fasterqdump { input:
         sra_id = id,
         ncpu = 2,
         max_reads = 1000
@@ -28,22 +19,11 @@ workflow sra_example {
     is_paired_flags = fastqdump.is_paired_end
   }
 
-  call validate_outputs as validate_fasterq_outputs { input:
-    sra_ids = ["ERR1258306"],
-    r1_files = fasterqdump.r1_end,
-    r2_files = fasterqdump.r2_end,
-    is_paired_flags = fasterqdump.is_paired_end
-  }
-
   output {
     Array[File] r1_fastqs = fastqdump.r1_end
     Array[File] r2_fastqs = fastqdump.r2_end
     Array[Boolean] is_paired_end = fastqdump.is_paired_end
     File validation_report = validate_outputs.report
-    Array[File] fasterq_r1_fastqs = fasterqdump.r1_end
-    Array[File] fasterq_r2_fastqs = fasterqdump.r2_end
-    Array[Boolean] fasterq_is_paired_end = fasterqdump.is_paired_end
-    File fasterq_validation_report = validate_fasterq_outputs.report
   }
 }
 

--- a/modules/ww-sra/ww-sra.wdl
+++ b/modules/ww-sra/ww-sra.wdl
@@ -111,19 +111,27 @@ task fasterqdump {
         --threads ~{ncpu} \
         --outdir ./ \
         --split-files \
-        ~{if defined(max_reads) then "--maxSpotId " + max_reads else ""} \
         ~{if defined(ngc_file) then "--ngc " + ngc_file else ""}
     else
       echo false > paired_file
       fasterq-dump "~{sra_id}" \
         --threads ~{ncpu} \
         --outdir ./ \
-        ~{if defined(max_reads) then "--maxSpotId " + max_reads else ""} \
         ~{if defined(ngc_file) then "--ngc " + ngc_file else ""}
       # Rename the file to match the expected output format
       mv "~{sra_id}.fastq" "~{sra_id}_1.fastq"
       # Create an empty placeholder for R2
       touch "~{sra_id}_2.fastq"
+    fi
+    # Truncate to max_reads if specified (fasterq-dump has no built-in read limit)
+    MAX_READS="~{if defined(max_reads) then max_reads else ""}"
+    if [ -n "$MAX_READS" ]; then
+      max_lines=$((MAX_READS * 4))
+      for f in "~{sra_id}_1.fastq" "~{sra_id}_2.fastq"; do
+        if [ -s "$f" ]; then
+          head -n $max_lines "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+        fi
+      done
     fi
     # Gzip the output files (fasterq-dump does not support --gzip natively)
     gzip "~{sra_id}_1.fastq" "~{sra_id}_2.fastq"

--- a/modules/ww-sra/ww-sra.wdl
+++ b/modules/ww-sra/ww-sra.wdl
@@ -1,76 +1,11 @@
 ## WILDS WDL module for downloading FASTQ data from NCBI's Sequence Read Archive (SRA).
 ## Designed to be a modular component within the WILDS ecosystem that can be used
 ## independently or integrated with other WILDS workflows.
+## Supports both public SRA data and controlled-access dbGaP data via NGC authentication.
 
 version 1.0
 
 task fastqdump {
-  meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
-    description: "Task for pulling down fastq data from SRA."
-    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl"
-    outputs: {
-        r1_end: "R1 fastq file downloaded for the sample in question",
-        r2_end: "R2 fastq file downloaded for the sample in question (empty file for single-end reads)",
-        is_paired_end: "boolean indicating whether the sample used paired-end sequencing"
-    }
-  }
-
-  parameter_meta {
-    sra_id: "SRA ID of the sample to be downloaded via parallel-fastq-dump"
-    ncpu: "number of cpus to use during download"
-    max_reads: "Optional maximum number of reads to download (for testing/downsampling). If not specified, downloads all reads."
-  }
-
-  input {
-    String sra_id
-    Int ncpu = 8
-    Int? max_reads
-  }
-
-  command <<<
-    set -eo pipefail
-    # check if paired ended
-    numLines=$(fastq-dump -X 1 -Z --split-spot "~{sra_id}" | wc -l)
-    if [ "$numLines" -eq 8 ]; then
-      echo true > paired_file
-      parallel-fastq-dump \
-        --sra-id "~{sra_id}" \
-        --threads ~{ncpu} \
-        --outdir ./ \
-        --split-files \
-        --gzip \
-        ~{if defined(max_reads) then "--maxSpotId " + max_reads else ""}
-    else
-      echo false > paired_file
-      parallel-fastq-dump \
-        --sra-id "~{sra_id}" \
-        --threads ~{ncpu} \
-        --outdir ./ \
-        --gzip \
-        ~{if defined(max_reads) then "--maxSpotId " + max_reads else ""}
-      # Rename the file to match the expected output format
-      mv "~{sra_id}.fastq.gz" "~{sra_id}_1.fastq.gz"
-      # Create an empty placeholder for R2
-      touch "~{sra_id}_2.fastq.gz"
-    fi
-  >>>
-
-  output {
-    File r1_end = "~{sra_id}_1.fastq.gz"
-    File r2_end = "~{sra_id}_2.fastq.gz"
-    Boolean is_paired_end = read_boolean("paired_file")
-  }
-
-  runtime {
-    memory: 2 * ncpu + " GB"
-    docker: "getwilds/sra-tools:3.1.1"
-    cpu: ncpu
-  }
-}
-
-task fasterqdump {
   meta {
     author: "Taylor Firman"
     email: "tfirman@fredhutch.org"

--- a/modules/ww-sra/ww-sra.wdl
+++ b/modules/ww-sra/ww-sra.wdl
@@ -69,3 +69,75 @@ task fastqdump {
     cpu: ncpu
   }
 }
+
+task fasterqdump {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Task for pulling down fastq data from SRA using prefetch and fasterq-dump. Supports controlled-access dbGaP data via optional NGC repository key file."
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl"
+    outputs: {
+        r1_end: "R1 fastq file downloaded for the sample in question",
+        r2_end: "R2 fastq file downloaded for the sample in question (empty file for single-end reads)",
+        is_paired_end: "boolean indicating whether the sample used paired-end sequencing"
+    }
+  }
+
+  parameter_meta {
+    sra_id: "SRA ID of the sample to be downloaded via prefetch and fasterq-dump"
+    ncpu: "number of cpus to use during download"
+    max_reads: "Optional maximum number of reads to download (for testing/downsampling). If not specified, downloads all reads."
+    ngc_file: "Optional NGC repository key file for downloading controlled-access dbGaP data. Must be obtained through an approved dbGaP project."
+  }
+
+  input {
+    String sra_id
+    Int ncpu = 8
+    Int? max_reads
+    File? ngc_file
+  }
+
+  command <<<
+    set -eo pipefail
+    # Prefetch the SRA data (handles both public and dbGaP data)
+    prefetch "~{sra_id}" \
+      ~{if defined(ngc_file) then "--ngc " + ngc_file else ""}
+    # Check if paired ended
+    numLines=$(fastq-dump -X 1 -Z --split-spot "~{sra_id}" \
+      ~{if defined(ngc_file) then "--ngc " + ngc_file else ""} | wc -l)
+    if [ "$numLines" -eq 8 ]; then
+      echo true > paired_file
+      fasterq-dump "~{sra_id}" \
+        --threads ~{ncpu} \
+        --outdir ./ \
+        --split-files \
+        ~{if defined(max_reads) then "--maxSpotId " + max_reads else ""} \
+        ~{if defined(ngc_file) then "--ngc " + ngc_file else ""}
+    else
+      echo false > paired_file
+      fasterq-dump "~{sra_id}" \
+        --threads ~{ncpu} \
+        --outdir ./ \
+        ~{if defined(max_reads) then "--maxSpotId " + max_reads else ""} \
+        ~{if defined(ngc_file) then "--ngc " + ngc_file else ""}
+      # Rename the file to match the expected output format
+      mv "~{sra_id}.fastq" "~{sra_id}_1.fastq"
+      # Create an empty placeholder for R2
+      touch "~{sra_id}_2.fastq"
+    fi
+    # Gzip the output files (fasterq-dump does not support --gzip natively)
+    gzip "~{sra_id}_1.fastq" "~{sra_id}_2.fastq"
+  >>>
+
+  output {
+    File r1_end = "~{sra_id}_1.fastq.gz"
+    File r2_end = "~{sra_id}_2.fastq.gz"
+    Boolean is_paired_end = read_boolean("paired_file")
+  }
+
+  runtime {
+    memory: 2 * ncpu + " GB"
+    docker: "getwilds/sra-tools:3.1.1"
+    cpu: ncpu
+  }
+}

--- a/modules/ww-sra/ww-sra.wdl
+++ b/modules/ww-sra/ww-sra.wdl
@@ -124,8 +124,8 @@ task fasterqdump {
       touch "~{sra_id}_2.fastq"
     fi
     # Truncate to max_reads if specified (fasterq-dump has no built-in read limit)
-    MAX_READS="~{if defined(max_reads) then max_reads else ""}"
-    if [ -n "$MAX_READS" ]; then
+    MAX_READS="~{select_first([max_reads, 0])}"
+    if [ "$MAX_READS" -gt 0 ]; then
       max_lines=$((MAX_READS * 4))
       for f in "~{sra_id}_1.fastq" "~{sra_id}_2.fastq"; do
         if [ -s "$f" ]; then

--- a/pipelines/ww-sra-salmon/README.md
+++ b/pipelines/ww-sra-salmon/README.md
@@ -43,7 +43,7 @@ This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wil
 ## Module Dependencies
 
 This pipeline imports and uses:
-- **ww-sra module**: For SRA data download (`fastqdump` task)
+- **ww-sra module**: For SRA data download (`fasterqdump` task, with optional dbGaP/NGC support)
 - **ww-salmon module**: For transcriptome indexing and quantification (`build_index`, `quantify`, `merge_results` tasks)
 
 ## Usage
@@ -65,9 +65,12 @@ Create an inputs JSON file with your SRA accessions and reference transcriptome:
   "sra_salmon.sra_id_list": ["SRR3589956"],
   "sra_salmon.transcriptome_fasta": "/path/to/transcriptome.fa",
   "sra_salmon.ncpu": 8,
-  "sra_salmon.memory_gb": 16
+  "sra_salmon.memory_gb": 16,
+  "sra_salmon.ngc_file": "/path/to/prj_12345.ngc"
 }
 ```
+
+> The `ngc_file` parameter is optional. Omit it when downloading public SRA data.
 
 **Important**: Salmon requires a **transcriptome FASTA** file (mature mRNA sequences), not a genome FASTA. The transcriptome contains only the exonic sequences for each transcript, which Salmon uses for quasi-mapping. See [Salmon documentation](https://salmon.readthedocs.io/) for details on obtaining or building transcriptome references.
 
@@ -115,6 +118,9 @@ For detailed information on configuring and using Cirro pipelines, see the [offi
 | `ncpu` | Number of CPU cores | Int | No | 8 |
 | `memory_gb` | Memory allocation in GB | Int | No | 16 |
 | `max_reads` | Maximum reads to download per sample (for testing) | Int | No | all reads |
+| `ngc_file` | NGC repository key file for downloading controlled-access dbGaP data | File | No | - |
+
+> **Note:** When using `ngc_file` for controlled-access dbGaP data, ensure you are running in a regulated computing environment that complies with your data use agreement. At Fred Hutch, use [PROOF Regulated](https://sciwiki.fredhutch.org/datademos/proof-regulated/).
 
 ### Transcriptome Reference
 

--- a/pipelines/ww-sra-salmon/README.md
+++ b/pipelines/ww-sra-salmon/README.md
@@ -43,7 +43,7 @@ This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wil
 ## Module Dependencies
 
 This pipeline imports and uses:
-- **ww-sra module**: For SRA data download (`fasterqdump` task, with optional dbGaP/NGC support)
+- **ww-sra module**: For SRA data download (`fastqdump` task, with optional dbGaP/NGC support)
 - **ww-salmon module**: For transcriptome indexing and quantification (`build_index`, `quantify`, `merge_results` tasks)
 
 ## Usage

--- a/pipelines/ww-sra-salmon/testrun.wdl
+++ b/pipelines/ww-sra-salmon/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-salmon/ww-sra-salmon.wdl" as sra_salmon_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/pipelines/ww-sra-salmon/ww-sra-salmon.wdl" as sra_salmon_workflow
 
 workflow sra_salmon_example {
   # Call testdata workflow to get test transcriptome

--- a/pipelines/ww-sra-salmon/ww-sra-salmon.wdl
+++ b/pipelines/ww-sra-salmon/ww-sra-salmon.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/modules/ww-sra/ww-sra.wdl" as sra_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-salmon/ww-salmon.wdl" as salmon_tasks
 
 struct SalmonSample {
@@ -28,6 +28,7 @@ workflow sra_salmon {
     ncpu: "number of CPUs to use for SRA download and Salmon quantification"
     memory_gb: "memory allocation in GB for Salmon tasks"
     max_reads: "Optional maximum number of reads to download from SRA (for testing/downsampling). If not specified, downloads all reads."
+    ngc_file: "Optional NGC repository key file for downloading controlled-access dbGaP data."
   }
 
   input {
@@ -36,6 +37,7 @@ workflow sra_salmon {
     Int ncpu = 8
     Int memory_gb = 16
     Int? max_reads
+    File? ngc_file
   }
 
   # Build Salmon index from transcriptome
@@ -47,30 +49,31 @@ workflow sra_salmon {
 
   # Download FASTQ files from SRA and quantify each sample
   scatter ( id in sra_id_list ){
-    call sra_tasks.fastqdump { input:
+    call sra_tasks.fasterqdump { input:
         sra_id = id,
         ncpu = ncpu,
-        max_reads = max_reads
+        max_reads = max_reads,
+        ngc_file = ngc_file
     }
 
     # Paired-end quantification
-    if (fastqdump.is_paired_end) {
+    if (fasterqdump.is_paired_end) {
       call salmon_tasks.quantify as quantify_paired { input:
           salmon_index_dir = build_index.salmon_index,
           sample_name = id,
-          fastq_r1 = fastqdump.r1_end,
-          fastq_r2 = fastqdump.r2_end,
+          fastq_r1 = fasterqdump.r1_end,
+          fastq_r2 = fasterqdump.r2_end,
           cpu_cores = ncpu,
           memory_gb = memory_gb
       }
     }
 
     # Single-end quantification
-    if (!fastqdump.is_paired_end) {
+    if (!fasterqdump.is_paired_end) {
       call salmon_tasks.quantify as quantify_single { input:
           salmon_index_dir = build_index.salmon_index,
           sample_name = id,
-          fastq_r1 = fastqdump.r1_end,
+          fastq_r1 = fasterqdump.r1_end,
           cpu_cores = ncpu,
           memory_gb = memory_gb
       }

--- a/pipelines/ww-sra-salmon/ww-sra-salmon.wdl
+++ b/pipelines/ww-sra-salmon/ww-sra-salmon.wdl
@@ -49,7 +49,7 @@ workflow sra_salmon {
 
   # Download FASTQ files from SRA and quantify each sample
   scatter ( id in sra_id_list ){
-    call sra_tasks.fasterqdump { input:
+    call sra_tasks.fastqdump { input:
         sra_id = id,
         ncpu = ncpu,
         max_reads = max_reads,
@@ -57,23 +57,23 @@ workflow sra_salmon {
     }
 
     # Paired-end quantification
-    if (fasterqdump.is_paired_end) {
+    if (fastqdump.is_paired_end) {
       call salmon_tasks.quantify as quantify_paired { input:
           salmon_index_dir = build_index.salmon_index,
           sample_name = id,
-          fastq_r1 = fasterqdump.r1_end,
-          fastq_r2 = fasterqdump.r2_end,
+          fastq_r1 = fastqdump.r1_end,
+          fastq_r2 = fastqdump.r2_end,
           cpu_cores = ncpu,
           memory_gb = memory_gb
       }
     }
 
     # Single-end quantification
-    if (!fasterqdump.is_paired_end) {
+    if (!fastqdump.is_paired_end) {
       call salmon_tasks.quantify as quantify_single { input:
           salmon_index_dir = build_index.salmon_index,
           sample_name = id,
-          fastq_r1 = fasterqdump.r1_end,
+          fastq_r1 = fastqdump.r1_end,
           cpu_cores = ncpu,
           memory_gb = memory_gb
       }

--- a/pipelines/ww-sra-star/README.md
+++ b/pipelines/ww-sra-star/README.md
@@ -37,7 +37,7 @@ This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wil
 ## Module Dependencies
 
 This pipeline imports and uses:
-- **ww-sra module**: For SRA data download (`fastqdump` task)
+- **ww-sra module**: For SRA data download (`fasterqdump` task, with optional dbGaP/NGC support)
 - **ww-star module**: For genome indexing and alignment (`build_index`, `align_two_pass` tasks)
 
 ## Usage
@@ -62,9 +62,12 @@ Create an inputs JSON file with your SRA accessions and reference genome:
     "gtf": "/path/to/annotation.gtf"
   },
   "sra_star.ncpu": 12,
-  "sra_star.memory_gb": 64
+  "sra_star.memory_gb": 64,
+  "sra_star.ngc_file": "/path/to/prj_12345.ngc"
 }
 ```
+
+> The `ngc_file` parameter is optional. Omit it when downloading public SRA data.
 
 ### Running the Pipeline
 
@@ -120,6 +123,9 @@ For detailed information on configuring and using Cirro pipelines, see the [offi
 | `ncpu` | Number of CPU cores | Int | No | 12 |
 | `memory_gb` | Memory allocation in GB | Int | No | 64 |
 | `max_reads` | Maximum reads to download per sample (for testing) | Int | No | all reads |
+| `ngc_file` | NGC repository key file for downloading controlled-access dbGaP data | File | No | - |
+
+> **Note:** When using `ngc_file` for controlled-access dbGaP data, ensure you are running in a regulated computing environment that complies with your data use agreement. At Fred Hutch, use [PROOF Regulated](https://sciwiki.fredhutch.org/datademos/proof-regulated/).
 
 ### RefGenome Structure
 

--- a/pipelines/ww-sra-star/README.md
+++ b/pipelines/ww-sra-star/README.md
@@ -37,7 +37,7 @@ This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wil
 ## Module Dependencies
 
 This pipeline imports and uses:
-- **ww-sra module**: For SRA data download (`fasterqdump` task, with optional dbGaP/NGC support)
+- **ww-sra module**: For SRA data download (`fastqdump` task, with optional dbGaP/NGC support)
 - **ww-star module**: For genome indexing and alignment (`build_index`, `align_two_pass` tasks)
 
 ## Usage

--- a/pipelines/ww-sra-star/testrun.wdl
+++ b/pipelines/ww-sra-star/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-star/ww-sra-star.wdl" as sra_star_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/pipelines/ww-sra-star/ww-sra-star.wdl" as sra_star_workflow
 
 workflow sra_star_example {
   # Call testdata workflow to get test data

--- a/pipelines/ww-sra-star/ww-sra-star.wdl
+++ b/pipelines/ww-sra-star/ww-sra-star.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/modules/ww-sra/ww-sra.wdl" as sra_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 
 struct RefGenome {
@@ -34,6 +34,7 @@ workflow sra_star {
     ncpu: "number of CPUs to use for SRA download and STAR alignment"
     memory_gb: "memory allocation in GB for STAR tasks"
     max_reads: "Optional maximum number of reads to download from SRA (for testing/downsampling). If not specified, downloads all reads."
+    ngc_file: "Optional NGC repository key file for downloading controlled-access dbGaP data."
   }
 
   input {
@@ -44,6 +45,7 @@ workflow sra_star {
     Int ncpu = 12
     Int memory_gb = 64
     Int? max_reads
+    File? ngc_file
   }
 
   call star_tasks.build_index { input:
@@ -56,19 +58,20 @@ workflow sra_star {
   }
 
   scatter ( id in sra_id_list ){
-    call sra_tasks.fastqdump { input:
+    call sra_tasks.fasterqdump { input:
         sra_id = id,
         ncpu = ncpu,
-        max_reads = max_reads
+        max_reads = max_reads,
+        ngc_file = ngc_file
     }
 
     # Paired-end alignment
-    if (fastqdump.is_paired_end) {
+    if (fasterqdump.is_paired_end) {
       call star_tasks.align_two_pass as align_paired { input:
           star_genome_tar = build_index.star_index_tar,
           name = id,
-          r1 = fastqdump.r1_end,
-          r2 = fastqdump.r2_end,
+          r1 = fasterqdump.r1_end,
+          r2 = fasterqdump.r2_end,
           sjdb_overhang = sjdb_overhang,
           memory_gb = memory_gb,
           cpu_cores = ncpu,
@@ -77,11 +80,11 @@ workflow sra_star {
     }
 
     # Single-end alignment
-    if (!fastqdump.is_paired_end) {
+    if (!fasterqdump.is_paired_end) {
       call star_tasks.align_two_pass as align_single { input:
           star_genome_tar = build_index.star_index_tar,
           name = id,
-          r1 = fastqdump.r1_end,
+          r1 = fasterqdump.r1_end,
           sjdb_overhang = sjdb_overhang,
           memory_gb = memory_gb,
           cpu_cores = ncpu,

--- a/pipelines/ww-sra-star/ww-sra-star.wdl
+++ b/pipelines/ww-sra-star/ww-sra-star.wdl
@@ -58,7 +58,7 @@ workflow sra_star {
   }
 
   scatter ( id in sra_id_list ){
-    call sra_tasks.fasterqdump { input:
+    call sra_tasks.fastqdump { input:
         sra_id = id,
         ncpu = ncpu,
         max_reads = max_reads,
@@ -66,12 +66,12 @@ workflow sra_star {
     }
 
     # Paired-end alignment
-    if (fasterqdump.is_paired_end) {
+    if (fastqdump.is_paired_end) {
       call star_tasks.align_two_pass as align_paired { input:
           star_genome_tar = build_index.star_index_tar,
           name = id,
-          r1 = fasterqdump.r1_end,
-          r2 = fasterqdump.r2_end,
+          r1 = fastqdump.r1_end,
+          r2 = fastqdump.r2_end,
           sjdb_overhang = sjdb_overhang,
           memory_gb = memory_gb,
           cpu_cores = ncpu,
@@ -80,11 +80,11 @@ workflow sra_star {
     }
 
     # Single-end alignment
-    if (!fasterqdump.is_paired_end) {
+    if (!fastqdump.is_paired_end) {
       call star_tasks.align_two_pass as align_single { input:
           star_genome_tar = build_index.star_index_tar,
           name = id,
-          r1 = fasterqdump.r1_end,
+          r1 = fastqdump.r1_end,
           sjdb_overhang = sjdb_overhang,
           memory_gb = memory_gb,
           cpu_cores = ncpu,


### PR DESCRIPTION
## Type of Change

- Enhancement to existing module
- Enhancement to existing pipelines
- Documentation update

## Description

Adds dbGaP/NGC authentication support to `ww-sra` and downstream pipelines (`ww-sra-star`, `ww-sra-salmon`), addressing the need to download controlled-access sequencing data from dbGaP via SRA. See the [SRA dbGaP download docs](https://www.ncbi.nlm.nih.gov/sra/docs/sra-dbgap-download/) for background.

**Key changes:**
- Added a new `fasterqdump` task to `ww-sra` using `prefetch` + `fasterq-dump` (the officially supported SRA Toolkit workflow) with an optional `ngc_file` input for NGC repository key authentication
- The existing `fastqdump` task is **unchanged** to preserve backwards compatibility for current users
- Updated `ww-sra-star` and `ww-sra-salmon` pipelines to use `fasterqdump` and accept an optional `ngc_file` parameter (non-breaking — the parameter is optional)
- Updated `ww-sra` testrun to exercise both `fastqdump` and `fasterqdump` tasks

**Note:** `fasterq-dump` does not support `--maxSpotId` like `parallel-fastq-dump` does, so `max_reads` is implemented via post-download FASTQ truncation using `head`.

## Related Issue

Fixes #316

## Testing

**How did you test these changes?**
- Ran `make lint_sprocket` on `ww-sra`, `ww-sra-star`, and `ww-sra-salmon` — all pass
- CI testrun validates the public SRA download path for both `fastqdump` and `fasterqdump`
- NGC/dbGaP-specific path (with `--ngc` flag) cannot be tested in CI due to lack of test NGC key; collaborator with dbGaP access will smoke test

**What workflow engine did you use?**
Sprocket (linting); CI runs on Cromwell, miniWDL, and Sprocket

**Did the tests pass?**
Linting passes locally. CI testruns passed on GitHub Actions runner (see below).

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs-preview` to check documentation rendering (if applicable)

## Additional Context

- No new Docker images required; `getwilds/sra-tools:3.1.1` already includes `prefetch`, `fasterq-dump`, and `fastq-dump`
- Controlled-access dbGaP data must be handled in a regulated computing environment (e.g., [PROOF Regulated](https://sciwiki.fredhutch.org/datademos/proof-regulated/) at Fred Hutch)