### PR TITLE
Switching import URL's back to `main` branch

### DIFF
--- a/modules/ww-sra/testrun.wdl
+++ b/modules/ww-sra/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/modules/ww-sra/ww-sra.wdl" as ww_sra
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
 
 workflow sra_example {
   # Pulling down test SRA data

--- a/pipelines/ww-sra-salmon/testrun.wdl
+++ b/pipelines/ww-sra-salmon/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/pipelines/ww-sra-salmon/ww-sra-salmon.wdl" as sra_salmon_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-salmon/ww-sra-salmon.wdl" as sra_salmon_workflow
 
 workflow sra_salmon_example {
   # Call testdata workflow to get test transcriptome

--- a/pipelines/ww-sra-salmon/ww-sra-salmon.wdl
+++ b/pipelines/ww-sra-salmon/ww-sra-salmon.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/modules/ww-sra/ww-sra.wdl" as sra_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-salmon/ww-salmon.wdl" as salmon_tasks
 
 struct SalmonSample {

--- a/pipelines/ww-sra-star/testrun.wdl
+++ b/pipelines/ww-sra-star/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/pipelines/ww-sra-star/ww-sra-star.wdl" as sra_star_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-star/ww-sra-star.wdl" as sra_star_workflow
 
 workflow sra_star_example {
   # Call testdata workflow to get test data

--- a/pipelines/ww-sra-star/ww-sra-star.wdl
+++ b/pipelines/ww-sra-star/ww-sra-star.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/sra-dbgap/modules/ww-sra/ww-sra.wdl" as sra_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 
 struct RefGenome {


### PR DESCRIPTION
## Type of Change

- Other: switching import URL's back to the `main` branch after updates to the `ww-sra` module

## Description

- No functional changes, just switching import URL's back to the `main` branch
- See GitHub Action test runs below just in case