### PR TITLE
Adding HPC test run infrastructure

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -277,7 +277,7 @@ All contributions must pass our automated testing pipeline which executes on a P
 
 #### CI-Excluded Modules
 
-Some modules require more memory than GitHub Actions runners provide (~16 GB) and are excluded from CI test runs. These modules are listed in the `CI_EXCLUDED_ITEMS` dictionary in [`.github/scripts/discover_wdls.py`](.github/scripts/discover_wdls.py). Linting still runs for these modules in CI, and their test workflows are validated on the Fred Hutch HPC on a monthly basis (see below).
+Some modules require more memory than GitHub Actions runners provide (~16 GB) and are excluded from CI test runs. These modules are listed in the `CI_EXCLUDED_ITEMS` dictionary in [`.github/scripts/discover_wdls.py`](.github/scripts/discover_wdls.py). Linting still runs for these modules in CI, and their test workflows are validated on the Fred Hutch high performance computing (HPC) cluster on a monthly basis (see below).
 
 Currently excluded:
 - **ww-esmfold**: Requires ~24 GB to load the 3B-parameter ESM-2 model
@@ -286,7 +286,7 @@ If your module exceeds GitHub Actions resource limits, add it to `CI_EXCLUDED_IT
 
 #### HPC Monthly Test Runs
 
-To supplement GitHub Actions CI (which has resource limits), we run the full test suite monthly on the Fred Hutch HPC using a SLURM batch script. This ensures that CI-excluded modules are still regularly validated, and that all modules/pipelines work under HPC execution conditions (Slurm + Apptainer).
+Contributors should be aware that to supplement GitHub Actions CI (which has resource limits), we run the full test suite monthly on the Fred Hutch HPC using a SLURM batch script. This ensures that CI-excluded modules are still regularly validated, and that all modules/pipelines work under HPC execution conditions (Slurm + Apptainer).
 
 The infrastructure consists of two scripts:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -279,14 +279,20 @@ All contributions must pass our automated testing pipeline which executes on a P
 
 To supplement GitHub Actions CI (which has resource limits), we run the full test suite monthly on the Fred Hutch HPC using a SLURM batch script. This ensures that CI-excluded modules are still regularly validated, and that all modules/pipelines work under HPC execution conditions (Slurm + Apptainer).
 
-The script is located at [`.github/scripts/hpc-testrun.sbatch`](.github/scripts/hpc-testrun.sbatch) and results are posted as comments on a central GitHub tracking issue for visibility. To run it:
+The infrastructure consists of two scripts:
+
+- [`.github/scripts/hpc-testrun.sbatch`](.github/scripts/hpc-testrun.sbatch) — SLURM batch script that clones the repo, runs `make run_sprocket` with a [Slurm + Apptainer sprocket config](https://sprocket.bio/guides/slurm), and invokes the report script.
+- [`.github/scripts/hpc_testrun_report.py`](.github/scripts/hpc_testrun_report.py) — Python script that parses the test output and posts a pass/fail summary as a comment on a central GitHub tracking issue.
+
+To run it:
 
 ```bash
 export GITHUB_ISSUE_NUMBER=<tracking_issue_number>
-sbatch .github/scripts/hpc-testrun.sbatch
+export WORK_DIR=/hpc/temp/your-username/wilds-testrun
+sbatch /path/to/hpc-testrun.sbatch
 ```
 
-The script uses `make run_sprocket` with a [Slurm + Apptainer sprocket config](https://sprocket.bio/guides/slurm) and posts a pass/fail summary to the tracking issue after each run. You can also run the test suite manually on the HPC with:
+You can also run the test suite manually on the HPC without the SLURM script:
 
 ```bash
 make run_sprocket SPROCKET_CONFIG=/path/to/your/sprocket-slurm-config.toml

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -275,6 +275,23 @@ All contributions must pass our automated testing pipeline which executes on a P
 - **Integration testing**: Cross-module compatibility testing
 - **Cirro validation**: Validates `.cirro/` configurations for pipelines that include them
 
+#### HPC Monthly Test Runs
+
+To supplement GitHub Actions CI (which has resource limits), we run the full test suite monthly on the Fred Hutch HPC using a SLURM batch script. This ensures that CI-excluded modules are still regularly validated, and that all modules/pipelines work under HPC execution conditions (Slurm + Apptainer).
+
+The script is located at [`.github/scripts/hpc-testrun.sbatch`](.github/scripts/hpc-testrun.sbatch) and results are posted as comments on a central GitHub tracking issue for visibility. To run it:
+
+```bash
+export GITHUB_ISSUE_NUMBER=<tracking_issue_number>
+sbatch .github/scripts/hpc-testrun.sbatch
+```
+
+The script uses `make run_sprocket` with a [Slurm + Apptainer sprocket config](https://sprocket.bio/guides/slurm) and posts a pass/fail summary to the tracking issue after each run. You can also run the test suite manually on the HPC with:
+
+```bash
+make run_sprocket SPROCKET_CONFIG=/path/to/your/sprocket-slurm-config.toml
+```
+
 ## Documentation Website
 
 The WILDS WDL Library includes an automatically-generated documentation website that provides comprehensive technical documentation for all modules and pipelines. Understanding how this documentation works is important for contributors.

--- a/.github/configs/sprocket-hpc.toml
+++ b/.github/configs/sprocket-hpc.toml
@@ -3,7 +3,3 @@ run.experimental_features_enabled = true
 
 # Set the default backend to Slurm + Apptainer.
 run.backends.default.type = "slurm_apptainer"
-
-# Suppress analyzer diagnostics already covered by the linting CI job
-# HPC run logs should stay focused on execution output
-analyzer.except = ["UnusedInput", "TodoComment", "ContainerUri"]

--- a/.github/configs/sprocket-hpc.toml
+++ b/.github/configs/sprocket-hpc.toml
@@ -3,3 +3,7 @@ run.experimental_features_enabled = true
 
 # Set the default backend to Slurm + Apptainer.
 run.backends.default.type = "slurm_apptainer"
+
+# Suppress analyzer diagnostics already covered by the linting CI job
+# HPC run logs should stay focused on execution output
+analyzer.except = ["UnusedInput", "TodoComment", "ContainerUri"]

--- a/.github/configs/sprocket-hpc.toml
+++ b/.github/configs/sprocket-hpc.toml
@@ -1,0 +1,5 @@
+# The Slurm + Apptainer backend requires explicitly opting into experimental features.
+run.experimental_features_enabled = true
+
+# Set the default backend to Slurm + Apptainer.
+run.backends.default.type = "slurm_apptainer"

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -12,7 +12,7 @@
 #
 # Prerequisites:
 #   - gh CLI authenticated (run `gh auth login` once)
-#   - sprocket, wdlparse, and Apptainer available via module load
+#   - sprocket and Apptainer available via module load
 #   - GITHUB_ISSUE_NUMBER set to the tracking issue number
 #
 # Usage:

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -2,9 +2,7 @@
 #SBATCH --job-name=wilds_wdl_testrun
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=4
-#SBATCH --mem=32G
-#SBATCH --time=12:00:00
+#SBATCH --time=72:00:00
 #SBATCH --output=logs/wilds_testrun_%j.out
 #SBATCH --error=logs/wilds_testrun_%j.err
 

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -52,7 +52,7 @@ cd "${WORK_DIR}/wilds-wdl-library"
 
 # ---- Run testruns ----
 echo "Starting WILDS WDL test runs at ${RUN_DATE}"
-SPROCKET_CONFIG="${SPROCKET_CONFIG:-notes/minimal-sprocket-config.toml}"
+SPROCKET_CONFIG="${SPROCKET_CONFIG:-.github/configs/sprocket-hpc.toml}"
 make run_sprocket SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
 
 # ---- Post results to GitHub ----

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -42,7 +42,7 @@ REPO="getwilds/wilds-wdl-library"
 # ---- Environment setup ----
 # Update these module versions as needed for your HPC
 module purge
-module load sprocket/0.22.0 Apptainer/1.1.6
+module load sprocket/0.23.0 Apptainer/1.1.6
 
 # ---- Clone fresh copy of the repo ----
 BRANCH="${BRANCH:-main}"

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -56,7 +56,7 @@ cd "${CLONE_DIR}"
 export TYPE="${TYPE:-all}"
 echo "Starting WILDS WDL test runs at ${RUN_DATE} (type: ${TYPE})"
 SPROCKET_CONFIG="${SPROCKET_CONFIG:-.github/configs/sprocket-hpc.toml}"
-make run_sprocket TYPE="${TYPE}" SPROCKET_CONFIG="${SPROCKET_CONFIG}" SPROCKET_VERBOSITY="-q" 2>&1 | tee "${LOGFILE}" || true
+make run_sprocket TYPE="${TYPE}" SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
 
 # ---- Post results to GitHub ----
 python3 .github/scripts/hpc_testrun_report.py "${LOGFILE}" "${ISSUE_NUMBER}" --repo "${REPO}"

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -47,9 +47,10 @@ module load sprocket/0.23.0 Apptainer/1.1.6
 
 # ---- Clone fresh copy of the repo ----
 BRANCH="${BRANCH:-main}"
-echo "Cloning ${REPO} (branch: ${BRANCH}) into ${WORK_DIR}..."
-git clone --branch "${BRANCH}" "https://github.com/${REPO}.git" "${WORK_DIR}/wilds-wdl-library"
-cd "${WORK_DIR}/wilds-wdl-library"
+CLONE_DIR="${WORK_DIR}/wilds-wdl-library-${SLURM_JOB_ID}"
+echo "Cloning ${REPO} (branch: ${BRANCH}) into ${CLONE_DIR}..."
+git clone --branch "${BRANCH}" "https://github.com/${REPO}.git" "${CLONE_DIR}"
+cd "${CLONE_DIR}"
 
 # ---- Run testruns ----
 export TYPE="${TYPE:-all}"
@@ -62,4 +63,4 @@ python3 .github/scripts/hpc_testrun_report.py "${LOGFILE}" "${ISSUE_NUMBER}" --r
 
 # ---- Cleanup ----
 rm -f "${LOGFILE}"
-rm -rf "${WORK_DIR}/wilds-wdl-library"
+# Note: cloned repo + sprocket output left in place for debugging

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -19,8 +19,11 @@
 #
 # Usage:
 #   export GITHUB_ISSUE_NUMBER=<issue_number>
-#   export WORK_DIR=/hpc/temp/your-username/wilds-testrun
+#   export WORK_DIR=/path/to/your/working/directory
 #   sbatch /path/to/hpc-testrun.sbatch
+#
+# Optional:
+#   BRANCH=my-feature-branch  # Defaults to "main"
 #
 # To create the tracking issue (one-time setup):
 #   gh issue create \
@@ -44,8 +47,9 @@ module purge
 module load sprocket/0.22.0 Apptainer/1.1.6
 
 # ---- Clone fresh copy of the repo ----
-echo "Cloning ${REPO} into ${WORK_DIR}..."
-git clone "https://github.com/${REPO}.git" "${WORK_DIR}/wilds-wdl-library"
+BRANCH="${BRANCH:-main}"
+echo "Cloning ${REPO} (branch: ${BRANCH}) into ${WORK_DIR}..."
+git clone --branch "${BRANCH}" "https://github.com/${REPO}.git" "${WORK_DIR}/wilds-wdl-library"
 cd "${WORK_DIR}/wilds-wdl-library"
 
 # ---- Run testruns ----

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -22,6 +22,7 @@
 #
 # Optional:
 #   BRANCH=my-feature-branch  # Defaults to "main"
+#   TYPE=modules|pipelines    # Defaults to "all"
 #
 # To create the tracking issue (one-time setup):
 #   gh issue create \
@@ -51,9 +52,10 @@ git clone --branch "${BRANCH}" "https://github.com/${REPO}.git" "${WORK_DIR}/wil
 cd "${WORK_DIR}/wilds-wdl-library"
 
 # ---- Run testruns ----
-echo "Starting WILDS WDL test runs at ${RUN_DATE}"
+export TYPE="${TYPE:-all}"
+echo "Starting WILDS WDL test runs at ${RUN_DATE} (type: ${TYPE})"
 SPROCKET_CONFIG="${SPROCKET_CONFIG:-.github/configs/sprocket-hpc.toml}"
-make run_sprocket SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
+make run_sprocket TYPE="${TYPE}" SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
 
 # ---- Post results to GitHub ----
 python3 .github/scripts/hpc_testrun_report.py "${LOGFILE}" "${ISSUE_NUMBER}" --repo "${REPO}"

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -32,11 +32,11 @@
 set -eo pipefail
 
 # ---- Configuration ----
-REPO="getwilds/wilds-wdl-library"
 ISSUE_NUMBER="${GITHUB_ISSUE_NUMBER:?Error: set GITHUB_ISSUE_NUMBER before submitting}"
 WORK_DIR="${WORK_DIR:-$(mktemp -d)}"
-RUN_DATE="$(date '+%Y-%m-%d %H:%M:%S')"
+export RUN_DATE="$(date '+%Y-%m-%d %H:%M:%S')"
 LOGFILE="$(mktemp)"
+REPO="getwilds/wilds-wdl-library"
 
 # ---- Environment setup ----
 # Update these module versions as needed for your HPC
@@ -50,64 +50,11 @@ cd "${WORK_DIR}/wilds-wdl-library"
 
 # ---- Run testruns ----
 echo "Starting WILDS WDL test runs at ${RUN_DATE}"
-echo "Logging to ${LOGFILE}"
-
-# Run sprocket testruns (continues past failures thanks to Makefile update)
 SPROCKET_CONFIG="${SPROCKET_CONFIG:-notes/minimal-sprocket-config.toml}"
-if make run_sprocket SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}"; then
-    STATUS="PASSED"
-else
-    STATUS="FAILED"
-fi
+make run_sprocket SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
 
-# ---- Build GitHub comment ----
-# Extract failure summary if any
-FAILURES=$(grep -A 100 "=== SPROCKET FAILURES ===" "${LOGFILE}" 2>/dev/null || true)
-ITEM_COUNT=$(grep -c "^\.\.\. Running " "${LOGFILE}" 2>/dev/null || echo "0")
-FAILED_COUNT=$(grep -c "^\.\.\. FAILED:" "${LOGFILE}" 2>/dev/null || echo "0")
-PASSED_COUNT=$((ITEM_COUNT - FAILED_COUNT))
-
-if [ "${STATUS}" = "PASSED" ]; then
-    STATUS_EMOJI="white_check_mark"
-else
-    STATUS_EMOJI="x"
-fi
-
-COMMENT_BODY="$(cat <<EOF
-## :${STATUS_EMOJI}: HPC Test Run — ${RUN_DATE}
-
-| | |
-|---|---|
-| **Status** | ${STATUS} |
-| **Date** | ${RUN_DATE} |
-| **Engine** | sprocket |
-| **Items tested** | ${ITEM_COUNT} |
-| **Passed** | ${PASSED_COUNT} |
-| **Failed** | ${FAILED_COUNT} |
-| **SLURM Job ID** | ${SLURM_JOB_ID:-N/A} |
-| **Branch** | $(git rev-parse --abbrev-ref HEAD) |
-| **Commit** | $(git rev-parse --short HEAD) |
-
-$(if [ -n "${FAILURES}" ]; then
-    echo "<details>"
-    echo "<summary>Failure Details</summary>"
-    echo ""
-    echo "\`\`\`"
-    echo "${FAILURES}"
-    echo "\`\`\`"
-    echo "</details>"
-fi)
-EOF
-)"
-
-# ---- Post to GitHub ----
-echo ""
-echo "Posting results to ${REPO}#${ISSUE_NUMBER}..."
-gh issue comment "${ISSUE_NUMBER}" \
-    --repo "${REPO}" \
-    --body "${COMMENT_BODY}"
-
-echo "Results posted successfully."
+# ---- Post results to GitHub ----
+python3 .github/scripts/hpc_testrun_report.py "${LOGFILE}" "${ISSUE_NUMBER}" --repo "${REPO}"
 
 # ---- Cleanup ----
 rm -f "${LOGFILE}"

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -56,7 +56,7 @@ cd "${CLONE_DIR}"
 export TYPE="${TYPE:-all}"
 echo "Starting WILDS WDL test runs at ${RUN_DATE} (type: ${TYPE})"
 SPROCKET_CONFIG="${SPROCKET_CONFIG:-.github/configs/sprocket-hpc.toml}"
-make run_sprocket TYPE="${TYPE}" SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
+make run_sprocket TYPE="${TYPE}" SPROCKET_CONFIG="${SPROCKET_CONFIG}" SPROCKET_VERBOSITY="-q" 2>&1 | tee "${LOGFILE}" || true
 
 # ---- Post results to GitHub ----
 python3 .github/scripts/hpc_testrun_report.py "${LOGFILE}" "${ISSUE_NUMBER}" --repo "${REPO}"

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -1,0 +1,114 @@
+#!/bin/bash
+#SBATCH --job-name=wilds_wdl_testrun
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=12:00:00
+#SBATCH --output=logs/wilds_testrun_%j.out
+#SBATCH --error=logs/wilds_testrun_%j.err
+
+# Monthly HPC test run for WILDS WDL Library
+# Runs all module/pipeline testruns with sprocket and posts results
+# as a comment on a central GitHub tracking issue.
+#
+# Prerequisites:
+#   - gh CLI authenticated (run `gh auth login` once)
+#   - sprocket, wdlparse, and Apptainer available via module load
+#   - GITHUB_ISSUE_NUMBER set to the tracking issue number
+#
+# Usage:
+#   export GITHUB_ISSUE_NUMBER=<issue_number>
+#   export WORK_DIR=/hpc/temp/your-username/wilds-testrun
+#   sbatch /path/to/hpc-testrun.sbatch
+#
+# To create the tracking issue (one-time setup):
+#   gh issue create \
+#     --repo getwilds/wilds-wdl-library \
+#     --title "HPC Monthly Test Run Log" \
+#     --body "Rolling log of monthly HPC test runs. Each run posts results as a comment." \
+#     --label "testing"
+
+set -eo pipefail
+
+# ---- Configuration ----
+REPO="getwilds/wilds-wdl-library"
+ISSUE_NUMBER="${GITHUB_ISSUE_NUMBER:?Error: set GITHUB_ISSUE_NUMBER before submitting}"
+WORK_DIR="${WORK_DIR:-$(mktemp -d)}"
+RUN_DATE="$(date '+%Y-%m-%d %H:%M:%S')"
+LOGFILE="$(mktemp)"
+
+# ---- Environment setup ----
+# Update these module versions as needed for your HPC
+module purge
+module load sprocket/0.22.0 Apptainer/1.1.6
+
+# ---- Clone fresh copy of the repo ----
+echo "Cloning ${REPO} into ${WORK_DIR}..."
+git clone "https://github.com/${REPO}.git" "${WORK_DIR}/wilds-wdl-library"
+cd "${WORK_DIR}/wilds-wdl-library"
+
+# ---- Run testruns ----
+echo "Starting WILDS WDL test runs at ${RUN_DATE}"
+echo "Logging to ${LOGFILE}"
+
+# Run sprocket testruns (continues past failures thanks to Makefile update)
+SPROCKET_CONFIG="${SPROCKET_CONFIG:-notes/minimal-sprocket-config.toml}"
+if make run_sprocket SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}"; then
+    STATUS="PASSED"
+else
+    STATUS="FAILED"
+fi
+
+# ---- Build GitHub comment ----
+# Extract failure summary if any
+FAILURES=$(grep -A 100 "=== SPROCKET FAILURES ===" "${LOGFILE}" 2>/dev/null || true)
+ITEM_COUNT=$(grep -c "^\.\.\. Running " "${LOGFILE}" 2>/dev/null || echo "0")
+FAILED_COUNT=$(grep -c "^\.\.\. FAILED:" "${LOGFILE}" 2>/dev/null || echo "0")
+PASSED_COUNT=$((ITEM_COUNT - FAILED_COUNT))
+
+if [ "${STATUS}" = "PASSED" ]; then
+    STATUS_EMOJI="white_check_mark"
+else
+    STATUS_EMOJI="x"
+fi
+
+COMMENT_BODY="$(cat <<EOF
+## :${STATUS_EMOJI}: HPC Test Run — ${RUN_DATE}
+
+| | |
+|---|---|
+| **Status** | ${STATUS} |
+| **Date** | ${RUN_DATE} |
+| **Engine** | sprocket |
+| **Items tested** | ${ITEM_COUNT} |
+| **Passed** | ${PASSED_COUNT} |
+| **Failed** | ${FAILED_COUNT} |
+| **SLURM Job ID** | ${SLURM_JOB_ID:-N/A} |
+| **Branch** | $(git rev-parse --abbrev-ref HEAD) |
+| **Commit** | $(git rev-parse --short HEAD) |
+
+$(if [ -n "${FAILURES}" ]; then
+    echo "<details>"
+    echo "<summary>Failure Details</summary>"
+    echo ""
+    echo "\`\`\`"
+    echo "${FAILURES}"
+    echo "\`\`\`"
+    echo "</details>"
+fi)
+EOF
+)"
+
+# ---- Post to GitHub ----
+echo ""
+echo "Posting results to ${REPO}#${ISSUE_NUMBER}..."
+gh issue comment "${ISSUE_NUMBER}" \
+    --repo "${REPO}" \
+    --body "${COMMENT_BODY}"
+
+echo "Results posted successfully."
+
+# ---- Cleanup ----
+rm -f "${LOGFILE}"
+rm -rf "${WORK_DIR}/wilds-wdl-library"

--- a/.github/scripts/hpc_testrun_report.py
+++ b/.github/scripts/hpc_testrun_report.py
@@ -84,16 +84,16 @@ def build_comment(results: dict, run_date: str, slurm_job_id: str) -> str:
 
 
 def post_comment(comment: str, issue_number: str, repo: str) -> None:
-    """Post the comment to the GitHub issue using gh CLI."""
+    """Post the comment to the GitHub issue using the gh REST API."""
     subprocess.run(
         [
-            "gh", "issue", "comment", issue_number,
-            "--repo", repo,
-            "--body", comment,
+            "gh", "api",
+            "repos/{}/issues/{}/comments".format(repo, issue_number),
+            "-f", "body={}".format(comment),
         ],
         check=True,
     )
-    print(f"Results posted to {repo}#{issue_number}")
+    print("Results posted to {}#{}".format(repo, issue_number))
 
 
 def main():

--- a/.github/scripts/hpc_testrun_report.py
+++ b/.github/scripts/hpc_testrun_report.py
@@ -25,7 +25,9 @@ def parse_log(logfile: str) -> dict:
 
     # Extract the failure summary block if present
     failure_block = ""
-    match = re.search(r"(=== SPROCKET FAILURES ===.*)", content, re.DOTALL)
+    match = re.search(
+        r"(=== SPROCKET FAILURES ===\n.*failed with sprocket:.*)", content
+    )
     if match:
         failure_block = match.group(1).strip()
 

--- a/.github/scripts/hpc_testrun_report.py
+++ b/.github/scripts/hpc_testrun_report.py
@@ -41,10 +41,10 @@ def parse_log(logfile: str) -> dict:
 def get_git_info() -> dict:
     """Get current branch and short commit hash."""
     branch = subprocess.check_output(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], universal_newlines=True
     ).strip()
     commit = subprocess.check_output(
-        ["git", "rev-parse", "--short", "HEAD"], text=True
+        ["git", "rev-parse", "--short", "HEAD"], universal_newlines=True
     ).strip()
     return {"branch": branch, "commit": commit}
 

--- a/.github/scripts/hpc_testrun_report.py
+++ b/.github/scripts/hpc_testrun_report.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+"""Parse make run_sprocket output and post results to a GitHub tracking issue.
+
+Usage:
+    python hpc_testrun_report.py <logfile> <issue_number> [--repo OWNER/REPO]
+
+Reads the log file produced by `make run_sprocket`, builds a markdown summary,
+and posts it as a comment on the specified GitHub issue using the `gh` CLI.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def parse_log(logfile: str) -> dict:
+    """Parse make run_sprocket output for pass/fail counts and failure details."""
+    with open(logfile) as f:
+        content = f.read()
+
+    items = re.findall(r"^\.\.\. Running (.+)$", content, re.MULTILINE)
+    failures = re.findall(r"^\.\.\. FAILED: (.+)$", content, re.MULTILINE)
+
+    # Extract the failure summary block if present
+    failure_block = ""
+    match = re.search(r"(=== SPROCKET FAILURES ===.*)", content, re.DOTALL)
+    if match:
+        failure_block = match.group(1).strip()
+
+    return {
+        "total": len(items),
+        "failed": len(failures),
+        "passed": len(items) - len(failures),
+        "failure_names": failures,
+        "failure_block": failure_block,
+    }
+
+
+def get_git_info() -> dict:
+    """Get current branch and short commit hash."""
+    branch = subprocess.check_output(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+    ).strip()
+    commit = subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"], text=True
+    ).strip()
+    return {"branch": branch, "commit": commit}
+
+
+def build_comment(results: dict, run_date: str, slurm_job_id: str) -> str:
+    """Build the markdown comment body."""
+    git = get_git_info()
+    status = "PASSED" if results["failed"] == 0 else "FAILED"
+    emoji = "white_check_mark" if status == "PASSED" else "x"
+
+    comment = f"""## :{emoji}: HPC Test Run — {run_date}
+
+| | |
+|---|---|
+| **Status** | {status} |
+| **Date** | {run_date} |
+| **Engine** | sprocket |
+| **Items tested** | {results['total']} |
+| **Passed** | {results['passed']} |
+| **Failed** | {results['failed']} |
+| **SLURM Job ID** | {slurm_job_id} |
+| **Branch** | {git['branch']} |
+| **Commit** | {git['commit']} |"""
+
+    if results["failure_block"]:
+        comment += f"""
+
+<details>
+<summary>Failure Details</summary>
+
+```
+{results['failure_block']}
+```
+</details>"""
+
+    return comment
+
+
+def post_comment(comment: str, issue_number: str, repo: str) -> None:
+    """Post the comment to the GitHub issue using gh CLI."""
+    subprocess.run(
+        [
+            "gh", "issue", "comment", issue_number,
+            "--repo", repo,
+            "--body", comment,
+        ],
+        check=True,
+    )
+    print(f"Results posted to {repo}#{issue_number}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logfile", help="Path to make run_sprocket log output")
+    parser.add_argument("issue_number", help="GitHub issue number for the tracking issue")
+    parser.add_argument(
+        "--repo", default="getwilds/wilds-wdl-library",
+        help="GitHub repo in OWNER/REPO format (default: getwilds/wilds-wdl-library)",
+    )
+    args = parser.parse_args()
+
+    run_date = os.environ.get("RUN_DATE", "unknown")
+    slurm_job_id = os.environ.get("SLURM_JOB_ID", "N/A")
+
+    results = parse_log(args.logfile)
+    comment = build_comment(results, run_date, slurm_job_id)
+    post_comment(comment, args.issue_number, args.repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/hpc_testrun_report.py
+++ b/.github/scripts/hpc_testrun_report.py
@@ -49,18 +49,20 @@ def get_git_info() -> dict:
     return {"branch": branch, "commit": commit}
 
 
-def build_comment(results: dict, run_date: str, slurm_job_id: str) -> str:
+def build_comment(results: dict, run_date: str, slurm_job_id: str, run_type: str = "all") -> str:
     """Build the markdown comment body."""
     git = get_git_info()
     status = "PASSED" if results["failed"] == 0 else "FAILED"
     emoji = "white_check_mark" if status == "PASSED" else "x"
+    type_label = run_type if run_type != "all" else "modules + pipelines"
 
-    comment = f"""## :{emoji}: HPC Test Run — {run_date}
+    comment = f"""## :{emoji}: HPC Test Run ({type_label}) — {run_date}
 
 | | |
 |---|---|
 | **Status** | {status} |
 | **Date** | {run_date} |
+| **Type** | {type_label} |
 | **Engine** | sprocket |
 | **Items tested** | {results['total']} |
 | **Passed** | {results['passed']} |
@@ -108,9 +110,10 @@ def main():
 
     run_date = os.environ.get("RUN_DATE", "unknown")
     slurm_job_id = os.environ.get("SLURM_JOB_ID", "N/A")
+    run_type = os.environ.get("TYPE", "all")
 
     results = parse_log(args.logfile)
-    comment = build_comment(results, run_date, slurm_job_id)
+    comment = build_comment(results, run_date, slurm_job_id, run_type)
     post_comment(comment, args.issue_number, args.repo)
 
 

--- a/.github/scripts/launch-hpc-testrun.sh
+++ b/.github/scripts/launch-hpc-testrun.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Launch script for monthly HPC test runs.
+# Intended to be called from crontab or manually.
+#
+# Update the paths and issue number below for your environment.
+#
+# Crontab example (1st of every month at midnight):
+#   0 0 1 * * /path/to/launch-hpc-testrun.sh
+
+export GITHUB_ISSUE_NUMBER=324
+export WORK_DIR=/path/to/scratch/wilds-testrun
+
+SBATCH_SCRIPT=/path/to/hpc-testrun.sbatch
+
+# Submit modules and pipelines as separate SLURM jobs
+TYPE=modules sbatch "${SBATCH_SCRIPT}"
+TYPE=pipelines sbatch "${SBATCH_SCRIPT}"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ MINIWDL ?= 1.13.0
 SPROCKET_MIN ?= 0.22.0
 SPROCKET_CONFIG ?=
 SPROCKET_CONFIG_FLAG := $(if $(SPROCKET_CONFIG),-c $(SPROCKET_CONFIG),)
+TYPE ?= all
 
 .PHONY: help
 help: ## Show this help message
@@ -151,9 +152,13 @@ lint: lint_sprocket lint_miniwdl lint_womtool lint_cirro ## Run all linting chec
 
 ##@ Run
 
-run_sprocket: check_sprocket check_name ## Run sprocket on testrun.wdl files (use NAME=foo, SPROCKET_CONFIG=path for HPC)
+run_sprocket: check_sprocket check_name ## Run sprocket on testrun.wdl files (use NAME=foo, TYPE=modules|pipelines, SPROCKET_CONFIG=path)
 	@echo "Running sprocket on testrun.wdl files..."
-	@failed=""; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
+	@failed=""; \
+	dirs=""; \
+	if [ "$(TYPE)" = "modules" ] || [ "$(TYPE)" = "all" ]; then dirs="$$dirs modules/$(NAME)/"; fi; \
+	if [ "$(TYPE)" = "pipelines" ] || [ "$(TYPE)" = "all" ]; then dirs="$$dirs pipelines/$(NAME)/"; fi; \
+	for dir in $$dirs; do \
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
 			echo "... Running $$(basename $$dir)"; \
 			entrypoint=$$(grep '^workflow ' "$$dir/testrun.wdl" | awk '{print $$2}' | tr -d '{'); \
@@ -173,9 +178,13 @@ run_sprocket: check_sprocket check_name ## Run sprocket on testrun.wdl files (us
 		echo "All sprocket runs passed."; \
 	fi
 
-run_miniwdl: check_uv check_name ## Run miniwdl on testrun.wdl files (use NAME=foo for specific item)
+run_miniwdl: check_uv check_name ## Run miniwdl on testrun.wdl files (use NAME=foo, TYPE=modules|pipelines)
 	@echo "Running miniwdl on testrun.wdl files..."
-	@failed=""; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
+	@failed=""; \
+	dirs=""; \
+	if [ "$(TYPE)" = "modules" ] || [ "$(TYPE)" = "all" ]; then dirs="$$dirs modules/$(NAME)/"; fi; \
+	if [ "$(TYPE)" = "pipelines" ] || [ "$(TYPE)" = "all" ]; then dirs="$$dirs pipelines/$(NAME)/"; fi; \
+	for dir in $$dirs; do \
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
 			echo "... Running $$(basename $$dir)"; \
 			if ! uv run --python 3.13 --with miniwdl==$(MINIWDL) miniwdl run "$$dir/testrun.wdl"; then \
@@ -193,9 +202,13 @@ run_miniwdl: check_uv check_name ## Run miniwdl on testrun.wdl files (use NAME=f
 		echo "All miniwdl runs passed."; \
 	fi
 
-run_cromwell: check_java check_cromwell check_name ## Run Cromwell on testrun.wdl files (use NAME=foo for specific item)
+run_cromwell: check_java check_cromwell check_name ## Run Cromwell on testrun.wdl files (use NAME=foo, TYPE=modules|pipelines)
 	@echo "Running Cromwell on testrun.wdl files..."
-	@failed=""; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
+	@failed=""; \
+	dirs=""; \
+	if [ "$(TYPE)" = "modules" ] || [ "$(TYPE)" = "all" ]; then dirs="$$dirs modules/$(NAME)/"; fi; \
+	if [ "$(TYPE)" = "pipelines" ] || [ "$(TYPE)" = "all" ]; then dirs="$$dirs pipelines/$(NAME)/"; fi; \
+	for dir in $$dirs; do \
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
 			echo "... Running $$(basename $$dir)"; \
 			if ! java -jar $(CROMWELL_JAR) run "$$dir/testrun.wdl"; then \

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ CROMWELL ?= 92
 CROMWELL_JAR ?= cromwell-$(CROMWELL).jar
 MINIWDL ?= 1.13.0
 SPROCKET_MIN ?= 0.22.0
-WDLPARSE_VERSION ?= v0.0.5
-WDLPARSE := $(shell command -v wdlparse 2>/dev/null || echo $(HOME)/.local/bin/wdlparse)
 SPROCKET_CONFIG ?=
 SPROCKET_CONFIG_FLAG := $(if $(SPROCKET_CONFIG),-c $(SPROCKET_CONFIG),)
 
@@ -47,25 +45,6 @@ check_uv:
 		echo "uv version $$(uv --version | awk '{print $$2}')"; \
 		uv run --python 3.13 --with miniwdl==$(MINIWDL) python -c "from importlib.metadata import version; print(f'miniwdl v{version(\"miniwdl\")}')"; \
 	fi;
-
-check_wdlparse:
-	@echo "Checking if wdlparse is available..."
-	@if ! command -v wdlparse >/dev/null 2>&1; then \
-		echo "wdlparse not found, installing $(WDLPARSE_VERSION)..."; \
-		OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
-		ARCH=$$(uname -m); \
-		if [ "$$OS" = "darwin" ]; then \
-			TARGET="$$ARCH-apple-$$OS"; \
-		else \
-			TARGET="$$ARCH-unknown-$$OS-gnu"; \
-		fi; \
-		mkdir -p $$HOME/.local/bin; \
-		wget -q -O /tmp/wdlparse.tar.gz \
-			"https://github.com/getwilds/wdlparse/releases/download/$(WDLPARSE_VERSION)/wdlparse-$$TARGET.tar.gz"; \
-		tar -xzf /tmp/wdlparse.tar.gz -C $$HOME/.local/bin; \
-		rm -f /tmp/wdlparse.tar.gz; \
-	fi; \
-	echo "wdlparse version $$($(WDLPARSE) --version | awk '{print $$2}')";
 
 check_name:
 	@if [ "$(NAME)" != "*" ]; then \
@@ -172,12 +151,12 @@ lint: lint_sprocket lint_miniwdl lint_womtool lint_cirro ## Run all linting chec
 
 ##@ Run
 
-run_sprocket: check_sprocket check_name check_wdlparse ## Run sprocket on testrun.wdl files (use NAME=foo, SPROCKET_CONFIG=path for HPC)
+run_sprocket: check_sprocket check_name ## Run sprocket on testrun.wdl files (use NAME=foo, SPROCKET_CONFIG=path for HPC)
 	@echo "Running sprocket on testrun.wdl files..."
 	@failed=""; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
 			echo "... Running $$(basename $$dir)"; \
-			entrypoint=$$($(WDLPARSE) parse --format json "$$dir/testrun.wdl" | jq -r '.wdl.workflows[].name'); \
+			entrypoint=$$(grep '^workflow ' "$$dir/testrun.wdl" | awk '{print $$2}' | tr -d '{'); \
 			echo "... Using entrypoint: $$entrypoint"; \
 			if ! sprocket run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
 				failed="$$failed $$(basename $$dir)"; \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ CROMWELL_JAR ?= cromwell-$(CROMWELL).jar
 MINIWDL ?= 1.13.0
 SPROCKET_MIN ?= 0.22.0
 WDLPARSE_VERSION ?= v0.0.5
+WDLPARSE := $(shell command -v wdlparse 2>/dev/null || echo $(HOME)/.local/bin/wdlparse)
 SPROCKET_CONFIG ?=
 SPROCKET_CONFIG_FLAG := $(if $(SPROCKET_CONFIG),-c $(SPROCKET_CONFIG),)
 
@@ -58,14 +59,13 @@ check_wdlparse:
 		else \
 			TARGET="$$ARCH-unknown-$$OS-gnu"; \
 		fi; \
+		mkdir -p $$HOME/.local/bin; \
 		wget -q -O /tmp/wdlparse.tar.gz \
 			"https://github.com/getwilds/wdlparse/releases/download/$(WDLPARSE_VERSION)/wdlparse-$$TARGET.tar.gz"; \
-		tar -xzf /tmp/wdlparse.tar.gz -C /usr/local/bin 2>/dev/null \
-			|| tar -xzf /tmp/wdlparse.tar.gz -C $$HOME/.local/bin 2>/dev/null \
-			|| (mkdir -p $$HOME/.local/bin && tar -xzf /tmp/wdlparse.tar.gz -C $$HOME/.local/bin && export PATH="$$HOME/.local/bin:$$PATH"); \
+		tar -xzf /tmp/wdlparse.tar.gz -C $$HOME/.local/bin; \
 		rm -f /tmp/wdlparse.tar.gz; \
 	fi; \
-	echo "wdlparse version $$(wdlparse --version | awk '{print $$2}')";
+	echo "wdlparse version $$($(WDLPARSE) --version | awk '{print $$2}')";
 
 check_name:
 	@if [ "$(NAME)" != "*" ]; then \
@@ -177,7 +177,7 @@ run_sprocket: check_sprocket check_name check_wdlparse ## Run sprocket on testru
 	@failed=""; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
 			echo "... Running $$(basename $$dir)"; \
-			entrypoint=$$(wdlparse parse --format json "$$dir/testrun.wdl" | jq -r '.wdl.workflows[].name'); \
+			entrypoint=$$($(WDLPARSE) parse --format json "$$dir/testrun.wdl" | jq -r '.wdl.workflows[].name'); \
 			echo "... Using entrypoint: $$entrypoint"; \
 			if ! sprocket run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
 				failed="$$failed $$(basename $$dir)"; \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ CROMWELL ?= 92
 CROMWELL_JAR ?= cromwell-$(CROMWELL).jar
 MINIWDL ?= 1.13.0
 SPROCKET_MIN ?= 0.22.0
+SPROCKET_CONFIG ?=
+SPROCKET_CONFIG_FLAG := $(if $(SPROCKET_CONFIG),-c $(SPROCKET_CONFIG),)
 
 .PHONY: help
 help: ## Show this help message
@@ -158,34 +160,67 @@ lint: lint_sprocket lint_miniwdl lint_womtool lint_cirro ## Run all linting chec
 
 ##@ Run
 
-run_sprocket: check_sprocket check_name check_wdlparse ## Run sprocket on testrun.wdl files (use NAME=foo for specific item)
+run_sprocket: check_sprocket check_name check_wdlparse ## Run sprocket on testrun.wdl files (use NAME=foo, SPROCKET_CONFIG=path for HPC)
 	@echo "Running sprocket on testrun.wdl files..."
-	@set -e; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
+	@failed=""; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
 			echo "... Running $$(basename $$dir)"; \
 			entrypoint=$$(wdlparse parse --format json "$$dir/testrun.wdl" | jq -r '.wdl.workflows[].name'); \
 			echo "... Using entrypoint: $$entrypoint"; \
-			sprocket run "$$dir/testrun.wdl" --target $$entrypoint; \
+			if ! sprocket run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
+				failed="$$failed $$(basename $$dir)"; \
+				echo "... FAILED: $$(basename $$dir) (sprocket)"; \
+			fi; \
 		fi; \
-	done
+	done; \
+	if [ -n "$$failed" ]; then \
+		echo ""; \
+		echo "=== SPROCKET FAILURES ==="; \
+		echo "The following items failed with sprocket:$$failed"; \
+		exit 1; \
+	else \
+		echo "All sprocket runs passed."; \
+	fi
 
 run_miniwdl: check_uv check_name ## Run miniwdl on testrun.wdl files (use NAME=foo for specific item)
 	@echo "Running miniwdl on testrun.wdl files..."
-	@set -e; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
+	@failed=""; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
 			echo "... Running $$(basename $$dir)"; \
-			uv run --python 3.13 --with miniwdl==$(MINIWDL) miniwdl run "$$dir/testrun.wdl"; \
+			if ! uv run --python 3.13 --with miniwdl==$(MINIWDL) miniwdl run "$$dir/testrun.wdl"; then \
+				failed="$$failed $$(basename $$dir)"; \
+				echo "... FAILED: $$(basename $$dir) (miniwdl)"; \
+			fi; \
 		fi; \
-	done
+	done; \
+	if [ -n "$$failed" ]; then \
+		echo ""; \
+		echo "=== MINIWDL FAILURES ==="; \
+		echo "The following items failed with miniwdl:$$failed"; \
+		exit 1; \
+	else \
+		echo "All miniwdl runs passed."; \
+	fi
 
 run_cromwell: check_java check_cromwell check_name ## Run Cromwell on testrun.wdl files (use NAME=foo for specific item)
 	@echo "Running Cromwell on testrun.wdl files..."
-	@set -e; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
+	@failed=""; for dir in modules/$(NAME)/ pipelines/$(NAME)/; do \
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
 			echo "... Running $$(basename $$dir)"; \
-			java -jar $(CROMWELL_JAR) run "$$dir/testrun.wdl"; \
+			if ! java -jar $(CROMWELL_JAR) run "$$dir/testrun.wdl"; then \
+				failed="$$failed $$(basename $$dir)"; \
+				echo "... FAILED: $$(basename $$dir) (Cromwell)"; \
+			fi; \
 		fi; \
-	done
+	done; \
+	if [ -n "$$failed" ]; then \
+		echo ""; \
+		echo "=== CROMWELL FAILURES ==="; \
+		echo "The following items failed with Cromwell:$$failed"; \
+		exit 1; \
+	else \
+		echo "All Cromwell runs passed."; \
+	fi
 
 run: run_sprocket run_miniwdl run_cromwell ## Run all engines on testrun.wdl files
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ MINIWDL ?= 1.13.0
 SPROCKET_MIN ?= 0.22.0
 SPROCKET_CONFIG ?=
 SPROCKET_CONFIG_FLAG := $(if $(SPROCKET_CONFIG),-c $(SPROCKET_CONFIG),)
-SPROCKET_VERBOSITY ?=
 TYPE ?= all
 
 .PHONY: help
@@ -164,7 +163,7 @@ run_sprocket: check_sprocket check_name ## Run sprocket on testrun.wdl files (us
 			echo "... Running $$(basename $$dir)"; \
 			entrypoint=$$(grep '^workflow ' "$$dir/testrun.wdl" | awk '{print $$2}' | tr -d '{'); \
 			echo "... Using entrypoint: $$entrypoint"; \
-			if ! sprocket $(SPROCKET_VERBOSITY) run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
+			if ! sprocket run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
 				failed="$$failed $$(basename $$dir)"; \
 				echo "... FAILED: $$(basename $$dir) (sprocket)"; \
 			fi; \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ MINIWDL ?= 1.13.0
 SPROCKET_MIN ?= 0.22.0
 SPROCKET_CONFIG ?=
 SPROCKET_CONFIG_FLAG := $(if $(SPROCKET_CONFIG),-c $(SPROCKET_CONFIG),)
+SPROCKET_VERBOSITY ?=
 TYPE ?= all
 
 .PHONY: help
@@ -163,7 +164,7 @@ run_sprocket: check_sprocket check_name ## Run sprocket on testrun.wdl files (us
 			echo "... Running $$(basename $$dir)"; \
 			entrypoint=$$(grep '^workflow ' "$$dir/testrun.wdl" | awk '{print $$2}' | tr -d '{'); \
 			echo "... Using entrypoint: $$entrypoint"; \
-			if ! sprocket run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
+			if ! sprocket $(SPROCKET_VERBOSITY) run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
 				failed="$$failed $$(basename $$dir)"; \
 				echo "... FAILED: $$(basename $$dir) (sprocket)"; \
 			fi; \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ CROMWELL ?= 92
 CROMWELL_JAR ?= cromwell-$(CROMWELL).jar
 MINIWDL ?= 1.13.0
 SPROCKET_MIN ?= 0.22.0
+WDLPARSE_VERSION ?= v0.0.5
 SPROCKET_CONFIG ?=
 SPROCKET_CONFIG_FLAG := $(if $(SPROCKET_CONFIG),-c $(SPROCKET_CONFIG),)
 
@@ -49,11 +50,22 @@ check_uv:
 check_wdlparse:
 	@echo "Checking if wdlparse is available..."
 	@if ! command -v wdlparse >/dev/null 2>&1; then \
-		echo >&2 "Error: wdlparse is not installed or not in PATH. Install wdlparse (https://github.com/getwilds/wdlparse?tab=readme-ov-file#from-releases)"; \
-		exit 1; \
-	else \
-	  echo "wdlparse version $$(wdlparse --version | awk '{print $$2}')"; \
-	fi;
+		echo "wdlparse not found, installing $(WDLPARSE_VERSION)..."; \
+		OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+		ARCH=$$(uname -m); \
+		if [ "$$OS" = "darwin" ]; then \
+			TARGET="$$ARCH-apple-$$OS"; \
+		else \
+			TARGET="$$ARCH-unknown-$$OS-gnu"; \
+		fi; \
+		wget -q -O /tmp/wdlparse.tar.gz \
+			"https://github.com/getwilds/wdlparse/releases/download/$(WDLPARSE_VERSION)/wdlparse-$$TARGET.tar.gz"; \
+		tar -xzf /tmp/wdlparse.tar.gz -C /usr/local/bin 2>/dev/null \
+			|| tar -xzf /tmp/wdlparse.tar.gz -C $$HOME/.local/bin 2>/dev/null \
+			|| (mkdir -p $$HOME/.local/bin && tar -xzf /tmp/wdlparse.tar.gz -C $$HOME/.local/bin && export PATH="$$HOME/.local/bin:$$PATH"); \
+		rm -f /tmp/wdlparse.tar.gz; \
+	fi; \
+	echo "wdlparse version $$(wdlparse --version | awk '{print $$2}')";
 
 check_name:
 	@if [ "$(NAME)" != "*" ]; then \

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Fred Hutch researchers can use [PROOF](https://sciwiki.fredhutch.org/datademos/p
 - **Multi-Executor Validation**: Ensures compatibility across different WDL engines
 - **Real Data Testing**: Uses authentic bioinformatics datasets for validation
 - **Scheduled Monitoring**: Weekly checks detect infrastructure changes
+- **HPC Monthly Test Runs**: Resource-intensive modules excluded from GitHub CI are validated monthly on the Fred Hutch HPC, with results posted to a [tracking issue](https://github.com/getwilds/wilds-wdl-library/issues) for visibility
 
 ### Standards and Best Practices
 - **Standardized Structure**: Consistent organization across all components

--- a/modules/ww-deseq2/testrun.wdl
+++ b/modules/ww-deseq2/testrun.wdl
@@ -73,8 +73,6 @@ task validate_outputs {
   command <<<
     set -eo pipefail
 
-    pip3 install --target="$(pwd)/.pip_packages" --cache-dir="$(pwd)/.pip_cache" pandas
-    export PYTHONPATH="$(pwd)/.pip_packages:${PYTHONPATH:-}"
     python3 << 'EOF'
 import pandas as pd
 import sys
@@ -149,9 +147,9 @@ EOF
   }
 
   runtime {
-    docker: "python:3.9-slim"
-    memory: "8 GB"
-    cpu: 2
+    docker: "getwilds/python-utils:0.1.0"
+    memory: "2 GB"
+    cpu: 1
   }
 }
 

--- a/modules/ww-deseq2/testrun.wdl
+++ b/modules/ww-deseq2/testrun.wdl
@@ -149,8 +149,8 @@ EOF
 
   runtime {
     docker: "python:3.9-slim"
-    memory: "2 GB"
-    cpu: 1
+    memory: "8 GB"
+    cpu: 2
   }
 }
 

--- a/modules/ww-deseq2/testrun.wdl
+++ b/modules/ww-deseq2/testrun.wdl
@@ -73,7 +73,8 @@ task validate_outputs {
   command <<<
     set -eo pipefail
 
-    pip3 install pandas
+    pip3 install --target="$(pwd)/.pip_packages" --cache-dir="$(pwd)/.pip_cache" pandas
+    export PYTHONPATH="$(pwd)/.pip_packages:${PYTHONPATH:-}"
     python3 << 'EOF'
 import pandas as pd
 import sys

--- a/modules/ww-esmfold/testrun.wdl
+++ b/modules/ww-esmfold/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 # Tests ESMFold structure prediction with a tiny protein sequence on CPU.

--- a/modules/ww-esmfold/ww-esmfold.wdl
+++ b/modules/ww-esmfold/ww-esmfold.wdl
@@ -48,7 +48,12 @@ task esmfold_predict {
   command <<<
     set -eo pipefail
 
-    mkdir -p pdb_output
+    # Redirect model/temp caches to working directory to avoid filling container root filesystem
+    TORCH_HOME="$(pwd)/.cache/torch"
+    HF_HOME="$(pwd)/.cache/huggingface"
+    TMPDIR="$(pwd)/.cache/tmp"
+    export TORCH_HOME HF_HOME TMPDIR
+    mkdir -p "${TORCH_HOME}" "${HF_HOME}" "${TMPDIR}" pdb_output
 
     # Build the esm-fold command
     esm-fold \

--- a/modules/ww-gatk/testrun.wdl
+++ b/modules/ww-gatk/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as ww_gatk
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-gatk/ww-gatk.wdl" as ww_gatk
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as ww_bwa
 
 struct GatkSample {

--- a/modules/ww-gatk/testrun.wdl
+++ b/modules/ww-gatk/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-gatk/ww-gatk.wdl" as ww_gatk
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as ww_bwa
 

--- a/modules/ww-gatk/ww-gatk.wdl
+++ b/modules/ww-gatk/ww-gatk.wdl
@@ -149,13 +149,11 @@ task base_recalibrator {
   command <<<
     set -eo pipefail
 
-    # Add local symbolic link for reference fasta and dict
+    # Add local symbolic link for reference data
     # If soft links aren't allowed on your HPC system, copy them locally instead
     ln -s "~{reference_fasta}" "~{basename(reference_fasta)}"
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
-
-    # Symlink VCF files locally so index files can be written alongside them
     ln -s "~{dbsnp_vcf}" "~{basename(dbsnp_vcf)}"
     known_vcfs=(~{sep=" " known_indels_sites_vcfs})
     known_sites_args=""
@@ -337,13 +335,11 @@ task markdup_recal_metrics {
     # Index resulting bam file
     samtools index "~{base_file_name}.markdup.bam"
 
-    # Add local symbolic link for reference fasta and dict
+    # Add local symbolic link for reference data
     # If soft links aren't allowed on your HPC system, copy them locally instead
     ln -s "~{reference_fasta}" "~{basename(reference_fasta)}"
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
-
-    # Symlink VCF files locally so index files can be written alongside them
     ln -s "~{dbsnp_vcf}" "~{basename(dbsnp_vcf)}"
     known_vcfs=(~{sep=" " known_indels_sites_vcfs})
     known_sites_args=""
@@ -642,13 +638,11 @@ task haplotype_caller {
   command <<<
     set -eo pipefail
 
-    # Add local symbolic link for reference fasta and dict
+    # Add local symbolic link for reference data
     # If soft links aren't allowed on your HPC system, copy them locally instead
     ln -s "~{reference_fasta}" "~{basename(reference_fasta)}"
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
-
-    # Symlink dbSNP VCF locally so index can be written alongside it
     ln -s "~{dbsnp_vcf}" "~{basename(dbsnp_vcf)}"
 
     # Create index for dbSNP vcf
@@ -725,13 +719,11 @@ task mutect2 {
   command <<<
     set -eo pipefail
 
-    # Add local symbolic link for reference fasta and dict
+    # Add local symbolic link for reference data
     # If soft links aren't allowed on your HPC system, copy them locally instead
     ln -s "~{reference_fasta}" "~{basename(reference_fasta)}"
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
-
-    # Symlink gnomad VCF locally so index can be written alongside it
     ln -s "~{gnomad_vcf}" "~{basename(gnomad_vcf)}"
 
     # Index gnomad VCF
@@ -916,12 +908,10 @@ task haplotype_caller_parallel {
   command <<<
     set -eo pipefail
 
-    # Add local symbolic link for reference fasta and dict
+    # Add local symbolic link for reference data
     ln -s "~{reference_fasta}" "~{basename(reference_fasta)}"
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
-
-    # Symlink dbSNP VCF locally so index can be written alongside it
     ln -s "~{dbsnp_vcf}" "~{basename(dbsnp_vcf)}"
 
     # Create index for dbSNP vcf
@@ -1034,13 +1024,11 @@ task mutect2_parallel {
   command <<<
     set -eo pipefail
 
-    # Add local symbolic link for reference fasta and dict
+    # Add local symbolic link for reference data
     # If soft links aren't allowed on your HPC system, copy them locally instead
     ln -s "~{reference_fasta}" "~{basename(reference_fasta)}"
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
-
-    # Symlink gnomad VCF locally so index can be written alongside it
     ln -s "~{gnomad_vcf}" "~{basename(gnomad_vcf)}"
 
     # Index gnomad VCF
@@ -1388,13 +1376,11 @@ task create_somatic_pon {
   command <<<
     set -eo pipefail
 
-    # Add local symbolic link for reference fasta and dict
+    # Add local symbolic link for reference data
     # If soft links aren't allowed on your HPC system, copy them locally instead
     ln -s "~{reference_fasta}" "~{basename(reference_fasta)}"
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
-
-    # Symlink and index germline resource if provided
     if [[ -f "~{germline_resource}" ]]; then
       ln -s "~{germline_resource}" "$(basename ~{germline_resource})"
       gatk IndexFeatureFile -I "$(basename ~{germline_resource})"

--- a/modules/ww-gatk/ww-gatk.wdl
+++ b/modules/ww-gatk/ww-gatk.wdl
@@ -155,11 +155,19 @@ task base_recalibrator {
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
 
-    # Generate vcf index files using GATK
-    gatk IndexFeatureFile -I "~{dbsnp_vcf}"
+    # Symlink VCF files locally so index files can be written alongside them
+    ln -s "~{dbsnp_vcf}" "~{basename(dbsnp_vcf)}"
     known_vcfs=(~{sep=" " known_indels_sites_vcfs})
+    known_sites_args=""
     for known_vcf in "${known_vcfs[@]}"; do
-      gatk IndexFeatureFile -I "${known_vcf}"
+      ln -s "${known_vcf}" "$(basename "${known_vcf}")"
+      known_sites_args="${known_sites_args} --known-sites $(basename "${known_vcf}")"
+    done
+
+    # Generate vcf index files using GATK
+    gatk IndexFeatureFile -I "~{basename(dbsnp_vcf)}"
+    for known_vcf in "${known_vcfs[@]}"; do
+      gatk IndexFeatureFile -I "$(basename "${known_vcf}")"
     done
 
     # Generate Base Recalibration Table
@@ -168,8 +176,8 @@ task base_recalibrator {
       -R "~{basename(reference_fasta)}" \
       -I "~{bam}" \
       -O "~{base_file_name}.recal_data.table" \
-      --known-sites "~{dbsnp_vcf}" \
-      --known-sites ~{sep=" --known-sites " known_indels_sites_vcfs} \
+      --known-sites "~{basename(dbsnp_vcf)}" \
+      ${known_sites_args} \
       ~{if defined(intervals) then "--intervals " + intervals else ""} \
       --verbosity WARNING
 
@@ -335,11 +343,19 @@ task markdup_recal_metrics {
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
 
-    # Generate vcf index files using GATK
-    gatk IndexFeatureFile -I "~{dbsnp_vcf}"
+    # Symlink VCF files locally so index files can be written alongside them
+    ln -s "~{dbsnp_vcf}" "~{basename(dbsnp_vcf)}"
     known_vcfs=(~{sep=" " known_indels_sites_vcfs})
+    known_sites_args=""
     for known_vcf in "${known_vcfs[@]}"; do
-      gatk IndexFeatureFile -I "${known_vcf}"
+      ln -s "${known_vcf}" "$(basename "${known_vcf}")"
+      known_sites_args="${known_sites_args} --known-sites $(basename "${known_vcf}")"
+    done
+
+    # Generate vcf index files using GATK
+    gatk IndexFeatureFile -I "~{basename(dbsnp_vcf)}"
+    for known_vcf in "${known_vcfs[@]}"; do
+      gatk IndexFeatureFile -I "$(basename "${known_vcf}")"
     done
 
     # Generate Base Recalibration Table
@@ -348,8 +364,8 @@ task markdup_recal_metrics {
       -R "~{basename(reference_fasta)}" \
       -I "~{bam}" \
       -O "~{base_file_name}.recal_data.table" \
-      --known-sites "~{dbsnp_vcf}" \
-      --known-sites ~{sep=" --known-sites " known_indels_sites_vcfs} \
+      --known-sites "~{basename(dbsnp_vcf)}" \
+      ${known_sites_args} \
       ~{if defined(intervals) then "--intervals " + intervals else ""} \
       --verbosity WARNING
 
@@ -632,8 +648,11 @@ task haplotype_caller {
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
 
+    # Symlink dbSNP VCF locally so index can be written alongside it
+    ln -s "~{dbsnp_vcf}" "~{basename(dbsnp_vcf)}"
+
     # Create index for dbSNP vcf
-    gatk IndexFeatureFile -I "~{dbsnp_vcf}"
+    gatk IndexFeatureFile -I "~{basename(dbsnp_vcf)}"
 
     # Run HaplotypeCaller
     gatk --java-options "-Xms~{memory_gb - 4}g -Xmx~{memory_gb - 2}g" \
@@ -641,7 +660,7 @@ task haplotype_caller {
       -R "~{basename(reference_fasta)}" \
       -I "~{bam}" \
       -O "~{base_file_name}.haplotypecaller.vcf.gz" \
-      --dbsnp "~{dbsnp_vcf}" \
+      --dbsnp "~{basename(dbsnp_vcf)}" \
       ~{if defined(intervals) then "--intervals " + intervals else ""} \
       ~{if defined(intervals) then "--interval-padding 100" else ""} \
       --verbosity WARNING
@@ -712,8 +731,11 @@ task mutect2 {
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
 
+    # Symlink gnomad VCF locally so index can be written alongside it
+    ln -s "~{gnomad_vcf}" "~{basename(gnomad_vcf)}"
+
     # Index gnomad VCF
-    gatk IndexFeatureFile -I "~{gnomad_vcf}"
+    gatk IndexFeatureFile -I "~{basename(gnomad_vcf)}"
 
     # Run Mutect2
     gatk --java-options "-Xms~{memory_gb - 4}g -Xmx~{memory_gb - 2}g" \
@@ -723,7 +745,7 @@ task mutect2 {
       -O "~{base_file_name}.unfiltered.vcf.gz" \
       ~{if defined(intervals) then "--intervals " + intervals else ""} \
       ~{if defined(intervals) then "--interval-padding 100" else ""} \
-      --germline-resource "~{gnomad_vcf}" \
+      --germline-resource "~{basename(gnomad_vcf)}" \
       --f1r2-tar-gz "~{base_file_name}.f1r2.tar.gz" \
       --max-mnp-distance "~{max_mnp_distance}" \
       --verbosity WARNING
@@ -899,8 +921,11 @@ task haplotype_caller_parallel {
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
 
+    # Symlink dbSNP VCF locally so index can be written alongside it
+    ln -s "~{dbsnp_vcf}" "~{basename(dbsnp_vcf)}"
+
     # Create index for dbSNP vcf
-    gatk IndexFeatureFile -I "~{dbsnp_vcf}"
+    gatk IndexFeatureFile -I "~{basename(dbsnp_vcf)}"
 
     # Calculate memory per parallel job
     mem_per_job=$(( (~{memory_gb} - 4) / ~{length(intervals)} ))
@@ -923,7 +948,7 @@ task haplotype_caller_parallel {
         -O "~{base_file_name}.${interval_name}.vcf.gz" \
         --intervals "$interval_file" \
         --interval-padding 100 \
-        --dbsnp "~{dbsnp_vcf}" \
+        --dbsnp "${dbsnp_vcf}" \
         --verbosity WARNING
     }
 
@@ -931,7 +956,7 @@ task haplotype_caller_parallel {
     export -f run_haplotypecaller
     export reference_fasta="~{basename(reference_fasta)}"
     export bam="~{bam}"
-    export dbsnp_vcf="~{dbsnp_vcf}"
+    export dbsnp_vcf="~{basename(dbsnp_vcf)}"
     export base_file_name="~{base_file_name}"
     export mem_per_job
 
@@ -1015,8 +1040,11 @@ task mutect2_parallel {
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
 
+    # Symlink gnomad VCF locally so index can be written alongside it
+    ln -s "~{gnomad_vcf}" "~{basename(gnomad_vcf)}"
+
     # Index gnomad VCF
-    gatk IndexFeatureFile -I "~{gnomad_vcf}"
+    gatk IndexFeatureFile -I "~{basename(gnomad_vcf)}"
 
     # Calculate memory per parallel job
     mem_per_job=$(( (~{memory_gb} - 4) / ~{length(intervals)} ))
@@ -1040,7 +1068,7 @@ task mutect2_parallel {
         -O "~{base_file_name}.${interval_name}.unfiltered.vcf.gz" \
         --intervals "$interval_file" \
         --interval-padding 100 \
-        --germline-resource "~{gnomad_vcf}" \
+        --germline-resource "${gnomad_vcf}" \
         --f1r2-tar-gz "~{base_file_name}.${interval_name}.f1r2.tar.gz" \
         --max-mnp-distance "~{max_mnp_distance}" \
         --verbosity WARNING
@@ -1059,7 +1087,7 @@ task mutect2_parallel {
     export -f run_mutect2
     export reference_fasta="~{basename(reference_fasta)}"
     export bam="~{bam}"
-    export gnomad_vcf="~{gnomad_vcf}"
+    export gnomad_vcf="~{basename(gnomad_vcf)}"
     export base_file_name="~{base_file_name}"
     export mem_per_job
 
@@ -1366,9 +1394,10 @@ task create_somatic_pon {
     ln -s "~{reference_fasta_index}" "~{basename(reference_fasta_index)}"
     ln -s "~{reference_dict}" "~{basename(reference_dict)}"
 
-    # Index germline resource if provided
+    # Symlink and index germline resource if provided
     if [[ -f "~{germline_resource}" ]]; then
-      gatk IndexFeatureFile -I "~{germline_resource}"
+      ln -s "~{germline_resource}" "$(basename ~{germline_resource})"
+      gatk IndexFeatureFile -I "$(basename ~{germline_resource})"
     fi
 
     # Create a GenomicsDB from normal calls
@@ -1387,7 +1416,7 @@ task create_somatic_pon {
       -V gendb://"~{database_name}" \
       -R "~{basename(reference_fasta)}" \
       -L "~{intervals}" \
-      ~{if defined(germline_resource) then "--germline-resource " + germline_resource else ""} \
+      ~{if defined(germline_resource) then "--germline-resource " + basename(select_first([germline_resource])) else ""} \
       -O "~{base_file_name}.pon.vcf.gz" \
       --verbosity WARNING
   >>>

--- a/modules/ww-jcast/testrun.wdl
+++ b/modules/ww-jcast/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-jcast/ww-jcast.wdl" as ww_jcast
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-jcast/ww-jcast.wdl" as ww_jcast
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow jcast_example {

--- a/modules/ww-jcast/ww-jcast.wdl
+++ b/modules/ww-jcast/ww-jcast.wdl
@@ -73,11 +73,14 @@ task jcast {
     echo "rMATS input directory contents:"
     ls -la "${RMATS_DIR}"
 
+    # Symlink GTF locally so JCAST can write cache files alongside it
+    ln -s "~{gtf_file}" "~{basename(gtf_file)}"
+
     # Run JCAST
     echo "Running JCAST..."
     jcast \
       "${RMATS_DIR}" \
-      "~{gtf_file}" \
+      "~{basename(gtf_file)}" \
       "~{genome_fasta}" \
       -o "~{output_name}" \
       -r ~{min_read_count} \

--- a/modules/ww-samtools/testrun.wdl
+++ b/modules/ww-samtools/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
 
 workflow samtools_example {
   # Download test data

--- a/modules/ww-samtools/testrun.wdl
+++ b/modules/ww-samtools/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
 
 workflow samtools_example {
@@ -12,7 +12,8 @@ workflow samtools_example {
       ref_fasta = download_ref_data.fasta
   }
   call ww_testdata.download_cram_data as download_cram_2 { input:
-      ref_fasta = download_ref_data.fasta
+      ref_fasta = download_ref_data.fasta,
+      output_name = "NA12878_chr1_copy"
   }
 
   # Download two BAM files to test merging in merge_bams_to_cram

--- a/modules/ww-samtools/ww-samtools.wdl
+++ b/modules/ww-samtools/ww-samtools.wdl
@@ -35,10 +35,21 @@ task crams_to_fastq {
   command <<<
     set -eo pipefail
 
+    # Symlink reference FASTA locally so samtools can write the .fai index
+    ln -s "~{ref}" "~{basename(ref)}"
+
+    # Symlink CRAM/BAM/SAM files locally to avoid read-only filesystem issues
+    cram_files=(~{sep=" " cram_files})
+    local_crams=""
+    for cram in "${cram_files[@]}"; do
+      ln -s "${cram}" "$(basename "${cram}")"
+      local_crams="${local_crams} $(basename "${cram}")"
+    done
+
     # Merge CRAM/BAM/SAM files if more than one, then collate and convert to FASTQ
-    samtools merge -@ ~{cpu_cores} --reference "~{ref}" -u - ~{sep=" " cram_files} | \
-    samtools collate -@ ~{cpu_cores} --reference "~{ref}" -O - | \
-    samtools fastq -@ ~{cpu_cores} --reference "~{ref}" -1 "~{name}_R1.fastq.gz" -2 "~{name}_R2.fastq.gz" -0 /dev/null -s /dev/null -
+    samtools merge -@ ~{cpu_cores} --reference "~{basename(ref)}" -u - ${local_crams} | \
+    samtools collate -@ ~{cpu_cores} --reference "~{basename(ref)}" -O - | \
+    samtools fastq -@ ~{cpu_cores} --reference "~{basename(ref)}" -1 "~{name}_R1.fastq.gz" -2 "~{name}_R2.fastq.gz" -0 /dev/null -s /dev/null -
   >>>
 
   output {

--- a/modules/ww-samtools/ww-samtools.wdl
+++ b/modules/ww-samtools/ww-samtools.wdl
@@ -136,8 +136,11 @@ task mpileup {
   command <<<
     set -eo pipefail
 
+    # Symlink reference FASTA locally so samtools can write the .fai index
+    ln -s "~{ref_fasta}" "~{basename(ref_fasta)}"
+
     samtools mpileup \
-      -f "~{ref_fasta}" \
+      -f "~{basename(ref_fasta)}" \
       -q "~{min_mapq}" \
       -Q "~{min_baseq}" \
       ~{if disable_baq then "--no-BAQ" else ""} \

--- a/modules/ww-starling/testrun.wdl
+++ b/modules/ww-starling/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module under test and testdata module using relative paths for local development
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-starling/ww-starling.wdl" as ww_starling
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-starling/ww-starling.wdl" as ww_starling
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-starling/testrun.wdl
+++ b/modules/ww-starling/testrun.wdl
@@ -33,8 +33,8 @@ workflow starling_example {
     fasta_file = create_test_idp_fasta.test_fasta,
     num_conformations = 50,
     gpu_enabled = false,
-    cpu_cores = 1,
-    memory_gb = 4
+    cpu_cores = 2,
+    memory_gb = 8
   }
 
   # Test split_fasta on the multi-sequence FASTA

--- a/modules/ww-starling/ww-starling.wdl
+++ b/modules/ww-starling/ww-starling.wdl
@@ -43,6 +43,10 @@ task generate_ensemble {
   command <<<
     set -eo pipefail
 
+    # Use working directory for model cache to avoid filling up container root filesystem
+    TORCH_HOME="$(pwd)/.torch_cache"
+    export TORCH_HOME
+
     # Generate the structural ensemble
     starling "~{sequence}" \
       -c ~{num_conformations} \
@@ -102,6 +106,10 @@ task generate_ensemble_batch {
 
   command <<<
     set -eo pipefail
+
+    # Use working directory for model cache to avoid filling up container root filesystem
+    TORCH_HOME="$(pwd)/.torch_cache"
+    export TORCH_HOME
 
     # Generate structural ensembles for all sequences in the FASTA
     starling "~{fasta_file}" \

--- a/modules/ww-testdata/testrun.wdl
+++ b/modules/ww-testdata/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow testdata_example {
   # Pull down reference genome and index files for chr1

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -221,6 +221,7 @@ task download_cram_data {
   parameter_meta {
     ref_fasta: "Reference genome FASTA file to use for CRAM conversion"
     chromosome: "Chromosome to extract from the BAM file (default: chr1)"
+    output_name: "Optional name for output CRAM file (default: NA12878_{chromosome})"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
   }
@@ -228,9 +229,12 @@ task download_cram_data {
   input {
     File ref_fasta
     String chromosome = "chr1"
+    String? output_name
     Int cpu_cores = 2
     Int memory_gb = 4
   }
+
+  String final_name = select_first([output_name, "NA12878_~{chromosome}"])
 
   command <<<
     set -euo pipefail
@@ -271,16 +275,16 @@ task download_cram_data {
     samtools index -@ ~{cpu_cores} NA12878_~{chromosome}.bam
 
     # Convert BAM to CRAM using the local reference copy
-    samtools view -@ ~{cpu_cores} -C -T ref.fa -o NA12878_~{chromosome}.cram NA12878_~{chromosome}.bam
-    samtools index -@ ~{cpu_cores} NA12878_~{chromosome}.cram
+    samtools view -@ ~{cpu_cores} -C -T ref.fa -o ~{final_name}.cram NA12878_~{chromosome}.bam
+    samtools index -@ ~{cpu_cores} ~{final_name}.cram
 
     # Clean up intermediate files
     rm NA12878_full.bam NA12878_full.bam.bai NA12878.bam NA12878.bam.bai NA12878_~{chromosome}.bam NA12878_~{chromosome}.bam.bai
   >>>
 
   output {
-    File cram = "NA12878_~{chromosome}.cram"
-    File crai = "NA12878_~{chromosome}.cram.crai"
+    File cram = "~{final_name}.cram"
+    File crai = "~{final_name}.cram.crai"
   }
 
   runtime {

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -822,10 +822,13 @@ task create_clean_amplicon_reference {
   command <<<
     set -eo pipefail
 
+    # Symlink input FASTA locally so samtools can write the .fai index
+    ln -s "~{input_fasta}" "~{basename(input_fasta)}"
+
     # Extract region if specified, otherwise use entire sequence
     if [ -n "~{region}" ]; then
-      samtools faidx "~{input_fasta}"
-      samtools faidx "~{input_fasta}" "~{region}" > temp_extract.fa
+      samtools faidx "~{basename(input_fasta)}"
+      samtools faidx "~{basename(input_fasta)}" "~{region}" > temp_extract.fa
 
       # Replace the header with just the chromosome name
       sed "s/^>.*/>~{output_name}/" temp_extract.fa > temp.fa

--- a/modules/ww-tritonnp/testrun.wdl
+++ b/modules/ww-tritonnp/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-tritonnp/ww-tritonnp.wdl" as ww_tritonnp
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-tritonnp/ww-tritonnp.wdl" as ww_tritonnp
 
 struct TritonSample {
     String name

--- a/modules/ww-tritonnp/ww-tritonnp.wdl
+++ b/modules/ww-tritonnp/ww-tritonnp.wdl
@@ -52,11 +52,6 @@ task triton_main {
     # Create results directory if it doesn't exist
     mkdir -p ~{results_dir}
     
-    # Needed Python packages for running Triton
-    PIP_TARGET="$(pwd)/.pip_packages"
-    python3 -m pip install --target="${PIP_TARGET}" --cache-dir="$(pwd)/.pip_cache" pysam numpy scipy pandas matplotlib seaborn
-    export PYTHONPATH="${PIP_TARGET}:${PYTHONPATH:-}"
-
     # Download script
     git clone https://github.com/caalo/TritonNP.git
 
@@ -81,7 +76,7 @@ task triton_main {
   runtime {
     cpu: ncpus
     memory: "~{memory_gb} GB"
-    docker: "python:bullseye"
+    docker: "getwilds/python-utils:0.1.0"
   }
 }
 
@@ -117,10 +112,6 @@ task combine_fms {
     # Download script
     git clone https://github.com/caalo/TritonNP.git
 
-    PIP_TARGET="$(pwd)/.pip_packages"
-    python3 -m pip install --target="${PIP_TARGET}" --cache-dir="$(pwd)/.pip_cache" pandas
-    export PYTHONPATH="${PIP_TARGET}:${PYTHONPATH:-}"
-
     # Run cleanup script
     python TritonNP/CombinePhasingFM.py \
        --inputs ~{sep=" " fm_files} \
@@ -134,6 +125,6 @@ task combine_fms {
   runtime {
     cpu: 1
     memory: "~{memory_gb} GB"
-    docker: "python:bullseye"
+    docker: "getwilds/python-utils:0.1.0"
   }
 }

--- a/modules/ww-tritonnp/ww-tritonnp.wdl
+++ b/modules/ww-tritonnp/ww-tritonnp.wdl
@@ -53,7 +53,9 @@ task triton_main {
     mkdir -p ~{results_dir}
     
     # Needed Python packages for running Triton
-    python3 -m pip install pysam numpy scipy pandas matplotlib seaborn
+    PIP_TARGET="$(pwd)/.pip_packages"
+    python3 -m pip install --target="${PIP_TARGET}" --cache-dir="$(pwd)/.pip_cache" pysam numpy scipy pandas matplotlib seaborn
+    export PYTHONPATH="${PIP_TARGET}:${PYTHONPATH:-}"
 
     # Download script
     git clone https://github.com/caalo/TritonNP.git
@@ -115,7 +117,9 @@ task combine_fms {
     # Download script
     git clone https://github.com/caalo/TritonNP.git
 
-    python3 -m pip install pandas
+    PIP_TARGET="$(pwd)/.pip_packages"
+    python3 -m pip install --target="${PIP_TARGET}" --cache-dir="$(pwd)/.pip_cache" pandas
+    export PYTHONPATH="${PIP_TARGET}:${PYTHONPATH:-}"
 
     # Run cleanup script
     python TritonNP/CombinePhasingFM.py \

--- a/modules/ww-varscan/testrun.wdl
+++ b/modules/ww-varscan/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-varscan/ww-varscan.wdl" as ww_varscan
 
 workflow varscan_example {

--- a/pipelines/ww-bwa-gatk/testrun.wdl
+++ b/pipelines/ww-bwa-gatk/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl" as bwa_gatk_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl" as bwa_gatk_workflow
 
 struct BwaSample {
     String name

--- a/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl
+++ b/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as bwa_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
 
 struct BwaSample {
     String name

--- a/pipelines/ww-leukemia/testrun.wdl
+++ b/pipelines/ww-leukemia/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
 
 workflow leukemia_test {
   # Download test reference data

--- a/pipelines/ww-leukemia/ww-leukemia.wdl
+++ b/pipelines/ww-leukemia/ww-leukemia.wdl
@@ -48,7 +48,7 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-ichorcna/ww-ichorcna.wdl" as ichorcna_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-manta/ww-manta.wdl" as manta_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-samtools/ww-samtools.wdl" as samtools_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-samtools/ww-samtools.wdl" as samtools_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-smoove/ww-smoove.wdl" as smoove_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-consensus/ww-consensus.wdl" as consensus_tasks
 

--- a/pipelines/ww-leukemia/ww-leukemia.wdl
+++ b/pipelines/ww-leukemia/ww-leukemia.wdl
@@ -45,7 +45,7 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bcftools/ww-bcftools.wdl" as bcftools_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as bwa_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-delly/ww-delly.wdl" as delly_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-ichorcna/ww-ichorcna.wdl" as ichorcna_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-manta/ww-manta.wdl" as manta_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-samtools/ww-samtools.wdl" as samtools_tasks

--- a/pipelines/ww-saturation/testrun.wdl
+++ b/pipelines/ww-saturation/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-saturation/ww-saturation.wdl" as saturation_workflow
 
 struct SaturationSample {

--- a/pipelines/ww-splicing-proteomics/testrun.wdl
+++ b/pipelines/ww-splicing-proteomics/testrun.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl" as splicing_proteomics_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl" as splicing_proteomics_workflow
 
 struct SampleInfo {
     String name

--- a/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl
+++ b/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl
@@ -8,7 +8,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rmats-turbo/ww-rmats-turbo.wdl" as rmats_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-jcast/ww-jcast.wdl" as jcast_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-jcast/ww-jcast.wdl" as jcast_tasks
 
 struct SampleInfo {
     String name

--- a/pipelines/ww-starling-batch/testrun.wdl
+++ b/pipelines/ww-starling-batch/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-starling-batch/ww-starling-batch.wdl" as starling_batch_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/pipelines/ww-starling-batch/ww-starling-batch.wdl" as starling_batch_workflow
 
 workflow starling_batch_example {
   # Create a test FASTA with multiple short IDP sequences

--- a/pipelines/ww-starling-batch/ww-starling-batch.wdl
+++ b/pipelines/ww-starling-batch/ww-starling-batch.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-starling/ww-starling.wdl" as starling_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-starling/ww-starling.wdl" as starling_tasks
 
 workflow starling_batch {
   meta {


### PR DESCRIPTION
## Type of Change

- Documentation update
- Other: CI/CD improvements (HPC test run infrastructure, Makefile resilience)

## Description

Adds infrastructure for running the full WILDS WDL test suite monthly on the Fred Hutch HPC via SLURM, supplementing GitHub Actions CI which has resource limits (~16 GB). This ensures that all modules/pipelines — including CI-excluded ones — are regularly validated under HPC execution conditions (Slurm + Apptainer).

The infrastructure consists of:

- **`.github/scripts/hpc-testrun.sbatch`** — SLURM batch script that clones the repo, runs `make run_sprocket` with a configurable sprocket config, and invokes the report script. Supports optional `BRANCH` and `TYPE` (modules/pipelines/all) arguments.
- **`.github/scripts/hpc_testrun_report.py`** — Python script that parses test output and posts a pass/fail summary as a comment on a central GitHub tracking issue via `gh` CLI.
- **`.github/scripts/launch-hpc-testrun.sh`** — Template launch script for scheduling via crontab. Submits separate SLURM jobs for modules and pipelines to avoid conflicts.
- **`.github/configs/sprocket-hpc.toml`** — Sprocket configuration for Slurm + Apptainer execution on the Fred Hutch HPC.
- **Makefile improvements** — `run_sprocket`, `run_miniwdl`, and `run_cromwell` now continue past individual failures and print an engine-specific summary at the end. Added optional `SPROCKET_CONFIG` and `TYPE` arguments for HPC execution.

Upon the merge to `main`, @tefirman will add `launch-hpc-testrun.sh` to his Rhino crontab for execution at midnight on the first of every month.

## Related Issue

- Addresses #169, potentially resolves it, but curious what other folks think.
- Companion to #320 which adds `ww-esmfold`, the first CI-excluded module that motivated this infrastructure.

## Testing

**How did you test these changes?**
Not yet tested end-to-end. The SLURM script and Python report script still need to be validated on the Fred Hutch HPC once the GitHub tracking issue is created.

**TODO:**
- [x] Create the GitHub tracking issue (#324)
- [x] Run `hpc-testrun.sbatch` and verify the issue comment is posted correctly
- [x] Confirm Makefile continue-on-failure behavior with a deliberate failure

**What workflow engine did you use?**
Sprocket for now, but plan to add Cromwell/miniwdl later.

**Did the tests pass?**
Pending end-to-end validation on the HPC.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs-preview` to check documentation rendering (if applicable)

## Additional Context

- Reviewers: the Makefile changes (continue-on-failure behavior, `TYPE` filtering) affect all modules/pipelines, not just CI-excluded ones.
- A GitHub tracking issue (#324) for HPC monthly test run results has been created. See the `hpc-testrun.sbatch` header for usage instructions.