### PR TITLE
Switching import URL's back to `main` for `ww-esmfold`

### DIFF
--- a/modules/ww-esmfold/testrun.wdl
+++ b/modules/ww-esmfold/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-esmfold/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-esmfold/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 # Tests ESMFold structure prediction with a tiny protein sequence on CPU.


### PR DESCRIPTION
## Type of Change

- Other: switching import URL's back to `main` branch

## Description

No functional change, just switching import URL's for `ww-esmfold` test run WDL back to the `main` branch.
See GitHub Action test run below just in case.