### PR TITLE
Reverting dummy workflows from Dockstore tool test

### DIFF
--- a/modules/ww-bedtools/ww-bedtools.wdl
+++ b/modules/ww-bedtools/ww-bedtools.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_bedtools {
-  meta {
-    description: "Tasks for BAM coverage analysis using BEDTools"
-  }
-}
-
 task coverage {
   meta {
     author: "Emma Bishop"

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_bwa {
-  meta {
-    description: "Tasks for building BWA index files and aligning reads"
-  }
-}
-
 task bwa_index {
   meta {
     author: "Emma Bishop"


### PR DESCRIPTION
## Type of Change

- Other: reverting addition of dummy workflow to `ww-bedtools` and `ww-bwa` modules for Dockstore tool upload

## Description

No functional change, just reverting a test of Dockstore functionality. See GitHub Action test runs below just in case.