### PR TITLE
Incorporating collaborator feedback on `ww-rnaseq` pipeline

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -287,6 +287,11 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
+      - name: Elaine Glenny
+        email: eglenny@fredhutch.org
+        role: Staff Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0002-1024-4290
     topic: WDL module for differential expression analysis using DESeq2
     enableAutoDois: true
     filters:
@@ -971,6 +976,34 @@ workflows:
       branches:
         - main
 
+  - name: ww-rnaseq
+    subclass: WDL
+    primaryDescriptorPath: /pipelines/ww-rnaseq/ww-rnaseq.wdl
+    readMePath: /pipelines/ww-rnaseq/README.md
+    testParameterFiles:
+      - /pipelines/ww-rnaseq/inputs.json
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+      - name: Elaine Glenny
+        email: eglenny@fredhutch.org
+        role: Staff Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0002-1024-4290
+    topic: Comprehensive RNA-seq pipeline covering read QC, adapter trimming, alignment, post-alignment QC, differential expression, and aggregated reporting
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-saturation
     subclass: WDL
     primaryDescriptorPath: /pipelines/ww-saturation/ww-saturation.wdl
@@ -992,6 +1025,7 @@ workflows:
         email: sobrien2@fredhutch.org
         role: Post-Doctoral Research Fellow
         affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4958-1080
     topic: WDL workflow to analyze saturation mutagenesis data using BWA alignment and GATK
     enableAutoDois: true
     filters:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -149,7 +149,7 @@ wilds-wdl-library/
 
 **Prefer Existing Modules**
 
-- Pipelines should primarily combine existing modules - prefer using existing modules over creating new task definitions. If you need new functionality, consider contributing it as a module first. Pipeline-local tasks are acceptable only when the logic is truly specific to that single pipeline and would not be reusable elsewhere (e.g., reorganizing that pipeline's particular outputs).
+- Pipelines should primarily combine existing modules - prefer using existing modules over creating new task definitions. If you need new functionality, consider contributing it as a module first. Tasks defined within pipelines are acceptable only when the logic is truly specific to that single pipeline and would not be reusable elsewhere (e.g., reorganizing that pipeline's particular outputs).
 
 **Pipeline inputs.json**
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -149,7 +149,7 @@ wilds-wdl-library/
 
 **Prefer Existing Modules**
 
-- Pipelines should primarily combine existing modules - prefer using existing modules over creating new task definitions. If you need new functionality, consider contributing it as a module first.
+- Pipelines should primarily combine existing modules - prefer using existing modules over creating new task definitions. If you need new functionality, consider contributing it as a module first. Pipeline-local tasks are acceptable only when the logic is truly specific to that single pipeline and would not be reusable elsewhere (e.g., reorganizing that pipeline's particular outputs).
 
 **Pipeline inputs.json**
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -67,6 +67,11 @@ authors:
   - family-names: O'Brien
     given-names: Siobhan
     affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0000-0003-4958-1080"
+  - family-names: Glenny
+    given-names: Elaine
+    affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0000-0002-1024-4290"
   - family-names: Bouvet
     given-names: Ethan
     affiliation: "Fred Hutch Cancer Center"

--- a/modules/ww-deseq2/README.md
+++ b/modules/ww-deseq2/README.md
@@ -248,6 +248,8 @@ Love MI, Huber W, Anders S. Moderated estimation of fold change and dispersion f
 
 ## Contributing
 
+Special thanks to [Elle Glenny](https://github.com/eglenny) for extensive testing of this module, identifying bugs, and suggesting feature improvements that have shaped the current design. Thank you for your contributions!
+
 If you would like to contribute to this WILDS WDL module, please see our [contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
 
 ## License

--- a/modules/ww-deseq2/README.md
+++ b/modules/ww-deseq2/README.md
@@ -21,6 +21,17 @@ This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds
 - **Dependencies**: Integrates with `ww-testdata` module for test data generation
 - **Test Data**: Uses Pasilla test dataset with 7 samples and 10,000 genes
 
+## Scripts
+
+All scripts are fetched from this repository at runtime via `curl`. This keeps the Docker images generic and makes it easy to iterate on analysis logic without rebuilding containers.
+
+| Script | Used by | Language | Description |
+|--------|---------|----------|-------------|
+| [`combine_star_counts.py`](combine_star_counts.py) | `combine_count_matrices` | Python | Reads individual STAR `ReadsPerGene.out.tab` files, extracts the specified count column (unstranded, forward, or reverse), merges them into a single gene-by-sample count matrix, and writes a sample metadata file for DESeq2 |
+| [`deseq2_analysis.R`](deseq2_analysis.R) | `run_deseq2` | R | Runs the full DESeq2 pipeline: reads counts and metadata, applies configurable gene filtering, fits the DESeq2 model, extracts results with optional LFC shrinkage, generates MA/PCA/volcano/heatmap plots, and writes results CSVs |
+| [`compile_deseq2_results.py`](compile_deseq2_results.py) | `compile_deseq2_results` | Python | Merges the all-genes results CSV with normalized counts on gene ID, parses GTF annotations (gene_name, gene_biotype, product), and joins them into a single comprehensive output CSV |
+| [`generate_pasilla_counts.R`](generate_pasilla_counts.R) | `generate_pasilla_counts` (in ww-testdata) | R | Generates synthetic STAR-format count files from the Bioconductor Pasilla dataset for testing; creates individual `ReadsPerGene.out.tab` files with realistic header statistics |
+
 ## Tasks
 
 ### `combine_count_matrices`
@@ -56,6 +67,9 @@ This ensures the analysis works reliably across diverse dataset sizes, from smal
 - `condition_column` (String): Column name containing experimental conditions (default: "condition")
 - `reference_level` (String): Reference level for DESeq2 contrast (typically control condition)
 - `contrast` (String): DESeq2 contrast string in format 'condition,treatment,control'
+- `min_counts` (Int): Minimum counts a gene must have to pass filtering (default: 10)
+- `min_samples` (Int): Minimum samples meeting `min_counts` threshold; 0 = use total counts instead (default: 0)
+- `shrinkage_method` (String): LFC shrinkage method — `apeglm`, `ashr`, or `normal`; empty = no shrinkage (default: "")
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores (default: 2)
 
@@ -66,6 +80,9 @@ This ensures the analysis works reliably across diverse dataset sizes, from smal
 - `deseq2_pca_plot` (File): Principal Component Analysis plot showing sample clustering
 - `deseq2_volcano_plot` (File): Volcano plot showing log fold change vs. statistical significance
 - `deseq2_heatmap` (File): Heatmap visualization of differentially expressed genes
+- `deseq2_ma_plot` (File): MA plot showing log fold change vs. mean expression (unshrunken)
+- `deseq2_ma_plot_shrunk` (File): MA plot with shrunken log fold changes (empty if shrinkage not applied)
+- `deseq2_results_shrunk` (File): DESeq2 results with shrunken log fold changes (empty if shrinkage not applied)
 
 ### `compile_deseq2_results`
 Merges DESeq2 differential expression results with normalized counts and gene annotations from a GTF file into a single comprehensive CSV. Uses [compile_deseq2_results.py](compile_deseq2_results.py) (fetched from this repository at runtime via wget).

--- a/modules/ww-deseq2/README.md
+++ b/modules/ww-deseq2/README.md
@@ -28,7 +28,7 @@ All scripts are fetched from this repository at runtime via `curl`. This keeps t
 | Script | Used by | Language | Description |
 |--------|---------|----------|-------------|
 | [`combine_star_counts.py`](combine_star_counts.py) | `combine_count_matrices` | Python | Reads individual STAR `ReadsPerGene.out.tab` files, extracts the specified count column (unstranded, forward, or reverse), merges them into a single gene-by-sample count matrix, and writes a sample metadata file for DESeq2 |
-| [`deseq2_analysis.R`](deseq2_analysis.R) | `run_deseq2` | R | Runs the full DESeq2 pipeline: reads counts and metadata, applies configurable gene filtering, fits the DESeq2 model, extracts results with optional LFC shrinkage, generates MA/PCA/volcano/heatmap plots, and writes results CSVs |
+| [`deseq2_analysis.R`](deseq2_analysis.R) | `run_deseq2` | R | Runs the full DESeq2 pipeline: reads counts and metadata, applies configurable gene filtering, fits the DESeq2 model, extracts results with optional log fold change shrinkage, generates MA/PCA/volcano/heatmap plots, and writes results CSVs |
 | [`compile_deseq2_results.py`](compile_deseq2_results.py) | `compile_deseq2_results` | Python | Merges the all-genes results CSV with normalized counts on gene ID, parses GTF annotations (gene_name, gene_biotype, product), and joins them into a single comprehensive output CSV |
 | [`generate_pasilla_counts.R`](generate_pasilla_counts.R) | `generate_pasilla_counts` (in ww-testdata) | R | Generates synthetic STAR-format count files from the Bioconductor Pasilla dataset for testing; creates individual `ReadsPerGene.out.tab` files with realistic header statistics |
 
@@ -68,7 +68,7 @@ This ensures the analysis works reliably across diverse dataset sizes, from smal
 - `reference_level` (String): Reference level for DESeq2 contrast (typically control condition)
 - `contrast` (String): DESeq2 contrast string in format 'condition,treatment,control'
 - `min_counts` (Int): Minimum counts a gene must have to pass filtering (default: 10)
-- `min_samples` (Int): Minimum samples meeting `min_counts` threshold; 0 = use total counts instead (default: 0)
+- `min_samples` (Int): A gene must meet the `min_counts` threshold in this many samples to be kept. 0 = Gene is kept if its count across all samples meets the `min_count` threshold (default: 0)
 - `shrinkage_method` (String): LFC shrinkage method — `apeglm`, `ashr`, or `normal`; empty = no shrinkage (default: "")
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores (default: 2)

--- a/modules/ww-deseq2/README.md
+++ b/modules/ww-deseq2/README.md
@@ -14,9 +14,10 @@ The module can run completely standalone with automatic test data generation. In
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
 
-- **Tasks**: `combine_count_matrices`, `run_deseq2`
+- **Tasks**: `combine_count_matrices`, `run_deseq2`, `compile_deseq2_results`
+- **Scripts**: `combine_star_counts.py`, `deseq2_analysis.R`, `compile_deseq2_results.py`, `generate_pasilla_counts.R` (fetched via wget at runtime)
 - **Test workflow**: `testrun.wdl` (demonstration workflow using test data)
-- **Containers**: `getwilds/combine-counts:0.1.0`, `getwilds/deseq2:1.40.2`
+- **Containers**: `python:3.12-slim` (count matrix tasks), `getwilds/deseq2:1.40.2` (DESeq2 analysis)
 - **Dependencies**: Integrates with `ww-testdata` module for test data generation
 - **Test Data**: Uses Pasilla test dataset with 7 samples and 10,000 genes
 
@@ -41,7 +42,7 @@ Combines STAR gene count files from multiple samples into a single count matrix 
 - `sample_metadata` (File): Metadata file containing sample names and conditions
 
 ### `run_deseq2`
-Performs differential expression analysis using DESeq2 with comprehensive statistical analysis and visualization via a prewritten R script: [deseq2_analysis.R](https://github.com/getwilds/wilds-docker-library/blob/main/deseq2/deseq2_analysis.R)
+Performs differential expression analysis using DESeq2 with comprehensive statistical analysis and visualization via a prewritten R script: [deseq2_analysis.R](deseq2_analysis.R) (fetched from this repository at runtime via wget)
 
 The task automatically selects the appropriate variance-stabilizing transformation method based on dataset size:
 - **≥1000 genes with counts**: Uses `vst()` for fast, efficient transformation
@@ -65,6 +66,20 @@ This ensures the analysis works reliably across diverse dataset sizes, from smal
 - `deseq2_pca_plot` (File): Principal Component Analysis plot showing sample clustering
 - `deseq2_volcano_plot` (File): Volcano plot showing log fold change vs. statistical significance
 - `deseq2_heatmap` (File): Heatmap visualization of differentially expressed genes
+
+### `compile_deseq2_results`
+Merges DESeq2 differential expression results with normalized counts and gene annotations from a GTF file into a single comprehensive CSV. Uses [compile_deseq2_results.py](compile_deseq2_results.py) (fetched from this repository at runtime via wget).
+
+**Inputs:**
+- `deseq2_results` (File): DESeq2 all-genes results CSV (output of `run_deseq2`)
+- `normalized_counts` (File): DESeq2 normalized counts CSV (output of `run_deseq2`)
+- `gtf_file` (File): GTF annotation file for extracting gene descriptions
+- `output_name` (String): Name for the output CSV file (default: "deseq2_compiled_results.csv")
+- `memory_gb` (Int): Memory allocation in GB (default: 4)
+- `cpu_cores` (Int): Number of CPU cores (default: 1)
+
+**Outputs:**
+- `compiled_results` (File): Combined CSV with DESeq2 statistics, normalized counts, and gene annotations (gene_name, gene_biotype, product where available)
 
 ## Usage as a Module
 
@@ -202,8 +217,9 @@ The `deseq2_example` workflow:
 ## Requirements
 
 - WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
-- R environment with DESeq2 package (provided in container)
-- Python environment for count matrix combination (provided in container)
+- Internet access for fetching scripts from GitHub at runtime
+- R environment with DESeq2 package (provided by `getwilds/deseq2:1.40.2` container)
+- Python 3.12 with pandas (provided by `python:3.12-slim` container, pandas installed at runtime)
 
 ## Support
 

--- a/modules/ww-deseq2/README.md
+++ b/modules/ww-deseq2/README.md
@@ -17,7 +17,7 @@ This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds
 - **Tasks**: `combine_count_matrices`, `run_deseq2`, `compile_deseq2_results`
 - **Scripts**: `combine_star_counts.py`, `deseq2_analysis.R`, `compile_deseq2_results.py`, `generate_pasilla_counts.R` (fetched via curl at runtime)
 - **Test workflow**: `testrun.wdl` (demonstration workflow using test data)
-- **Containers**: `python:3.12` (count matrix tasks; pandas installed into the task working directory at runtime), `getwilds/deseq2:1.40.2` (DESeq2 analysis)
+- **Containers**: `getwilds/python-utils:0.1.0` (count matrix tasks), `getwilds/deseq2:1.40.2` (DESeq2 analysis)
 - **Dependencies**: Integrates with `ww-testdata` module for test data generation
 - **Test Data**: Uses Pasilla test dataset with 7 samples and 10,000 genes
 
@@ -236,7 +236,7 @@ The `deseq2_example` workflow:
 - WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
 - Internet access for fetching scripts from GitHub at runtime
 - R environment with DESeq2 package (provided by `getwilds/deseq2:1.40.2` container)
-- Python 3.12 (provided by `python:3.12` container; pandas is installed into the task's working directory at runtime to avoid filling system scratch space on HPC systems)
+- Python 3 with pandas (provided by `getwilds/python-utils:0.1.0` container)
 
 ## Support
 

--- a/modules/ww-deseq2/README.md
+++ b/modules/ww-deseq2/README.md
@@ -15,9 +15,9 @@ The module can run completely standalone with automatic test data generation. In
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
 
 - **Tasks**: `combine_count_matrices`, `run_deseq2`, `compile_deseq2_results`
-- **Scripts**: `combine_star_counts.py`, `deseq2_analysis.R`, `compile_deseq2_results.py`, `generate_pasilla_counts.R` (fetched via wget at runtime)
+- **Scripts**: `combine_star_counts.py`, `deseq2_analysis.R`, `compile_deseq2_results.py`, `generate_pasilla_counts.R` (fetched via curl at runtime)
 - **Test workflow**: `testrun.wdl` (demonstration workflow using test data)
-- **Containers**: `python:3.12-slim` (count matrix tasks), `getwilds/deseq2:1.40.2` (DESeq2 analysis)
+- **Containers**: `python:3.12` (count matrix tasks; pandas installed into the task working directory at runtime), `getwilds/deseq2:1.40.2` (DESeq2 analysis)
 - **Dependencies**: Integrates with `ww-testdata` module for test data generation
 - **Test Data**: Uses Pasilla test dataset with 7 samples and 10,000 genes
 
@@ -236,7 +236,7 @@ The `deseq2_example` workflow:
 - WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
 - Internet access for fetching scripts from GitHub at runtime
 - R environment with DESeq2 package (provided by `getwilds/deseq2:1.40.2` container)
-- Python 3.12 with pandas (provided by `python:3.12-slim` container, pandas installed at runtime)
+- Python 3.12 (provided by `python:3.12` container; pandas is installed into the task's working directory at runtime to avoid filling system scratch space on HPC systems)
 
 ## Support
 

--- a/modules/ww-deseq2/combine_star_counts.py
+++ b/modules/ww-deseq2/combine_star_counts.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*-coding:utf-8 -*-
+"""
+@File    :   combine_star_counts.py
+@Time    :   2025/04/24
+@Author  :   Taylor Firman
+@Version :   0.1.0
+@Contact :   tfirman@fredhutch.org
+@Desc    :   Combine individual STAR counts into a single matrix for DESeq2
+"""
+
+import pandas as pd
+import os
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Combine STAR count matrices')
+    parser.add_argument('--input', nargs='+', required=True, help='Input gene count files from STAR')
+    parser.add_argument('--names', nargs='+', required=False, help='Sample names corresponding to input files')
+    parser.add_argument('--conditions', nargs='+', required=False, help='Condition labels for each sample')
+    parser.add_argument('--output', default='combined_counts_matrix.txt', help='Output combined matrix file')
+    parser.add_argument('--metadata', default='sample_metadata.txt', help='Output metadata file for DESeq2')
+    parser.add_argument('--count_column', type=int, default=2, 
+                        help='Which column to use (2=unstranded, 3=stranded forward, 4=stranded reverse)')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    count_files = args.input
+    count_column = args.count_column
+    
+    # Extract or use provided sample names
+    if args.names and len(args.names) == len(count_files):
+        sample_names = args.names
+        print(f"Using provided sample names: {sample_names}")
+    else:
+        # Extract sample names from file paths
+        sample_names = []
+        for file_path in count_files:
+            # Extract the base filename from the path
+            basename = os.path.basename(file_path)
+            # Extract the sample name before the first dot
+            sample_name = basename.split('.')[0]
+            sample_names.append(sample_name)
+        print(f"Extracted sample names from filenames: {sample_names}")
+    
+    # Check if conditions are provided
+    if args.conditions and len(args.conditions) == len(count_files):
+        conditions = args.conditions
+        print(f"Using provided conditions: {conditions}")
+    else:
+        # If conditions not provided, use "unknown" for all samples
+        conditions = ["unknown"] * len(count_files)
+        print("No conditions provided, using 'unknown' for all samples")
+    
+    print(f"Processing {len(count_files)} count files...")
+    
+    # Function to read STAR gene count file
+    def read_star_counts(file_path, sample_name, count_col):
+        # Skip the first 4 lines (summary statistics)
+        df = pd.read_csv(file_path, sep="\t", skiprows=4, header=None)
+
+        # Select only gene ID column and the requested count column
+        df = df.iloc[:, [0, count_col - 1]]
+
+        # Name the columns
+        df.columns = ["gene_id", sample_name]
+
+        return df
+
+    # Read the first file to get the gene list
+    print(f"Reading first file: {os.path.basename(count_files[0])}")
+    combined = read_star_counts(count_files[0], sample_names[0], count_column)
+
+    # Add the rest of the samples
+    if len(count_files) > 1:
+        for i in range(1, len(count_files)):
+            print(
+                f"Reading file {i + 1}/{len(count_files)}: {os.path.basename(count_files[i])}"
+            )
+            sample_counts = read_star_counts(
+                count_files[i], sample_names[i], count_column
+            )
+            combined = pd.merge(combined, sample_counts, on="gene_id")
+
+    # Write out the combined matrix
+    print(f"Writing combined matrix to {args.output}...")
+    combined.to_csv(args.output, sep='\t', index=False)
+    
+    # Create and write metadata file for DESeq2
+    metadata = pd.DataFrame({
+        'sample': sample_names,
+        'condition': conditions
+    })
+    
+    print(f"Writing sample metadata to {args.metadata}...")
+    metadata.to_csv(args.metadata, sep='\t', index=False)
+    
+    # Print summary
+    print(f"Combined {len(sample_names)} samples into a single count matrix")
+    print(f"Total genes: {len(combined)}")
+    print("Output files:")
+    print(f"  - {args.output} (main counts matrix)")
+    print(f"  - {args.metadata} (sample metadata for DESeq2)")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/ww-deseq2/compile_deseq2_results.py
+++ b/modules/ww-deseq2/compile_deseq2_results.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# -*-coding:utf-8 -*-
+"""
+@File    :   compile_deseq2_results.py
+@Time    :   2026/04/22
+@Author  :   Taylor Firman
+@Version :   0.1.0
+@Contact :   tfirman@fredhutch.org
+@Desc    :   Merge DESeq2 results with normalized counts and GTF gene annotations
+"""
+
+import pandas as pd
+import re
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Merge DESeq2 results, normalized counts, and GTF annotations"
+    )
+    parser.add_argument(
+        "--results", required=True, help="DESeq2 all-genes results CSV"
+    )
+    parser.add_argument(
+        "--counts", required=True, help="DESeq2 normalized counts CSV"
+    )
+    parser.add_argument(
+        "--gtf", required=True, help="GTF annotation file"
+    )
+    parser.add_argument(
+        "--output",
+        default="deseq2_compiled_results.csv",
+        help="Output compiled CSV file",
+    )
+    return parser.parse_args()
+
+
+def extract_attr(attributes, key):
+    """Extract a specific attribute value from a GTF attributes string."""
+    pattern = key + r'\s+"?([^";]+)"?'
+    match = re.search(pattern, attributes)
+    if match:
+        return match.group(1)
+    return None
+
+
+def parse_gtf_annotations(gtf_path):
+    """Parse gene annotations from a GTF file."""
+    records = []
+    with open(gtf_path, "r") as f:
+        for line in f:
+            if line.startswith("#"):
+                continue
+            fields = line.strip().split("\t")
+            if len(fields) < 9 or fields[2] != "gene":
+                continue
+            attrs = fields[8]
+            record = {
+                "gene_id": extract_attr(attrs, "gene_id"),
+                "gene_name": extract_attr(attrs, "gene_name"),
+                "gene_biotype": extract_attr(attrs, "gene_biotype"),
+                "product": extract_attr(attrs, "product"),
+            }
+            records.append(record)
+
+    annotations = pd.DataFrame(records)
+    # Remove columns that are entirely empty
+    annotations = annotations.dropna(axis=1, how="all")
+    # Deduplicate by gene_id
+    annotations = annotations.drop_duplicates(subset="gene_id")
+    return annotations
+
+
+def main():
+    args = parse_args()
+
+    print("Parsing GTF annotations...")
+    annotations = parse_gtf_annotations(args.gtf)
+    print(f"  Found {len(annotations)} gene annotations")
+
+    print("Reading DESeq2 results...")
+    results = pd.read_csv(args.results)
+    print(f"  {len(results)} genes in results")
+
+    print("Reading normalized counts...")
+    counts = pd.read_csv(args.counts, index_col=0)
+    counts.index.name = "gene_id"
+    counts = counts.reset_index()
+    print(f"  {len(counts)} genes in normalized counts")
+
+    # Merge results and counts
+    # The results CSV has a 'gene' column with gene IDs
+    # The counts CSV has gene IDs as the row index
+    gene_col = "gene" if "gene" in results.columns else results.columns[0]
+    compiled = pd.merge(
+        results, counts, left_on=gene_col, right_on="gene_id", how="left"
+    )
+    # Drop duplicate gene_id column if merge created one
+    if "gene_id" in compiled.columns and gene_col != "gene_id":
+        compiled = compiled.drop(columns=["gene_id"])
+
+    # Join annotations
+    compiled = pd.merge(
+        annotations, compiled, left_on="gene_id", right_on=gene_col, how="right"
+    )
+    # Drop duplicate gene column if merge created one
+    if gene_col in compiled.columns and gene_col != "gene_id":
+        compiled = compiled.drop(columns=[gene_col])
+
+    print(f"Writing compiled results ({len(compiled)} genes)...")
+    compiled.to_csv(args.output, index=False)
+    print(f"Output written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/ww-deseq2/compile_deseq2_results.py
+++ b/modules/ww-deseq2/compile_deseq2_results.py
@@ -63,9 +63,14 @@ def parse_gtf_annotations(gtf_path):
             }
             records.append(record)
 
+    if not records:
+        return pd.DataFrame(columns=["gene_id"])
+
     annotations = pd.DataFrame(records)
-    # Remove columns that are entirely empty
-    annotations = annotations.dropna(axis=1, how="all")
+    # Remove columns that are entirely empty, but always keep gene_id
+    keep_cols = [c for c in annotations.columns
+                 if c == "gene_id" or annotations[c].notna().any()]
+    annotations = annotations[keep_cols]
     # Deduplicate by gene_id
     annotations = annotations.drop_duplicates(subset="gene_id")
     return annotations
@@ -95,17 +100,16 @@ def main():
     compiled = pd.merge(
         results, counts, left_on=gene_col, right_on="gene_id", how="left"
     )
-    # Drop duplicate gene_id column if merge created one
-    if "gene_id" in compiled.columns and gene_col != "gene_id":
-        compiled = compiled.drop(columns=["gene_id"])
+    # Standardize the gene identifier column to 'gene_id'
+    if gene_col != "gene_id":
+        compiled = compiled.rename(columns={gene_col: "gene_id"})
+    # Drop any duplicate gene_id columns from the counts side
+    compiled = compiled.loc[:, ~compiled.columns.duplicated()]
 
     # Join annotations
     compiled = pd.merge(
-        annotations, compiled, left_on="gene_id", right_on=gene_col, how="right"
+        annotations, compiled, on="gene_id", how="right"
     )
-    # Drop duplicate gene column if merge created one
-    if gene_col in compiled.columns and gene_col != "gene_id":
-        compiled = compiled.drop(columns=[gene_col])
 
     print(f"Writing compiled results ({len(compiled)} genes)...")
     compiled.to_csv(args.output, index=False)

--- a/modules/ww-deseq2/deseq2_analysis.R
+++ b/modules/ww-deseq2/deseq2_analysis.R
@@ -22,6 +22,9 @@ option_list <- list(
   make_option("--condition_column", type="character", default="condition", help="Column in metadata to use for comparison [default: %default]"),
   make_option("--reference_level", type="character", default="", help="Reference level for comparison [default: first alphabetically]"),
   make_option("--contrast", type="character", default="", help="Contrast to use (comma-separated: condition,treatment,control) [default: infer from condition_column]"),
+  make_option("--min_counts", type="integer", default=10, help="Minimum number of counts a gene must have to pass filtering [default: %default]"),
+  make_option("--min_samples", type="integer", default=0, help="Minimum number of samples that must meet min_counts threshold (0 = use rowSums instead) [default: %default]"),
+  make_option("--shrinkage_method", type="character", default="", help="LFC shrinkage method: apeglm, ashr, or normal (empty = no shrinkage) [default: none]"),
   make_option("--output_prefix", type="character", default="deseq2_results", help="Prefix for output files [default: %default]")
 )
 
@@ -78,8 +81,16 @@ dds <- DESeqDataSetFromMatrix(
 
 # Filter out genes with too few counts
 cat("Filtering low count genes...\n")
-keep <- rowSums(counts(dds)) >= 10
+if (opt$min_samples > 0) {
+  cat("Keeping genes with >=", opt$min_counts, "counts in >=", opt$min_samples, "samples...\n")
+  keep <- rowSums(counts(dds) >= opt$min_counts) >= opt$min_samples
+} else {
+  cat("Keeping genes with total counts >=", opt$min_counts, "...\n")
+  keep <- rowSums(counts(dds)) >= opt$min_counts
+}
+cat("Genes before filtering:", nrow(dds), "\n")
 dds <- dds[keep,]
+cat("Genes after filtering:", nrow(dds), "\n")
 
 # Run DESeq2
 cat("Running DESeq2 analysis...\n")
@@ -105,6 +116,52 @@ res$gene <- rownames(res)
 
 # Sort by adjusted p-value
 res_ordered <- res[order(res$padj),]
+
+# Create MA plot (unshrunken)
+cat("Creating MA plot...\n")
+pdf(paste0(opt$output_prefix, "_ma_plot.pdf"), width=8, height=6)
+plotMA(res, main="MA Plot (unshrunken)", ylim=c(-5, 5))
+dev.off()
+
+# Apply LFC shrinkage if requested
+if (opt$shrinkage_method != "") {
+  cat("Applying LFC shrinkage using method:", opt$shrinkage_method, "...\n")
+
+  if (opt$shrinkage_method == "apeglm") {
+    library(apeglm)
+    # apeglm requires coef, not contrast
+    coef_name <- resultsNames(dds)[2]
+    cat("Using coefficient:", coef_name, "\n")
+    res_shrunk <- lfcShrink(dds, coef=coef_name, type="apeglm")
+  } else if (opt$shrinkage_method == "ashr") {
+    library(ashr)
+    res_shrunk <- lfcShrink(dds, contrast=if (opt$contrast != "") contrast_use else NULL,
+                            res=res, type="ashr")
+  } else if (opt$shrinkage_method == "normal") {
+    res_shrunk <- lfcShrink(dds, contrast=if (opt$contrast != "") contrast_use else NULL,
+                            res=res, type="normal")
+  } else {
+    stop("Unknown shrinkage method: ", opt$shrinkage_method,
+         ". Use 'apeglm', 'ashr', or 'normal'.")
+  }
+
+  # MA plot (shrunken)
+  cat("Creating shrunken MA plot...\n")
+  pdf(paste0(opt$output_prefix, "_ma_plot_shrunk.pdf"), width=8, height=6)
+  plotMA(res_shrunk, main=paste0("MA Plot (", opt$shrinkage_method, " shrinkage)"), ylim=c(-5, 5))
+  dev.off()
+
+  # Write shrunken results
+  res_shrunk$gene <- rownames(res_shrunk)
+  res_shrunk_ordered <- res_shrunk[order(res_shrunk$padj),]
+  write.csv(as.data.frame(res_shrunk_ordered),
+            file=paste0(opt$output_prefix, "_all_genes_shrunk.csv"), row.names=FALSE)
+  cat("Shrunken results written.\n")
+} else {
+  # Create empty shrinkage output files so WDL outputs are always satisfied
+  file.create(paste0(opt$output_prefix, "_ma_plot_shrunk.pdf"))
+  file.create(paste0(opt$output_prefix, "_all_genes_shrunk.csv"))
+}
 
 # Get normalized counts
 normalized_counts <- counts(dds, normalized=TRUE)

--- a/modules/ww-deseq2/deseq2_analysis.R
+++ b/modules/ww-deseq2/deseq2_analysis.R
@@ -1,0 +1,201 @@
+#!/usr/bin/env Rscript
+
+# Script for running DESeq2 analysis from a WDL workflow
+# This script handles:
+# 1. Reading in count data and sample metadata
+# 2. Setting up and running DESeq2 analysis
+# 3. Outputting results files and visualizations
+
+# Load required libraries
+suppressPackageStartupMessages({
+  library(DESeq2)
+  library(ggplot2)
+  library(pheatmap)
+  library(optparse)
+  library(RColorBrewer)
+})
+
+# Parse command line arguments
+option_list <- list(
+  make_option("--counts_file", type="character", help="Path to input counts matrix file"),
+  make_option("--metadata_file", type="character", help="Path to sample metadata file"),
+  make_option("--condition_column", type="character", default="condition", help="Column in metadata to use for comparison [default: %default]"),
+  make_option("--reference_level", type="character", default="", help="Reference level for comparison [default: first alphabetically]"),
+  make_option("--contrast", type="character", default="", help="Contrast to use (comma-separated: condition,treatment,control) [default: infer from condition_column]"),
+  make_option("--output_prefix", type="character", default="deseq2_results", help="Prefix for output files [default: %default]")
+)
+
+opt <- parse_args(OptionParser(option_list=option_list))
+
+# Validate inputs
+if (is.null(opt$counts_file) || is.null(opt$metadata_file)) {
+  stop("Counts file and metadata file are required")
+}
+
+# Read input data
+cat("Reading input data...\n")
+counts_data <- read.delim(opt$counts_file, row.names=1, check.names=FALSE)
+sample_metadata <- read.delim(opt$metadata_file, row.names=1, check.names=FALSE)
+
+# Ensure samples in counts match metadata
+common_samples <- intersect(colnames(counts_data), rownames(sample_metadata))
+if (length(common_samples) == 0) {
+  stop("No matching samples between counts and metadata")
+}
+
+# Subset data to matching samples
+counts_data <- counts_data[, common_samples]
+sample_metadata <- sample_metadata[common_samples, , drop=FALSE]
+
+# Ensure the condition column exists
+if (!opt$condition_column %in% colnames(sample_metadata)) {
+  stop("Condition column '", opt$condition_column, "' not found in metadata")
+}
+
+# Ensure condition column has at least two levels
+if (length(unique(sample_metadata[[opt$condition_column]])) < 2) {
+  stop("Need at least two different levels in condition column for comparison")
+}
+
+# Set the condition column as a factor
+sample_metadata[[opt$condition_column]] <- as.factor(sample_metadata[[opt$condition_column]])
+
+# Set reference level if specified
+if (opt$reference_level != "") {
+  if (!opt$reference_level %in% levels(sample_metadata[[opt$condition_column]])) {
+    stop("Reference level '", opt$reference_level, "' not found in condition column")
+  }
+  sample_metadata[[opt$condition_column]] <- relevel(sample_metadata[[opt$condition_column]], ref=opt$reference_level)
+}
+
+# Create DESeq2 dataset
+cat("Setting up DESeq2 dataset...\n")
+dds <- DESeqDataSetFromMatrix(
+  countData = round(counts_data), # Ensure counts are integers
+  colData = sample_metadata,
+  design = as.formula(paste("~", opt$condition_column))
+)
+
+# Filter out genes with too few counts
+cat("Filtering low count genes...\n")
+keep <- rowSums(counts(dds)) >= 10
+dds <- dds[keep,]
+
+# Run DESeq2
+cat("Running DESeq2 analysis...\n")
+dds <- DESeq(dds)
+
+# Get results
+cat("Extracting results...\n")
+if (opt$contrast != "") {
+  # Parse contrast
+  contrast_parts <- strsplit(opt$contrast, ",")[[1]]
+  if (length(contrast_parts) != 3) {
+    stop("Contrast should be in format: condition,treatment,control")
+  }
+  contrast_use <- c(contrast_parts[1], contrast_parts[2], contrast_parts[3])
+  res <- results(dds, contrast=contrast_use)
+} else {
+  # Use default contrast
+  res <- results(dds)
+}
+
+# Add gene names to results
+res$gene <- rownames(res)
+
+# Sort by adjusted p-value
+res_ordered <- res[order(res$padj),]
+
+# Get normalized counts
+normalized_counts <- counts(dds, normalized=TRUE)
+
+# Write results to files
+cat("Writing output files...\n")
+
+# All genes
+write.csv(as.data.frame(res_ordered), file=paste0(opt$output_prefix, "_all_genes.csv"), row.names=FALSE)
+
+# Significantly differentially expressed genes
+sig_genes <- subset(res_ordered, padj < 0.05)
+write.csv(as.data.frame(sig_genes), file=paste0(opt$output_prefix, "_significant.csv"), row.names=FALSE)
+
+# Normalized counts
+write.csv(normalized_counts, file=paste0(opt$output_prefix, "_normalized_counts.csv"))
+
+# Create PCA plot
+cat("Creating PCA plot...\n")
+# Use vst() for larger datasets (>1000 genes), rlog() for smaller datasets
+# vst() is faster but requires sufficient genes; rlog() is more robust for small datasets
+n_genes <- nrow(dds)
+if (n_genes >= 1000) {
+  cat("Using vst() transformation for", n_genes, "genes...\n")
+  vsd <- vst(dds, blind=FALSE)
+} else {
+  cat("Using rlog() transformation for", n_genes, "genes (< 1000)...\n")
+  vsd <- rlog(dds, blind=FALSE)
+}
+pcaData <- plotPCA(vsd, intgroup=opt$condition_column, returnData=TRUE)
+percentVar <- round(100 * attr(pcaData, "percentVar"))
+pca_plot <- ggplot(pcaData, aes(PC1, PC2, color=get(opt$condition_column), shape=get(opt$condition_column))) +
+  geom_point(size=3) +
+  xlab(paste0("PC1: ", percentVar[1], "% variance")) +
+  ylab(paste0("PC2: ", percentVar[2], "% variance")) +
+  labs(color=opt$condition_column, shape=opt$condition_column) +
+  theme_classic() +
+  ggtitle("PCA Plot")
+ggsave(paste0(opt$output_prefix, "_pca.pdf"), pca_plot, width=8, height=6)
+
+# Create volcano plot
+cat("Creating volcano plot...\n")
+volcano_data <- as.data.frame(res)
+volcano_data$significant <- ifelse(volcano_data$padj < 0.05, "FDR < 0.05", "Not Sig")
+volcano_data$log10padj <- -log10(volcano_data$padj)
+
+volcano_plot <- ggplot(volcano_data, aes(x=log2FoldChange, y=log10padj, color=significant)) +
+  geom_point(alpha=0.6) +
+  scale_color_manual(values=c("FDR < 0.05"="red", "Not Sig"="grey")) +
+  theme_classic() +
+  geom_vline(xintercept=c(-1, 1), linetype="dashed") +
+  geom_hline(yintercept=-log10(0.05), linetype="dashed") +
+  labs(x="Log2 Fold Change", y="-Log10 Adjusted P-value", color="Significance") +
+  ggtitle("Volcano Plot")
+ggsave(paste0(opt$output_prefix, "_volcano.pdf"), volcano_plot, width=8, height=6)
+
+# Create heatmap of top differentially expressed genes
+if (nrow(sig_genes) > 0) {
+  cat("Creating heatmap of top differentially expressed genes...\n")
+  # Get top 50 genes or all significant genes if fewer
+  top_genes <- rownames(sig_genes)[1:min(50, nrow(sig_genes))]
+  heatmap_data <- assay(vsd)[top_genes, ]
+  
+  # Scale rows
+  heatmap_data_z <- t(scale(t(heatmap_data)))
+  
+  # Create annotation for samples
+  anno_col <- data.frame(Condition = sample_metadata[[opt$condition_column]])
+  rownames(anno_col) <- colnames(heatmap_data)
+  
+  # Create heatmap
+  pheatmap(
+    heatmap_data_z,
+    annotation_col = anno_col,
+    clustering_distance_rows = "correlation",
+    clustering_distance_cols = "correlation",
+    show_rownames = TRUE,
+    show_colnames = TRUE,
+    fontsize_row = 8,
+    color = colorRampPalette(rev(brewer.pal(11, "RdBu")))(255),
+    filename = paste0(opt$output_prefix, "_heatmap.pdf"),
+    width = 8,
+    height = 10
+  )
+} else {
+  cat("No significant genes found for heatmap.\n")
+  # Create empty heatmap file
+  pdf(paste0(opt$output_prefix, "_heatmap.pdf"), width=8, height=6)
+  plot.new()
+  text(0.5, 0.5, "No significant differentially expressed genes found")
+  dev.off()
+}
+
+cat("DESeq2 analysis complete!\n")

--- a/modules/ww-deseq2/generate_pasilla_counts.R
+++ b/modules/ww-deseq2/generate_pasilla_counts.R
@@ -1,0 +1,218 @@
+#!/usr/bin/env Rscript
+
+# Generate individual STAR-format count files using the pasilla Bioconductor dataset
+# Author: WILDS Team
+# Description: Creates individual ReadsPerGene.out.tab files for each sample to mimic STAR output
+
+# Load required libraries
+suppressPackageStartupMessages({
+    library(optparse)
+    library(pasilla)
+    library(DESeq2)
+})
+
+# Define command line options
+option_list <- list(
+    make_option(c("-n", "--nsamples"), type = "integer", default = 7,
+                help = "Number of samples to include (default: 7, max: 7 for pasilla dataset)"),
+    make_option(c("-g", "--ngenes"), type = "integer", default = 10000,
+                help = "Approximate number of genes to include (will select top expressed genes)"),
+    make_option(c("-c", "--condition"), type = "character", default = "condition",
+                help = "Name for the condition column in metadata"),
+    make_option(c("-p", "--prefix"), type = "character", default = "pasilla",
+                help = "Prefix for output files")
+)
+
+# Parse command line arguments
+opt_parser <- OptionParser(option_list = option_list,
+                          description = "Generate individual STAR-format count files from pasilla dataset")
+opt <- parse_args(opt_parser)
+
+# Main execution
+tryCatch({
+    cat("=== Generating individual STAR-format count files from pasilla data ===\n")
+    cat("Parameters:\n")
+    cat("  Samples:", opt$nsamples, "\n")
+    cat("  Genes:", opt$ngenes, "\n")
+    cat("  Condition column:", opt$condition, "\n")
+    cat("  Output prefix:", opt$prefix, "\n\n")
+    
+    # Get the actual pasilla data files
+    count_file <- system.file("extdata", "pasilla_gene_counts.tsv", package = "pasilla")
+    sample_file <- system.file("extdata", "pasilla_sample_annotation.csv", package = "pasilla")
+    
+    cat("Loading pasilla data from:\n")
+    cat("Count file:", count_file, "\n")
+    cat("Sample file:", sample_file, "\n\n")
+    
+    # Read the count matrix and sample data
+    count_data <- read.table(count_file, header = TRUE, row.names = 1, sep = "\t")
+    sample_data <- read.csv(sample_file, header = TRUE, row.names = 1)
+    
+    cat("Original data dimensions:\n")
+    cat("Genes:", nrow(count_data), "\n")
+    cat("Samples:", ncol(count_data), "\n\n")
+    
+    # Remove 'fb' suffix from sample metadata row names to match count data
+    rownames(sample_data) <- gsub("fb$", "", rownames(sample_data))
+
+    # Make sure sample names match between count data and metadata
+    common_samples <- intersect(colnames(count_data), rownames(sample_data))
+    count_data <- count_data[, common_samples]
+    sample_data <- sample_data[common_samples, ]
+    
+    # Limit to requested number of samples
+    n_samples_requested <- opt$nsamples
+    if (n_samples_requested > ncol(count_data)) {
+        n_samples_requested <- ncol(count_data)
+        cat("Warning: Requested", opt$nsamples, "samples, but only", ncol(count_data), "available\n")
+    }
+    
+    # Select samples (ensure we have both conditions represented)
+    untreated_samples <- rownames(sample_data)[sample_data$condition == "untreated"]
+    treated_samples <- rownames(sample_data)[sample_data$condition == "treated"]
+    
+    # Take roughly equal numbers from each condition
+    n_untreated <- ceiling(n_samples_requested / 2)
+    n_treated <- n_samples_requested - n_untreated
+    
+    # Adjust if we don't have enough samples of one type
+    if (n_untreated > length(untreated_samples)) {
+        n_untreated <- length(untreated_samples)
+        n_treated <- n_samples_requested - n_untreated
+    }
+    if (n_treated > length(treated_samples)) {
+        n_treated <- length(treated_samples)
+        n_untreated <- n_samples_requested - n_treated
+    }
+    
+    selected_samples <- c(
+        untreated_samples[1:n_untreated],
+        treated_samples[1:n_treated]
+    )
+    
+    # Subset data
+    count_data <- count_data[, selected_samples]
+    sample_data <- sample_data[selected_samples, ]
+    
+    # Select top expressed genes
+    n_genes_requested <- opt$ngenes
+    if (n_genes_requested > nrow(count_data)) {
+        n_genes_requested <- nrow(count_data)
+        cat("Warning: Requested", opt$ngenes, "genes, but only", nrow(count_data), "available\n")
+    }
+    
+    # Calculate mean counts per gene and select top expressed
+    gene_means <- rowMeans(count_data)
+    top_genes <- order(gene_means, decreasing = TRUE)[1:n_genes_requested]
+    
+    count_data <- count_data[top_genes, ]
+    
+    # Create individual STAR-format count files for each sample
+    individual_count_files <- character(0)
+    sample_names <- character(0)
+    sample_conditions <- character(0)
+    
+    for (i in 1:ncol(count_data)) {
+        sample_name <- colnames(count_data)[i]
+        sample_condition <- as.character(sample_data[sample_name, "condition"])
+        
+        # Generate filename in STAR format: samplename.ReadsPerGene.out.tab
+        count_filename <- paste0(sample_name, ".ReadsPerGene.out.tab")
+        
+        # Get counts for this sample
+        sample_counts <- count_data[, i]
+        
+        # Calculate some realistic summary statistics for STAR header
+        # These are fake but representative values
+        total_reads <- sum(sample_counts) * 2  # Approximate total reads
+        uniquely_mapped <- round(sum(sample_counts) * 0.85)  # ~85% uniquely mapped
+        multimapping <- round(sum(sample_counts) * 0.10)     # ~10% multimapping
+        unmapped <- total_reads - uniquely_mapped - multimapping
+        
+        # Create STAR-format output with header statistics
+        # STAR ReadsPerGene.out.tab format:
+        # First 4 lines are summary statistics
+        # Then: gene_id, unstranded_count, stranded_forward, stranded_reverse
+        
+        # Open file for writing
+        file_conn <- file(count_filename, "w")
+        
+        # Write STAR header lines (summary statistics)
+        writeLines(paste("N_unmapped", unmapped, sep = "\t"), file_conn)
+        writeLines(paste("N_multimapping", multimapping, sep = "\t"), file_conn)
+        writeLines(paste("N_noFeature", round(total_reads * 0.02), sep = "\t"), file_conn)  # ~2% no feature
+        writeLines(paste("N_ambiguous", round(total_reads * 0.03), sep = "\t"), file_conn)  # ~3% ambiguous
+        
+        # Write gene counts
+        # Format: gene_id, unstranded, forward_strand, reverse_strand
+        # We'll use the actual counts as "unstranded" and generate reasonable strand-specific counts
+        for (j in 1:length(sample_counts)) {
+            gene_id <- rownames(count_data)[j]
+            unstranded_count <- sample_counts[j]
+            
+            # Generate strand-specific counts (simulate roughly 60/40 split for strand specificity)
+            forward_count <- round(unstranded_count * runif(1, 0.3, 0.7))
+            reverse_count <- unstranded_count - forward_count
+            
+            writeLines(paste(gene_id, unstranded_count, forward_count, reverse_count, sep = "\t"), file_conn)
+        }
+        
+        close(file_conn)
+        
+        # Store information for outputs
+        individual_count_files <- c(individual_count_files, count_filename)
+        sample_names <- c(sample_names, sample_name)
+        sample_conditions <- c(sample_conditions, sample_condition)
+        
+        cat("Created:", count_filename, "for sample", sample_name, "with condition", sample_condition, "\n")
+    }
+    
+    # Create sample names file
+    sample_names_file <- paste0(opt$prefix, "_sample_names.txt")
+    writeLines(sample_names, sample_names_file)
+    
+    # Create sample conditions file
+    sample_conditions_file <- paste0(opt$prefix, "_sample_conditions.txt")
+    writeLines(sample_conditions, sample_conditions_file)
+    
+    # Create count files list
+    count_files_list <- paste0(opt$prefix, "_count_files.txt")
+    writeLines(individual_count_files, count_files_list)
+    
+    # Write gene information
+    gene_info_file <- paste0(opt$prefix, "_gene_info.txt")
+    gene_info <- data.frame(
+        gene_id = rownames(count_data),
+        gene_name = rownames(count_data),  # Use gene ID as name since we don't have symbols
+        stringsAsFactors = FALSE
+    )
+    write.table(gene_info, 
+                file = gene_info_file, 
+                sep = "\t", 
+                row.names = FALSE, 
+                col.names = TRUE,
+                quote = FALSE)
+    
+    # Print summary
+    cat("\n=== Generated individual STAR-format count files ===\n")
+    cat("Files created:\n")
+    for (i in 1:length(individual_count_files)) {
+        cat("  Count file:", individual_count_files[i], "(", sample_names[i], "-", sample_conditions[i], ")\n")
+    }
+    cat("  Sample names list:", sample_names_file, "\n")
+    cat("  Sample conditions list:", sample_conditions_file, "\n")
+    cat("  Count files list:", count_files_list, "\n")
+    cat("  Gene info:", gene_info_file, "\n\n")
+    cat("Data summary:\n")
+    cat("  Total samples:", length(sample_names), "\n")
+    cat("  Genes per file:", nrow(count_data), "\n")
+    cat("  Conditions:", paste(unique(sample_conditions), collapse = ", "), "\n")
+    cat("  Sample names:", paste(sample_names, collapse = ", "), "\n")
+    cat("\nScript completed successfully!\n")
+
+}, error = function(e) {
+    cat("Error occurred during execution:\n")
+    cat(conditionMessage(e), "\n")
+    quit(status = 1)
+})

--- a/modules/ww-deseq2/testrun.wdl
+++ b/modules/ww-deseq2/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as ww_deseq2
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/ww-deseq2.wdl" as ww_deseq2
 
 workflow deseq2_example {
   # Generate test data

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -99,7 +99,7 @@ task run_deseq2 {
     reference_level: "Reference level for the contrast (typically the control condition)"
     contrast: "DESeq2 contrast string in the format 'condition,treatment,control'"
     min_counts: "Minimum number of counts a gene must have to pass filtering"
-    min_samples: "Minimum number of samples that must meet min_counts threshold (0 = use total counts instead)"
+    min_samples: "A gene must meet the `min_counts` threshold in this many samples to be kept. 0 = Gene is kept if its count across all samples meets the `min_count` threshold (default: 0)"
     shrinkage_method: "LFC shrinkage method: apeglm, ashr, or normal (empty = no shrinkage)"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -61,7 +61,7 @@ task combine_count_matrices {
   }
 
   runtime {
-    docker: "python:3.12-slim"
+    docker: "python:3.12"
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -183,7 +183,7 @@ task compile_deseq2_results {
   }
 
   runtime {
-    docker: "python:3.12-slim"
+    docker: "python:3.12"
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -30,8 +30,8 @@ task combine_count_matrices {
     Array[File] gene_count_files
     Array[String] sample_names
     Array[String] sample_conditions
-    Int memory_gb = 4
-    Int cpu_cores = 1
+    Int memory_gb = 8
+    Int cpu_cores = 2
     Int count_column = 2
         # Column to extract from ReadsPerGene.out.tab files:
         # 2 = unstranded counts
@@ -42,7 +42,11 @@ task combine_count_matrices {
   command <<<
     set -eo pipefail
 
-    pip install --no-cache-dir pandas==2.2.3
+    # Install pandas into the task working directory to avoid
+    # filling up scratch/tmp space on HPC systems
+    PIP_TARGET="$(pwd)/.pip_packages"
+    python3 -m pip install --target="${PIP_TARGET}" --cache-dir="$(pwd)/.pip_cache" pandas==2.2.3
+    export PYTHONPATH="${PIP_TARGET}:${PYTHONPATH:-}"
 
     curl -so combine_star_counts.py \
       "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/combine_star_counts.py"
@@ -174,14 +178,18 @@ task compile_deseq2_results {
     File normalized_counts
     File gtf_file
     String output_name = "deseq2_compiled_results.csv"
-    Int memory_gb = 4
-    Int cpu_cores = 1
+    Int memory_gb = 8
+    Int cpu_cores = 2
   }
 
   command <<<
     set -eo pipefail
 
-    pip install --no-cache-dir pandas==2.2.3
+    # Install pandas into the task working directory to avoid
+    # filling up scratch/tmp space on HPC systems
+    PIP_TARGET="$(pwd)/.pip_packages"
+    python3 -m pip install --target="${PIP_TARGET}" --cache-dir="$(pwd)/.pip_cache" pandas==2.2.3
+    export PYTHONPATH="${PIP_TARGET}:${PYTHONPATH:-}"
 
     curl -so compile_deseq2_results.py \
       "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/compile_deseq2_results.py"

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -42,7 +42,12 @@ task combine_count_matrices {
   command <<<
     set -eo pipefail
 
-    combine_star_counts.py \
+    pip install pandas==2.2.3
+
+    wget -q "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/combine_star_counts.py" \
+      -O combine_star_counts.py
+
+    python combine_star_counts.py \
       --input ~{sep=" " gene_count_files} \
       --names ~{sep=" " sample_names} \
       --conditions ~{sep=" " sample_conditions} \
@@ -56,7 +61,7 @@ task combine_count_matrices {
   }
 
   runtime {
-    docker: "getwilds/combine-counts:0.1.0"
+    docker: "python:3.12-slim"
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -101,7 +106,10 @@ task run_deseq2 {
   command <<<
     set -eo pipefail
 
-    deseq2_analysis.R \
+    wget -q "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/deseq2_analysis.R" \
+      -O deseq2_analysis.R
+
+    Rscript deseq2_analysis.R \
       --counts_file="~{counts_matrix}" \
       --metadata_file="~{sample_metadata}" \
       --condition_column="~{condition_column}" \
@@ -121,6 +129,61 @@ task run_deseq2 {
 
   runtime {
     docker: "getwilds/deseq2:1.40.2"
+    memory: "~{memory_gb} GB"
+    cpu: cpu_cores
+  }
+}
+
+task compile_deseq2_results {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Merge DESeq2 results with normalized counts and GTF gene annotations into a single comprehensive output file"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl"
+    outputs: {
+        compiled_results: "Combined CSV with DESeq2 statistics, normalized counts, and gene annotations from the GTF"
+    }
+  }
+
+  parameter_meta {
+    deseq2_results: "DESeq2 all-genes results CSV (output of run_deseq2)"
+    normalized_counts: "DESeq2 normalized counts CSV (output of run_deseq2)"
+    gtf_file: "GTF annotation file used for alignment, for extracting gene descriptions"
+    output_name: "Name for the output CSV file"
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
+  }
+
+  input {
+    File deseq2_results
+    File normalized_counts
+    File gtf_file
+    String output_name = "deseq2_compiled_results.csv"
+    Int memory_gb = 4
+    Int cpu_cores = 1
+  }
+
+  command <<<
+    set -eo pipefail
+
+    pip install pandas==2.2.3
+
+    wget -q "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/compile_deseq2_results.py" \
+      -O compile_deseq2_results.py
+
+    python compile_deseq2_results.py \
+      --results "~{deseq2_results}" \
+      --counts "~{normalized_counts}" \
+      --gtf "~{gtf_file}" \
+      --output "~{output_name}"
+  >>>
+
+  output {
+    File compiled_results = "~{output_name}"
+  }
+
+  runtime {
+    docker: "python:3.12-slim"
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -44,8 +44,8 @@ task combine_count_matrices {
 
     pip install pandas==2.2.3
 
-    wget -q "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/combine_star_counts.py" \
-      -O combine_star_counts.py
+    curl -so combine_star_counts.py \
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/combine_star_counts.py"
 
     python combine_star_counts.py \
       --input ~{sep=" " gene_count_files} \
@@ -106,8 +106,8 @@ task run_deseq2 {
   command <<<
     set -eo pipefail
 
-    wget -q "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/deseq2_analysis.R" \
-      -O deseq2_analysis.R
+    curl -so deseq2_analysis.R \
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/deseq2_analysis.R"
 
     Rscript deseq2_analysis.R \
       --counts_file="~{counts_matrix}" \
@@ -168,8 +168,8 @@ task compile_deseq2_results {
 
     pip install pandas==2.2.3
 
-    wget -q "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/compile_deseq2_results.py" \
-      -O compile_deseq2_results.py
+    curl -so compile_deseq2_results.py \
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/compile_deseq2_results.py"
 
     python compile_deseq2_results.py \
       --results "~{deseq2_results}" \

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -79,7 +79,10 @@ task run_deseq2 {
         deseq2_normalized_counts: "Normalized count values produced by DESeq2 for all samples",
         deseq2_pca_plot: "Principal Component Analysis plot showing sample clustering based on expression patterns",
         deseq2_volcano_plot: "Volcano plot showing log fold change vs. statistical significance",
-        deseq2_heatmap: "Heatmap visualization of differentially expressed genes across samples"
+        deseq2_heatmap: "Heatmap visualization of differentially expressed genes across samples",
+        deseq2_ma_plot: "MA plot showing log fold change vs. mean expression (unshrunken)",
+        deseq2_ma_plot_shrunk: "MA plot with shrunken log fold changes (empty if shrinkage not applied)",
+        deseq2_results_shrunk: "DESeq2 results with shrunken log fold changes (empty if shrinkage not applied)"
     }
   }
 
@@ -89,6 +92,9 @@ task run_deseq2 {
     condition_column: "Column name in the metadata file that contains the experimental condition"
     reference_level: "Reference level for the contrast (typically the control condition)"
     contrast: "DESeq2 contrast string in the format 'condition,treatment,control'"
+    min_counts: "Minimum number of counts a gene must have to pass filtering"
+    min_samples: "Minimum number of samples that must meet min_counts threshold (0 = use total counts instead)"
+    shrinkage_method: "LFC shrinkage method: apeglm, ashr, or normal (empty = no shrinkage)"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
   }
@@ -99,6 +105,9 @@ task run_deseq2 {
     String condition_column = "condition"
     String reference_level = ""
     String contrast = ""
+    Int min_counts = 10
+    Int min_samples = 0
+    String shrinkage_method = ""
     Int memory_gb = 8
     Int cpu_cores = 2
   }
@@ -115,6 +124,9 @@ task run_deseq2 {
       --condition_column="~{condition_column}" \
       --reference_level="~{reference_level}" \
       --contrast="~{contrast}" \
+      --min_counts=~{min_counts} \
+      --min_samples=~{min_samples} \
+      --shrinkage_method="~{shrinkage_method}" \
       --output_prefix="deseq2_results"
   >>>
 
@@ -125,6 +137,9 @@ task run_deseq2 {
     File deseq2_pca_plot = "deseq2_results_pca.pdf"
     File deseq2_volcano_plot = "deseq2_results_volcano.pdf"
     File deseq2_heatmap = "deseq2_results_heatmap.pdf"
+    File deseq2_ma_plot = "deseq2_results_ma_plot.pdf"
+    File deseq2_ma_plot_shrunk = "deseq2_results_ma_plot_shrunk.pdf"
+    File deseq2_results_shrunk = "deseq2_results_all_genes_shrunk.csv"
   }
 
   runtime {

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -67,8 +67,16 @@ task combine_count_matrices {
 
 task run_deseq2 {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Elaine Glenny",
+            email: "eglenny@fredhutch.org"
+        }
+    ]
     description: "Perform differential expression analysis using DESeq2"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl"
     outputs: {
@@ -149,8 +157,16 @@ task run_deseq2 {
 
 task compile_deseq2_results {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Elaine Glenny",
+            email: "eglenny@fredhutch.org"
+        }
+    ]
     description: "Merge DESeq2 results with normalized counts and GTF gene annotations into a single comprehensive output file"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl"
     outputs: {

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -42,7 +42,7 @@ task combine_count_matrices {
   command <<<
     set -eo pipefail
 
-    pip install pandas==2.2.3
+    pip install --no-cache-dir pandas==2.2.3
 
     curl -so combine_star_counts.py \
       "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/combine_star_counts.py"
@@ -181,7 +181,7 @@ task compile_deseq2_results {
   command <<<
     set -eo pipefail
 
-    pip install pandas==2.2.3
+    pip install --no-cache-dir pandas==2.2.3
 
     curl -so compile_deseq2_results.py \
       "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/compile_deseq2_results.py"

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -30,8 +30,8 @@ task combine_count_matrices {
     Array[File] gene_count_files
     Array[String] sample_names
     Array[String] sample_conditions
-    Int memory_gb = 8
-    Int cpu_cores = 2
+    Int memory_gb = 4
+    Int cpu_cores = 1
     Int count_column = 2
         # Column to extract from ReadsPerGene.out.tab files:
         # 2 = unstranded counts
@@ -41,12 +41,6 @@ task combine_count_matrices {
 
   command <<<
     set -eo pipefail
-
-    # Install pandas into the task working directory to avoid
-    # filling up scratch/tmp space on HPC systems
-    PIP_TARGET="$(pwd)/.pip_packages"
-    python3 -m pip install --target="${PIP_TARGET}" --cache-dir="$(pwd)/.pip_cache" pandas==2.2.3
-    export PYTHONPATH="${PIP_TARGET}:${PYTHONPATH:-}"
 
     curl -so combine_star_counts.py \
       "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/combine_star_counts.py"
@@ -65,7 +59,7 @@ task combine_count_matrices {
   }
 
   runtime {
-    docker: "python:3.12"
+    docker: "getwilds/python-utils:0.1.0"
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -185,12 +179,6 @@ task compile_deseq2_results {
   command <<<
     set -eo pipefail
 
-    # Install pandas into the task working directory to avoid
-    # filling up scratch/tmp space on HPC systems
-    PIP_TARGET="$(pwd)/.pip_packages"
-    python3 -m pip install --target="${PIP_TARGET}" --cache-dir="$(pwd)/.pip_cache" pandas==2.2.3
-    export PYTHONPATH="${PIP_TARGET}:${PYTHONPATH:-}"
-
     curl -so compile_deseq2_results.py \
       "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/compile_deseq2_results.py"
 
@@ -206,7 +194,7 @@ task compile_deseq2_results {
   }
 
   runtime {
-    docker: "python:3.12"
+    docker: "getwilds/python-utils:0.1.0"
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-star/README.md
+++ b/modules/ww-star/README.md
@@ -178,6 +178,10 @@ The module supports flexible resource configuration:
 - `star_threads`: Usually set slightly less than `cpu_cores` to leave resources for I/O
 - Resource allocation can be tuned for different compute environments
 
+**For prokaryotic data:** A new `align_two_pass` parameter would be needed that sets `--alignIntronMax` to `1` to prohibit splicing (see [this thread](https://groups.google.com/g/rna-star/c/UhKoLcWr4TA) involving the tool author). If you need this added, please [file an issue](https://github.com/getwilds/wilds-wdl-library/issues).
+
+**For stranded data:** Our STAR tasks currently account for stranded data by default, since we require an annotation file when building the index and use `--quantMode GeneCounts` when aligning. Strand information is reported in the `align_two_pass` output `gene_counts` (a `ReadsPerGene.out.tab` file). See Section 7 of the [STAR manual](https://github.com/alexdobin/STAR/tree/2.7.6a/doc) and [this thread](https://groups.google.com/g/rna-star/c/oGvChGG2gto/m/UQrP3c8yDQAJ) with the tool author.
+
 
 ## Requirements
 

--- a/modules/ww-star/README.md
+++ b/modules/ww-star/README.md
@@ -40,6 +40,7 @@ Performs RNA-seq alignment using STAR's two-pass methodology.
 - `r1` (File): R1 FASTQ file
 - `r2` (File?, optional): R2 FASTQ file (omit for single-end data)
 - `name` (String): Sample name for output files
+- `prohibit_splicing` (Boolean): Whether to set `--alignIntronMax` to 1 (default: false)
 - `sjdb_overhang` (Int): Length of genomic sequence around junctions (default: 100)
 - `memory_gb` (Int): Memory allocation in GB (default: 62)
 - `cpu_cores` (Int): Total CPU cores (default: 8)
@@ -178,7 +179,7 @@ The module supports flexible resource configuration:
 - `star_threads`: Usually set slightly less than `cpu_cores` to leave resources for I/O
 - Resource allocation can be tuned for different compute environments
 
-**For prokaryotic data:** A new `align_two_pass` parameter would be needed that sets `--alignIntronMax` to `1` to prohibit splicing (see [this thread](https://groups.google.com/g/rna-star/c/UhKoLcWr4TA) involving the tool author). If you need this added, please [file an issue](https://github.com/getwilds/wilds-wdl-library/issues).
+**For prokaryotic data:** Set the `align_two_pass` parameter `prohibit_splicing` to `true`, which sets `--alignIntronMax` to `1` to prohibit splicing (see [this thread](https://groups.google.com/g/rna-star/c/UhKoLcWr4TA) involving the tool author). If you need this added, please [file an issue](https://github.com/getwilds/wilds-wdl-library/issues).
 
 **For stranded data:** Our STAR tasks currently account for stranded data by default, since we require an annotation file when building the index and use `--quantMode GeneCounts` when aligning. Strand information is reported in the `align_two_pass` output `gene_counts` (a `ReadsPerGene.out.tab` file). See Section 7 of the [STAR manual](https://github.com/alexdobin/STAR/tree/2.7.6a/doc) and [this thread](https://groups.google.com/g/rna-star/c/oGvChGG2gto/m/UQrP3c8yDQAJ) with the tool author.
 

--- a/modules/ww-star/testrun.wdl
+++ b/modules/ww-star/testrun.wdl
@@ -19,7 +19,7 @@ workflow star_example {
       reference_gtf = download_ref_data.gtf,
       sjdb_overhang = 100,
       genome_sa_index_nbases = 14,
-      memory_gb = 8,
+      memory_gb = 2,
       cpu_cores = 2
   }
 
@@ -50,7 +50,7 @@ workflow star_example {
       r1 = download_fastq_data.r1_fastq,
       name = "demo_sample_se",
       sjdb_overhang = 100,
-      memory_gb = 8,
+      memory_gb = 2,
       cpu_cores = 2
   }
 

--- a/modules/ww-star/testrun.wdl
+++ b/modules/ww-star/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as ww_star
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-star/ww-star.wdl" as ww_star
 
 struct StarSample {
     String name
@@ -54,13 +54,28 @@ workflow star_example {
       cpu_cores = 2
   }
 
+  # Test prohibiting splicing
+  call ww_star.align_two_pass as align_no_splice { input:
+        star_genome_tar = build_index.star_index_tar,
+        r1 = download_fastq_data.r1_fastq,
+        r2 = download_fastq_data.r2_fastq,
+        name = "demo_sample_ns",
+        prohibit_splicing = true,
+        sjdb_overhang = 100,
+        memory_gb = 8,
+        cpu_cores = 2
+  }
+
   call validate_outputs { input:
     bam_files = align_two_pass.bam,
     bai_files = align_two_pass.bai,
     gene_count_files = align_two_pass.gene_counts,
     se_bam = align_single_end.bam,
     se_bai = align_single_end.bai,
-    se_gene_counts = align_single_end.gene_counts
+    se_gene_counts = align_single_end.gene_counts,
+    ns_bam = align_no_splice.bam,
+    ns_bai = align_no_splice.bai,
+    ns_gene_counts = align_no_splice.gene_counts
   }
 
   output {
@@ -74,6 +89,9 @@ workflow star_example {
     File star_se_bam = align_single_end.bam
     File star_se_bai = align_single_end.bai
     File star_se_gene_counts = align_single_end.gene_counts
+    File star_ns_bam = align_no_splice.bam
+    File star_ns_bai = align_no_splice.bai
+    File star_ns_gene_counts = align_no_splice.gene_counts
     File validation_report = validate_outputs.report
   }
 }
@@ -93,6 +111,9 @@ task validate_outputs {
     se_bam: "Single-end BAM file to validate"
     se_bai: "Single-end BAM index file to validate"
     se_gene_counts: "Single-end gene count file to validate"
+    ns_bam: "Splicing-prohibited BAM file to validate"
+    ns_bai: "Splicing-prohibited BAM index file to validate"
+    ns_gene_counts: "Splicing-prohibited gene count file to validate"
   }
 
   input {
@@ -102,6 +123,9 @@ task validate_outputs {
     File se_bam
     File se_bai
     File se_gene_counts
+    File ns_bam
+    File ns_bai
+    File ns_gene_counts
   }
 
   command <<<
@@ -201,6 +225,43 @@ task validate_outputs {
       echo "Gene counts file: ~{se_gene_counts} (${se_gc_size} bytes, ${se_gc_lines} lines)" >> validation_report.txt
     else
       echo "Gene counts file: ~{se_gene_counts} - MISSING OR EMPTY" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    echo "" >> validation_report.txt
+
+    # Validate splice-prohibited outputs
+    echo "--- Splice-prohibited sample: ~{ns_bam} ---" >> validation_report.txt
+
+    if [[ -f "~{ns_bam}" && -s "~{ns_bam}" ]]; then
+      ns_bam_size=$(stat -c%s "~{ns_bam}")
+      echo "BAM file: ~{ns_bam} (${ns_bam_size} bytes)" >> validation_report.txt
+
+      if command -v samtools &> /dev/null; then
+        ns_mapped=$(samtools view -c -F 4 "~{ns_bam}" 2>/dev/null || echo "N/A")
+        ns_total=$(samtools view -c "~{ns_bam}" 2>/dev/null || echo "N/A")
+        echo "  Total reads: $ns_total" >> validation_report.txt
+        echo "  Mapped reads: $ns_mapped" >> validation_report.txt
+      fi
+    else
+      echo "BAM file: ~{ns_bam} - MISSING OR EMPTY" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    if [[ -f "~{ns_bai}" ]]; then
+      ns_bai_size=$(stat -c%s "~{ns_bai}")
+      echo "BAI file: ~{ns_bai} (${ns_bai_size} bytes)" >> validation_report.txt
+    else
+      echo "BAI file: ~{ns_bai} - MISSING" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    if [[ -f "~{ns_gene_counts}" && -s "~{ns_gene_counts}" ]]; then
+      ns_gc_size=$(stat -c%s "~{ns_gene_counts}")
+      ns_gc_lines=$(wc -l < "~{ns_gene_counts}" 2>/dev/null || echo "N/A")
+      echo "Gene counts file: ~{ns_gene_counts} (${ns_gc_size} bytes, ${ns_gc_lines} lines)" >> validation_report.txt
+    else
+      echo "Gene counts file: ~{ns_gene_counts} - MISSING OR EMPTY" >> validation_report.txt
       validation_passed=false
     fi
 

--- a/modules/ww-star/testrun.wdl
+++ b/modules/ww-star/testrun.wdl
@@ -39,7 +39,7 @@ workflow star_example {
         r2 = sample.r2,
         name = sample.name,
         sjdb_overhang = 100,
-        memory_gb = 8,
+        memory_gb = 2,
         cpu_cores = 2
     }
   }
@@ -62,7 +62,7 @@ workflow star_example {
         name = "demo_sample_ns",
         prohibit_splicing = true,
         sjdb_overhang = 100,
-        memory_gb = 8,
+        memory_gb = 2,
         cpu_cores = 2
   }
 

--- a/modules/ww-star/ww-star.wdl
+++ b/modules/ww-star/ww-star.wdl
@@ -88,6 +88,7 @@ task align_two_pass {
     r1: "FASTQ file for read 1"
     r2: "Optional FASTQ file for read 2 (omit for single-end data)"
     name: "Sample name to include in output filenames"
+    prohibit_splicing: "Whether to set --alignIntronMax to 1 (default: false)"
     sjdb_overhang: "Length of the genomic sequence around the annotated junction"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Total number of CPU cores allocated for the task"
@@ -99,6 +100,7 @@ task align_two_pass {
     File r1
     File? r2
     String name
+    Boolean prohibit_splicing = false
     Int sjdb_overhang = 100
     Int memory_gb = 62
     Int cpu_cores = 8
@@ -129,6 +131,7 @@ task align_two_pass {
       --outFileNamePrefix "./" \
       --quantMode GeneCounts \
       --quantTranscriptomeBAMcompression 5 \
+      ~{if prohibit_splicing then "--alignIntronMax 1" else ""} \
       --limitBAMsortRAM ${BAM_SORT_RAM} 
 
     # Clean up temporary directories

--- a/modules/ww-testdata/README.md
+++ b/modules/ww-testdata/README.md
@@ -412,6 +412,8 @@ Downloads the official ShapeMapper example data (TPP riboswitch) from the Weeks-
 
 ### generate_pasilla_counts
 
+Generates DESeq2 test count matrices using the Pasilla Bioconductor dataset. Uses [generate_pasilla_counts.R](../ww-deseq2/generate_pasilla_counts.R) from the `ww-deseq2` module (fetched via wget at runtime).
+
 **Inputs**:
 - `n_samples` (Int): Number of samples to include (default: 7, max: 7 for pasilla dataset)
 - `n_genes` (Int): Approximate number of genes to include (default: 10000)

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -721,7 +721,10 @@ task generate_pasilla_counts {
   command <<<
     set -eo pipefail
 
-    generate_pasilla_counts.R \
+    wget -q "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/generate_pasilla_counts.R" \
+      -O generate_pasilla_counts.R
+
+    Rscript generate_pasilla_counts.R \
       --nsamples ~{n_samples} \
       --ngenes ~{n_genes} \
       --condition "~{condition_name}" \

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -721,8 +721,8 @@ task generate_pasilla_counts {
   command <<<
     set -eo pipefail
 
-    wget -q "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/generate_pasilla_counts.R" \
-      -O generate_pasilla_counts.R
+    curl -so generate_pasilla_counts.R \
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/generate_pasilla_counts.R"
 
     Rscript generate_pasilla_counts.R \
       --nsamples ~{n_samples} \

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -301,6 +301,8 @@ For questions, bugs, and/or feature requests, reach out to the Fred Hutch Office
 
 ## Contributing
 
+Special thanks to [Elle Glenny](https://github.com/eglenny) for extensive testing of this pipeline, identifying bugs, and suggesting feature improvements that have shaped the current design. Thank you for your contributions!
+
 If you would like to contribute to this WILDS WDL pipeline, please see our [contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
 
 ## License

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -308,3 +308,4 @@ If you would like to contribute to this WILDS WDL pipeline, please see our [cont
 ## License
 
 Distributed under the MIT License. See `LICENSE` for details.
+

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -190,7 +190,7 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `star_memory_gb` | Memory allocation in GB for STAR alignment tasks | Int | No | 64 |
 | `genome_sa_index_nbases` | STAR SA pre-indexing string length (scales with genome size) | Int | No | 14 |
 | `min_counts` | Minimum counts a gene must have to pass DESeq2 pre-filtering | Int | No | 10 |
-| `min_samples` | Minimum samples meeting `min_counts` threshold (0 = use total counts) | Int | No | 0 |
+| `min_samples` | A gene must meet the `min_counts` threshold in this many samples to be kept. 0 = Gene is kept if its count across all samples meets the `min_count` threshold (default: 0)| Int | No | 0 |
 | `shrinkage_method` | LFC shrinkage method: `apeglm`, `ashr`, `normal`, or empty for none | String | No | "" |
 | `organize_results` | Reorganize outputs into a clean directory tarball | Boolean | No | false |
 | `include_bams` | Include BAM/BAI files in the organized tarball | Boolean | No | false |

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -19,7 +19,7 @@ This pipeline extends the simpler `ww-star-deseq2` pipeline with upstream read Q
 
 ## Pipeline Structure
 
-**Complexity Level: Advanced** (10 steps, 8 distinct modules)
+**Complexity Level: Advanced** (11 steps, 8 distinct modules)
 
 1. **GTF Normalization** (using `ww-gffread` module):
    - Ensures the reference GTF has proper `exon` features for every transcript
@@ -58,7 +58,12 @@ This pipeline extends the simpler `ww-star-deseq2` pipeline with upstream read Q
    - Combines gene counts from all samples into a single matrix
    - Performs statistical analysis and generates visualizations (PCA, volcano, heatmap)
 
-10. **MultiQC — Aggregated Reporting** (using `ww-multiqc` module):
+10. **DESeq2 — Compiled Results** (using `ww-deseq2` module):
+    - Merges differential expression results with normalized counts
+    - Annotates genes with descriptions from the GTF (gene_name, gene_biotype, product)
+    - Produces a single comprehensive CSV for downstream use
+
+11. **MultiQC — Aggregated Reporting** (using `ww-multiqc` module):
     - Collects reports from FastQC, Trim Galore, STAR, and RSeQC
     - Generates a single interactive HTML report summarizing all QC metrics
 
@@ -71,7 +76,7 @@ This pipeline imports and uses:
 - **ww-star module**: Genome indexing and read alignment (`build_index`, `align_two_pass` tasks)
 - **ww-bedparse module**: GTF to BED12 conversion (`gtf2bed` task)
 - **ww-rseqc module**: RNA-seq alignment quality control (`run_rseqc` task)
-- **ww-deseq2 module**: Count matrix assembly and differential expression (`combine_count_matrices`, `run_deseq2` tasks)
+- **ww-deseq2 module**: Count matrix assembly, differential expression, and compiled results (`combine_count_matrices`, `run_deseq2`, `compile_deseq2_results` tasks)
 - **ww-multiqc module**: Aggregated QC reporting (`run_multiqc` task)
 
 ## Usage
@@ -221,6 +226,7 @@ The pipeline produces comprehensive outputs from all modules:
 | `deseq2_pca_plot` | PCA plot of samples | ww-deseq2 |
 | `deseq2_volcano_plot` | Volcano plot of differential expression | ww-deseq2 |
 | `deseq2_heatmap` | Heatmap of differentially expressed genes | ww-deseq2 |
+| `deseq2_compiled_results` | Combined CSV with DESeq2 stats, normalized counts, and gene annotations | ww-deseq2 |
 | `multiqc_report` | Aggregated interactive HTML QC report | ww-multiqc |
 | `multiqc_data` | MultiQC parsed metrics data directory | ww-multiqc |
 

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -85,24 +85,49 @@ This pipeline imports and uses:
 
 ### Input Configuration
 
-Create an inputs JSON file with your samples and reference genome:
+Sample information can be provided either as a **TSV file** (recommended) or as **separate arrays** in the inputs JSON.
+
+#### Option 1: TSV File (Recommended)
+
+Create a tab-separated file (`samples.tsv`) with a header row and one row per sample:
+
+```tsv
+name	r1	r2	condition
+sample1	/path/to/sample1_R1.fastq.gz	/path/to/sample1_R2.fastq.gz	control
+sample2	/path/to/sample2_R1.fastq.gz	/path/to/sample2_R2.fastq.gz	control
+sample3	/path/to/sample3_R1.fastq.gz	/path/to/sample3_R2.fastq.gz	treatment
+sample4	/path/to/sample4_R1.fastq.gz	/path/to/sample4_R2.fastq.gz	treatment
+```
+
+Then reference it in your inputs JSON:
 
 ```json
 {
-  "rnaseq.samples": [
-    {
-      "name": "sample1",
-      "r1": "/path/to/sample1_R1.fastq.gz",
-      "r2": "/path/to/sample1_R2.fastq.gz",
-      "condition": "control"
-    },
-    {
-      "name": "sample2",
-      "r1": "/path/to/sample2_R1.fastq.gz",
-      "r2": "/path/to/sample2_R2.fastq.gz",
-      "condition": "treatment"
-    }
-  ],
+  "rnaseq.samples_tsv": "/path/to/samples.tsv",
+  "rnaseq.reference_genome": {
+    "name": "hg38",
+    "fasta": "/path/to/genome.fasta",
+    "gtf": "/path/to/annotation.gtf"
+  },
+  "rnaseq.reference_level": "control",
+  "rnaseq.contrast": "condition,treatment,control",
+  "rnaseq.star_cpu": 8,
+  "rnaseq.star_memory_gb": 64
+}
+```
+
+An example `samples.tsv` template is included in this directory.
+
+#### Option 2: Separate Arrays
+
+Alternatively, provide sample information as parallel arrays directly in the inputs JSON. This approach is primarily used by the `testrun.wdl` test workflow, where constructing a TSV file within WDL itself is not straightforward.
+
+```json
+{
+  "rnaseq.sample_names": ["sample1", "sample2", "sample3", "sample4"],
+  "rnaseq.r1_fastqs": ["/path/to/sample1_R1.fastq.gz", "/path/to/sample2_R1.fastq.gz", "/path/to/sample3_R1.fastq.gz", "/path/to/sample4_R1.fastq.gz"],
+  "rnaseq.r2_fastqs": ["/path/to/sample1_R2.fastq.gz", "/path/to/sample2_R2.fastq.gz", "/path/to/sample3_R2.fastq.gz", "/path/to/sample4_R2.fastq.gz"],
+  "rnaseq.conditions": ["control", "control", "treatment", "treatment"],
   "rnaseq.reference_genome": {
     "name": "hg38",
     "fasta": "/path/to/genome.fasta",
@@ -140,7 +165,11 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 
 | Parameter | Description | Type | Required? | Default |
 |-----------|-------------|------|-----------|---------|
-| `samples` | List of SampleInfo objects with paired FASTQ files and condition labels | Array[SampleInfo] | Yes | - |
+| `samples_tsv` | TSV file with columns: name, r1, r2, condition (header required) | File | No* | - |
+| `sample_names` | Array of sample names | Array[String] | No* | - |
+| `r1_fastqs` | Array of R1 FASTQ file paths | Array[File] | No* | - |
+| `r2_fastqs` | Array of R2 FASTQ file paths | Array[File] | No* | - |
+| `conditions` | Array of condition labels per sample | Array[String] | No* | - |
 | `reference_genome` | Reference genome information (name, fasta, gtf) | RefGenome | Yes | - |
 | `reference_level` | Reference level for DESeq2 contrast (e.g., 'control') | String | No | "" |
 | `contrast` | DESeq2 contrast string (e.g., 'condition,treatment,control') | String | No | "" |
@@ -150,16 +179,7 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `star_memory_gb` | Memory allocation in GB for STAR alignment tasks | Int | No | 64 |
 | `genome_sa_index_nbases` | STAR SA pre-indexing string length (scales with genome size) | Int | No | 14 |
 
-### SampleInfo Structure
-
-```json
-{
-  "name": "sample_name",
-  "r1": "/path/to/R1.fastq.gz",
-  "r2": "/path/to/R2.fastq.gz",
-  "condition": "control_or_treatment"
-}
-```
+*Provide either `samples_tsv` OR all four separate arrays (`sample_names`, `r1_fastqs`, `r2_fastqs`, `conditions`).
 
 ### RefGenome Structure
 

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -19,7 +19,7 @@ This pipeline extends the simpler `ww-star-deseq2` pipeline with upstream read Q
 
 ## Pipeline Structure
 
-**Complexity Level: Advanced** (11 steps, 8 distinct modules)
+**Complexity Level: Advanced** (12 steps, 8 distinct modules + 1 pipeline-local task)
 
 1. **GTF Normalization** (using `ww-gffread` module):
    - Ensures the reference GTF has proper `exon` features for every transcript
@@ -66,6 +66,12 @@ This pipeline extends the simpler `ww-star-deseq2` pipeline with upstream read Q
 11. **MultiQC — Aggregated Reporting** (using `ww-multiqc` module):
     - Collects reports from FastQC, Trim Galore, STAR, and RSeQC
     - Generates a single interactive HTML report summarizing all QC metrics
+
+12. **Organize Outputs** (optional, pipeline-local task):
+    - Reorganizes all outputs into a clean numbered directory structure with sample-named subdirectories
+    - Packages results as a single `.tar.gz` for easy delivery
+    - Disabled by default (`organize_results = false`) to avoid data duplication
+    - BAM files and trimmed FASTQs can be optionally included via `include_bams` and `include_trimmed_fastqs`
 
 ## Module Dependencies
 
@@ -183,6 +189,9 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `star_cpu` | Number of CPU cores for STAR alignment tasks | Int | No | 8 |
 | `star_memory_gb` | Memory allocation in GB for STAR alignment tasks | Int | No | 64 |
 | `genome_sa_index_nbases` | STAR SA pre-indexing string length (scales with genome size) | Int | No | 14 |
+| `organize_results` | Reorganize outputs into a clean directory tarball | Boolean | No | false |
+| `include_bams` | Include BAM/BAI files in the organized tarball | Boolean | No | false |
+| `include_trimmed_fastqs` | Include trimmed FASTQ files in the organized tarball | Boolean | No | false |
 
 *Provide either `samples_tsv` OR all four separate arrays (`sample_names`, `r1_fastqs`, `r2_fastqs`, `conditions`).
 
@@ -229,6 +238,7 @@ The pipeline produces comprehensive outputs from all modules:
 | `deseq2_compiled_results` | Combined CSV with DESeq2 stats, normalized counts, and gene annotations | ww-deseq2 |
 | `multiqc_report` | Aggregated interactive HTML QC report | ww-multiqc |
 | `multiqc_data` | MultiQC parsed metrics data directory | ww-multiqc |
+| `organized_results` | (Optional) Tarball with all outputs organized by step and sample | pipeline-local |
 
 ## Resource Considerations
 

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -189,6 +189,9 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `star_cpu` | Number of CPU cores for STAR alignment tasks | Int | No | 8 |
 | `star_memory_gb` | Memory allocation in GB for STAR alignment tasks | Int | No | 64 |
 | `genome_sa_index_nbases` | STAR SA pre-indexing string length (scales with genome size) | Int | No | 14 |
+| `min_counts` | Minimum counts a gene must have to pass DESeq2 pre-filtering | Int | No | 10 |
+| `min_samples` | Minimum samples meeting `min_counts` threshold (0 = use total counts) | Int | No | 0 |
+| `shrinkage_method` | LFC shrinkage method: `apeglm`, `ashr`, `normal`, or empty for none | String | No | "" |
 | `organize_results` | Reorganize outputs into a clean directory tarball | Boolean | No | false |
 | `include_bams` | Include BAM/BAI files in the organized tarball | Boolean | No | false |
 | `include_trimmed_fastqs` | Include trimmed FASTQ files in the organized tarball | Boolean | No | false |
@@ -235,6 +238,9 @@ The pipeline produces comprehensive outputs from all modules:
 | `deseq2_pca_plot` | PCA plot of samples | ww-deseq2 |
 | `deseq2_volcano_plot` | Volcano plot of differential expression | ww-deseq2 |
 | `deseq2_heatmap` | Heatmap of differentially expressed genes | ww-deseq2 |
+| `deseq2_ma_plot` | MA plot of log fold change vs. mean expression | ww-deseq2 |
+| `deseq2_ma_plot_shrunk` | MA plot with shrunken LFC (empty if shrinkage not applied) | ww-deseq2 |
+| `deseq2_results_shrunk` | DESeq2 results with shrunken LFC (empty if shrinkage not applied) | ww-deseq2 |
 | `deseq2_compiled_results` | Combined CSV with DESeq2 stats, normalized counts, and gene annotations | ww-deseq2 |
 | `multiqc_report` | Aggregated interactive HTML QC report | ww-multiqc |
 | `multiqc_data` | MultiQC parsed metrics data directory | ww-multiqc |

--- a/pipelines/ww-rnaseq/inputs.json
+++ b/pipelines/ww-rnaseq/inputs.json
@@ -11,5 +11,8 @@
   "rnaseq.trim_length": 20,
   "rnaseq.star_cpu": 8,
   "rnaseq.star_memory_gb": 64,
-  "rnaseq.genome_sa_index_nbases": 14
+  "rnaseq.genome_sa_index_nbases": 14,
+  "rnaseq.organize_results": false,
+  "rnaseq.include_bams": false,
+  "rnaseq.include_trimmed_fastqs": false
 }

--- a/pipelines/ww-rnaseq/inputs.json
+++ b/pipelines/ww-rnaseq/inputs.json
@@ -1,30 +1,5 @@
 {
-  "rnaseq.samples": [
-    {
-      "name": "sample1",
-      "r1": "/path/to/sample1_R1.fastq.gz",
-      "r2": "/path/to/sample1_R2.fastq.gz",
-      "condition": "control"
-    },
-    {
-      "name": "sample2",
-      "r1": "/path/to/sample2_R1.fastq.gz",
-      "r2": "/path/to/sample2_R2.fastq.gz",
-      "condition": "control"
-    },
-    {
-      "name": "sample3",
-      "r1": "/path/to/sample3_R1.fastq.gz",
-      "r2": "/path/to/sample3_R2.fastq.gz",
-      "condition": "treatment"
-    },
-    {
-      "name": "sample4",
-      "r1": "/path/to/sample4_R1.fastq.gz",
-      "r2": "/path/to/sample4_R2.fastq.gz",
-      "condition": "treatment"
-    }
-  ],
+  "rnaseq.samples_tsv": "/path/to/samples.tsv",
   "rnaseq.reference_genome": {
     "name": "hg38",
     "fasta": "/path/to/genome.fasta",

--- a/pipelines/ww-rnaseq/inputs.json
+++ b/pipelines/ww-rnaseq/inputs.json
@@ -9,6 +9,8 @@
   "rnaseq.contrast": "condition,treatment,control",
   "rnaseq.trim_quality": 20,
   "rnaseq.trim_length": 20,
+  "rnaseq.min_counts": 10,
+  "rnaseq.min_samples": 0,
   "rnaseq.star_cpu": 8,
   "rnaseq.star_memory_gb": 64,
   "rnaseq.genome_sa_index_nbases": 14,

--- a/pipelines/ww-rnaseq/samples.tsv
+++ b/pipelines/ww-rnaseq/samples.tsv
@@ -1,0 +1,5 @@
+name	r1	r2	condition
+sample1	/path/to/sample1_R1.fastq.gz	/path/to/sample1_R2.fastq.gz	control
+sample2	/path/to/sample2_R1.fastq.gz	/path/to/sample2_R2.fastq.gz	control
+sample3	/path/to/sample3_R1.fastq.gz	/path/to/sample3_R2.fastq.gz	treatment
+sample4	/path/to/sample4_R1.fastq.gz	/path/to/sample4_R2.fastq.gz	treatment

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -47,7 +47,10 @@ workflow rnaseq_example {
       trim_length = 20,
       star_cpu = 2,
       star_memory_gb = 6,
-      genome_sa_index_nbases = 10
+      genome_sa_index_nbases = 10,
+      organize_results = true,
+      include_bams = true,
+      include_trimmed_fastqs = true
   }
 
   output {
@@ -75,7 +78,9 @@ workflow rnaseq_example {
     File deseq2_pca_plot = rnaseq.deseq2_pca_plot
     File deseq2_volcano_plot = rnaseq.deseq2_volcano_plot
     File deseq2_heatmap = rnaseq.deseq2_heatmap
+    File deseq2_compiled_results = rnaseq.deseq2_compiled_results
     File multiqc_report = rnaseq.multiqc_report
     File multiqc_data = rnaseq.multiqc_data
+    File? organized_results = rnaseq.organized_results
   }
 }

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
 
 struct RefGenome {
     String name

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -4,13 +4,6 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
 
-struct SampleInfo {
-    String name
-    File r1
-    File r2
-    String condition
-}
-
 struct RefGenome {
     String name
     File fasta
@@ -33,35 +26,6 @@ workflow rnaseq_example {
   call ww_sra.fastqdump as treated1 { input: sra_id = "SRR1039508", ncpu = 2, max_reads = 250000 }
   call ww_sra.fastqdump as treated2 { input: sra_id = "SRR1039512", ncpu = 2, max_reads = 250000 }
 
-  # Construct SampleInfo structs from SRA downloads
-  SampleInfo sample1 = {
-    "name": "untreated_1",
-    "r1": untreated1.r1_end,
-    "r2": untreated1.r2_end,
-    "condition": "untreated"
-  }
-
-  SampleInfo sample2 = {
-    "name": "untreated_2",
-    "r1": untreated2.r1_end,
-    "r2": untreated2.r2_end,
-    "condition": "untreated"
-  }
-
-  SampleInfo sample3 = {
-    "name": "treated_1",
-    "r1": treated1.r1_end,
-    "r2": treated1.r2_end,
-    "condition": "treated"
-  }
-
-  SampleInfo sample4 = {
-    "name": "treated_2",
-    "r1": treated2.r1_end,
-    "r2": treated2.r2_end,
-    "condition": "treated"
-  }
-
   # Construct RefGenome struct
   RefGenome reference = {
     "name": "chr1_50M",
@@ -72,7 +36,10 @@ workflow rnaseq_example {
   # Run the full RNA-seq pipeline with reduced resources for testing
   call rnaseq_workflow.rnaseq {
     input:
-      samples = [sample1, sample2, sample3, sample4],
+      sample_names = ["untreated_1", "untreated_2", "treated_1", "treated_2"],
+      r1_fastqs = [untreated1.r1_end, untreated2.r1_end, treated1.r1_end, treated2.r1_end],
+      r2_fastqs = [untreated1.r2_end, untreated2.r2_end, treated1.r2_end, treated2.r2_end],
+      conditions = ["untreated", "untreated", "treated", "treated"],
       reference_genome = reference,
       reference_level = "untreated",
       contrast = "condition,treated,untreated",

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -118,11 +118,12 @@ workflow rnaseq {
   }
 
   scatter (idx in sample_indices) {
-    # Resolve sample fields: +1 offset on tsv_rows skips the header row
-    String sample_name = if defined(sample_names) then select_first([sample_names])[idx] else tsv_rows[idx + 1][0]
-    File sample_r1 = if defined(r1_fastqs) then select_first([r1_fastqs])[idx] else tsv_rows[idx + 1][1]
-    File sample_r2 = if defined(r2_fastqs) then select_first([r2_fastqs])[idx] else tsv_rows[idx + 1][2]
-    String sample_condition = if defined(conditions) then select_first([conditions])[idx] else tsv_rows[idx + 1][3]
+    # Offset index by 1 to skip the TSV header row
+    Int tsv_idx = idx + 1
+    String sample_name = if defined(sample_names) then select_first([sample_names])[idx] else tsv_rows[tsv_idx][0]
+    File sample_r1 = if defined(r1_fastqs) then select_first([r1_fastqs])[idx] else tsv_rows[tsv_idx][1]
+    File sample_r2 = if defined(r2_fastqs) then select_first([r2_fastqs])[idx] else tsv_rows[tsv_idx][2]
+    String sample_condition = if defined(conditions) then select_first([conditions])[idx] else tsv_rows[tsv_idx][3]
 
     # Step 1: Pre-trim FastQC
     call fastqc_tasks.run_fastqc as pretrim_fastqc { input:

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -48,7 +48,8 @@ workflow rnaseq {
         deseq2_heatmap: "Heatmap of differentially expressed genes across samples",
         deseq2_compiled_results: "Combined CSV with DESeq2 statistics, normalized counts, and gene annotations",
         multiqc_report: "MultiQC interactive HTML report aggregating all QC metrics",
-        multiqc_data: "MultiQC data directory with parsed metrics from all tools"
+        multiqc_data: "MultiQC data directory with parsed metrics from all tools",
+        organized_results: "Tarball containing all pipeline outputs organized by step and sample name"
     }
   }
 
@@ -66,6 +67,9 @@ workflow rnaseq {
     star_cpu: "Number of CPU cores for STAR alignment tasks"
     star_memory_gb: "Memory allocation in GB for STAR alignment tasks"
     genome_sa_index_nbases: "Length of the SA pre-indexing string for STAR (typically 10-15, scales with genome size)"
+    organize_results: "Whether to reorganize all outputs into a clean directory structure tarball (duplicates data, increases storage)"
+    include_bams: "Whether to include BAM/BAI files in the organized results tarball (can significantly increase output size)"
+    include_trimmed_fastqs: "Whether to include trimmed FASTQ files in the organized results tarball (can significantly increase output size)"
   }
 
   input {
@@ -84,6 +88,9 @@ workflow rnaseq {
     Int star_cpu = 8
     Int star_memory_gb = 64
     Int genome_sa_index_nbases = 14
+    Boolean organize_results = false
+    Boolean include_bams = false
+    Boolean include_trimmed_fastqs = false
   }
 
   # Parse sample information from TSV if provided.
@@ -202,6 +209,39 @@ workflow rnaseq {
       report_title = "RNA-seq Pipeline QC Report"
   }
 
+  # Step 10 (optional): Organize all outputs into a clean directory structure
+  if (organize_results) {
+    call organize_outputs as step10_organize_outputs { input:
+        sample_names = sample_name,
+        pretrim_fastqc_html = flatten(step01_pretrim_fastqc.html_reports),
+        pretrim_fastqc_zip = flatten(step01_pretrim_fastqc.zip_reports),
+        trimgalore_r1_trimmed = step02_trimgalore.r1_trimmed,
+        trimgalore_r2_trimmed = step02_trimgalore.r2_trimmed,
+        trimgalore_r1_report = step02_trimgalore.r1_report,
+        trimgalore_r2_report = step02_trimgalore.r2_report,
+        posttrim_fastqc_html = flatten(step03_posttrim_fastqc.html_reports),
+        posttrim_fastqc_zip = flatten(step03_posttrim_fastqc.zip_reports),
+        star_bam = step04_star_align.bam,
+        star_bai = step04_star_align.bai,
+        star_gene_counts = step04_star_align.gene_counts,
+        star_log_final = step04_star_align.log_final,
+        rseqc_summary = step05_rseqc.rseqc_summary,
+        counts_matrix = step06_combine_counts.counts_matrix,
+        sample_metadata = step06_combine_counts.sample_metadata,
+        deseq2_results = step07_deseq2.deseq2_results,
+        deseq2_significant = step07_deseq2.deseq2_significant,
+        deseq2_normalized_counts = step07_deseq2.deseq2_normalized_counts,
+        deseq2_pca_plot = step07_deseq2.deseq2_pca_plot,
+        deseq2_volcano_plot = step07_deseq2.deseq2_volcano_plot,
+        deseq2_heatmap = step07_deseq2.deseq2_heatmap,
+        deseq2_compiled_results = step08_compile_results.compiled_results,
+        multiqc_report = step09_multiqc.html_report,
+        multiqc_data = step09_multiqc.data_dir,
+        include_bams = include_bams,
+        include_trimmed_fastqs = include_trimmed_fastqs
+    }
+  }
+
   output {
     Array[Array[File]] pretrim_fastqc_html = step01_pretrim_fastqc.html_reports
     Array[Array[File]] pretrim_fastqc_zip = step01_pretrim_fastqc.zip_reports
@@ -230,5 +270,137 @@ workflow rnaseq {
     File deseq2_compiled_results = step08_compile_results.compiled_results
     File multiqc_report = step09_multiqc.html_report
     File multiqc_data = step09_multiqc.data_dir
+    File? organized_results = step10_organize_outputs.results_tar
+  }
+}
+
+task organize_outputs {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Organize all RNA-seq pipeline outputs into a clean, numbered directory structure and package as a tarball"
+    outputs: {
+        results_tar: "Tarball containing all pipeline outputs organized by step and sample"
+    }
+  }
+
+  parameter_meta {
+    sample_names: "Array of sample names used to create per-sample subdirectories"
+    include_bams: "Whether to include BAM/BAI files in the output tarball (can be very large)"
+    include_trimmed_fastqs: "Whether to include trimmed FASTQ files in the output tarball (can be very large)"
+    output_prefix: "Prefix for the output tarball filename"
+  }
+
+  input {
+    Array[String] sample_names
+    Array[File] pretrim_fastqc_html
+    Array[File] pretrim_fastqc_zip
+    Array[File] trimgalore_r1_trimmed
+    Array[File] trimgalore_r2_trimmed
+    Array[File] trimgalore_r1_report
+    Array[File] trimgalore_r2_report
+    Array[File] posttrim_fastqc_html
+    Array[File] posttrim_fastqc_zip
+    Array[File] star_bam
+    Array[File] star_bai
+    Array[File] star_gene_counts
+    Array[File] star_log_final
+    Array[File] rseqc_summary
+    File counts_matrix
+    File sample_metadata
+    File deseq2_results
+    File deseq2_significant
+    File deseq2_normalized_counts
+    File deseq2_pca_plot
+    File deseq2_volcano_plot
+    File deseq2_heatmap
+    File deseq2_compiled_results
+    File multiqc_report
+    File multiqc_data
+    Boolean include_bams = false
+    Boolean include_trimmed_fastqs = false
+    String output_prefix = "rnaseq_results"
+    Int memory_gb = 4
+    Int cpu_cores = 1
+  }
+
+  command <<<
+    set -eo pipefail
+
+    OUTDIR="~{output_prefix}"
+    NAMES=(~{sep=" " sample_names})
+    N=${#NAMES[@]}
+
+    PRETRIM_HTML=(~{sep=" " pretrim_fastqc_html})
+    PRETRIM_ZIP=(~{sep=" " pretrim_fastqc_zip})
+    TRIM_R1=(~{sep=" " trimgalore_r1_trimmed})
+    TRIM_R2=(~{sep=" " trimgalore_r2_trimmed})
+    TRIM_R1_RPT=(~{sep=" " trimgalore_r1_report})
+    TRIM_R2_RPT=(~{sep=" " trimgalore_r2_report})
+    POSTTRIM_HTML=(~{sep=" " posttrim_fastqc_html})
+    POSTTRIM_ZIP=(~{sep=" " posttrim_fastqc_zip})
+    STAR_BAM=(~{sep=" " star_bam})
+    STAR_BAI=(~{sep=" " star_bai})
+    STAR_COUNTS=(~{sep=" " star_gene_counts})
+    STAR_LOG=(~{sep=" " star_log_final})
+    RSEQC=(~{sep=" " rseqc_summary})
+
+    for i in $(seq 0 $((N - 1))); do
+      SAMPLE="${NAMES[$i]}"
+
+      mkdir -p "$OUTDIR/01-pretrim_fastqc/$SAMPLE"
+      cp "${PRETRIM_HTML[$i]}" "$OUTDIR/01-pretrim_fastqc/$SAMPLE/"
+      cp "${PRETRIM_ZIP[$i]}" "$OUTDIR/01-pretrim_fastqc/$SAMPLE/"
+
+      mkdir -p "$OUTDIR/02-trimgalore/$SAMPLE"
+      if [ "~{include_trimmed_fastqs}" = "true" ]; then
+        cp "${TRIM_R1[$i]}" "$OUTDIR/02-trimgalore/$SAMPLE/"
+        cp "${TRIM_R2[$i]}" "$OUTDIR/02-trimgalore/$SAMPLE/"
+      fi
+      cp "${TRIM_R1_RPT[$i]}" "$OUTDIR/02-trimgalore/$SAMPLE/"
+      cp "${TRIM_R2_RPT[$i]}" "$OUTDIR/02-trimgalore/$SAMPLE/"
+
+      mkdir -p "$OUTDIR/03-posttrim_fastqc/$SAMPLE"
+      cp "${POSTTRIM_HTML[$i]}" "$OUTDIR/03-posttrim_fastqc/$SAMPLE/"
+      cp "${POSTTRIM_ZIP[$i]}" "$OUTDIR/03-posttrim_fastqc/$SAMPLE/"
+
+      mkdir -p "$OUTDIR/04-star_align/$SAMPLE"
+      if [ "~{include_bams}" = "true" ]; then
+        cp "${STAR_BAM[$i]}" "$OUTDIR/04-star_align/$SAMPLE/"
+        cp "${STAR_BAI[$i]}" "$OUTDIR/04-star_align/$SAMPLE/"
+      fi
+      cp "${STAR_COUNTS[$i]}" "$OUTDIR/04-star_align/$SAMPLE/"
+      cp "${STAR_LOG[$i]}" "$OUTDIR/04-star_align/$SAMPLE/"
+
+      mkdir -p "$OUTDIR/05-rseqc/$SAMPLE"
+      cp "${RSEQC[$i]}" "$OUTDIR/05-rseqc/$SAMPLE/"
+    done
+
+    mkdir -p "$OUTDIR/06-deseq2"
+    cp "~{counts_matrix}" "$OUTDIR/06-deseq2/"
+    cp "~{sample_metadata}" "$OUTDIR/06-deseq2/"
+    cp "~{deseq2_results}" "$OUTDIR/06-deseq2/"
+    cp "~{deseq2_significant}" "$OUTDIR/06-deseq2/"
+    cp "~{deseq2_normalized_counts}" "$OUTDIR/06-deseq2/"
+    cp "~{deseq2_compiled_results}" "$OUTDIR/06-deseq2/"
+    cp "~{deseq2_pca_plot}" "$OUTDIR/06-deseq2/"
+    cp "~{deseq2_volcano_plot}" "$OUTDIR/06-deseq2/"
+    cp "~{deseq2_heatmap}" "$OUTDIR/06-deseq2/"
+
+    mkdir -p "$OUTDIR/07-multiqc"
+    cp "~{multiqc_report}" "$OUTDIR/07-multiqc/"
+    cp -r "~{multiqc_data}" "$OUTDIR/07-multiqc/"
+
+    tar -czf "~{output_prefix}.tar.gz" "$OUTDIR"
+  >>>
+
+  output {
+    File results_tar = "~{output_prefix}.tar.gz"
+  }
+
+  runtime {
+    docker: "ubuntu:24.04"
+    memory: "~{memory_gb} GB"
+    cpu: cpu_cores
   }
 }

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -5,7 +5,7 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bedparse/ww-bedparse.wdl" as bedparse_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rseqc/ww-rseqc.wdl" as rseqc_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/rnaseq-feedback/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as multiqc_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
 
@@ -46,6 +46,7 @@ workflow rnaseq {
         deseq2_pca_plot: "Principal Component Analysis plot of samples based on expression patterns",
         deseq2_volcano_plot: "Volcano plot showing log fold change vs. statistical significance",
         deseq2_heatmap: "Heatmap of differentially expressed genes across samples",
+        deseq2_compiled_results: "Combined CSV with DESeq2 statistics, normalized counts, and gene annotations",
         multiqc_report: "MultiQC interactive HTML report aggregating all QC metrics",
         multiqc_data: "MultiQC data directory with parsed metrics from all tools"
     }
@@ -179,6 +180,13 @@ workflow rnaseq {
       contrast = contrast
   }
 
+  # Step 6b: Compile DESeq2 results with normalized counts and GTF annotations
+  call deseq2_tasks.compile_deseq2_results { input:
+      deseq2_results = run_deseq2.deseq2_results,
+      normalized_counts = run_deseq2.deseq2_normalized_counts,
+      gtf_file = normalize_gtf.normalized_gtf
+  }
+
   # Step 7: MultiQC aggregation of all QC reports
   call multiqc_tasks.run_multiqc { input:
       input_files = flatten([
@@ -219,6 +227,7 @@ workflow rnaseq {
     File deseq2_pca_plot = run_deseq2.deseq2_pca_plot
     File deseq2_volcano_plot = run_deseq2.deseq2_volcano_plot
     File deseq2_heatmap = run_deseq2.deseq2_heatmap
+    File deseq2_compiled_results = compile_deseq2_results.compiled_results
     File multiqc_report = run_multiqc.html_report
     File multiqc_data = run_multiqc.data_dir
   }

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -17,8 +17,20 @@ struct RefGenome {
 
 workflow rnaseq {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Emma Bishop",
+            email: "ebishop@fredhutch.org"
+        },
+        {
+            name: "Elaine Glenny",
+            email: "eglenny@fredhutch.org"
+        }
+    ]
     description: "Comprehensive RNA-seq pipeline covering read QC, adapter trimming, alignment, post-alignment QC, differential expression, and aggregated reporting"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-rnaseq/ww-rnaseq.wdl"
     outputs: {

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -127,13 +127,13 @@ workflow rnaseq {
     String sample_condition = if defined(conditions) then select_first([conditions])[idx] else tsv_rows[tsv_idx][3]
 
     # Step 1: Pre-trim FastQC
-    call fastqc_tasks.run_fastqc as pretrim_fastqc { input:
+    call fastqc_tasks.run_fastqc as step01_pretrim_fastqc { input:
         r1_fastq = sample_r1,
         r2_fastq = sample_r2
     }
 
     # Step 2: Trim Galore adapter/quality trimming
-    call trimgalore_tasks.trimgalore_paired { input:
+    call trimgalore_tasks.trimgalore_paired as step02_trimgalore { input:
         sample_name = sample_name,
         r1_fastq = sample_r1,
         r2_fastq = sample_r2,
@@ -142,93 +142,93 @@ workflow rnaseq {
     }
 
     # Step 3: Post-trim FastQC
-    call fastqc_tasks.run_fastqc as posttrim_fastqc { input:
-        r1_fastq = trimgalore_paired.r1_trimmed,
-        r2_fastq = trimgalore_paired.r2_trimmed
+    call fastqc_tasks.run_fastqc as step03_posttrim_fastqc { input:
+        r1_fastq = step02_trimgalore.r1_trimmed,
+        r2_fastq = step02_trimgalore.r2_trimmed
     }
 
     # Step 4: STAR two-pass alignment on trimmed reads
-    call star_tasks.align_two_pass { input:
+    call star_tasks.align_two_pass as step04_star_align { input:
         star_genome_tar = build_index.star_index_tar,
-        r1 = trimgalore_paired.r1_trimmed,
-        r2 = trimgalore_paired.r2_trimmed,
+        r1 = step02_trimgalore.r1_trimmed,
+        r2 = step02_trimgalore.r2_trimmed,
         name = sample_name + "." + reference_genome.name,
         cpu_cores = star_cpu,
         memory_gb = star_memory_gb
     }
 
     # Step 5: RSeQC alignment quality control
-    call rseqc_tasks.run_rseqc { input:
+    call rseqc_tasks.run_rseqc as step05_rseqc { input:
         sample_name = sample_name,
-        bam_file = align_two_pass.bam,
-        bam_index = align_two_pass.bai,
+        bam_file = step04_star_align.bam,
+        bam_index = step04_star_align.bai,
         ref_bed = gtf2bed.bed_file
     }
   }
 
   # Step 6: DESeq2 count matrix assembly and differential expression
-  call deseq2_tasks.combine_count_matrices { input:
-      gene_count_files = align_two_pass.gene_counts,
+  call deseq2_tasks.combine_count_matrices as step06_combine_counts { input:
+      gene_count_files = step04_star_align.gene_counts,
       sample_names = sample_name,
       sample_conditions = sample_condition
   }
 
-  call deseq2_tasks.run_deseq2 { input:
-      counts_matrix = combine_count_matrices.counts_matrix,
-      sample_metadata = combine_count_matrices.sample_metadata,
+  call deseq2_tasks.run_deseq2 as step07_deseq2 { input:
+      counts_matrix = step06_combine_counts.counts_matrix,
+      sample_metadata = step06_combine_counts.sample_metadata,
       reference_level = reference_level,
       contrast = contrast
   }
 
-  # Step 6b: Compile DESeq2 results with normalized counts and GTF annotations
-  call deseq2_tasks.compile_deseq2_results { input:
-      deseq2_results = run_deseq2.deseq2_results,
-      normalized_counts = run_deseq2.deseq2_normalized_counts,
+  # Step 8: Compile DESeq2 results with normalized counts and GTF annotations
+  call deseq2_tasks.compile_deseq2_results as step08_compile_results { input:
+      deseq2_results = step07_deseq2.deseq2_results,
+      normalized_counts = step07_deseq2.deseq2_normalized_counts,
       gtf_file = normalize_gtf.normalized_gtf
   }
 
-  # Step 7: MultiQC aggregation of all QC reports
-  call multiqc_tasks.run_multiqc { input:
+  # Step 9: MultiQC aggregation of all QC reports
+  call multiqc_tasks.run_multiqc as step09_multiqc { input:
       input_files = flatten([
-        flatten(pretrim_fastqc.html_reports),
-        flatten(pretrim_fastqc.zip_reports),
-        trimgalore_paired.r1_report,
-        trimgalore_paired.r2_report,
-        flatten(posttrim_fastqc.html_reports),
-        flatten(posttrim_fastqc.zip_reports),
-        align_two_pass.log_final,
-        run_rseqc.rseqc_summary
+        flatten(step01_pretrim_fastqc.html_reports),
+        flatten(step01_pretrim_fastqc.zip_reports),
+        step02_trimgalore.r1_report,
+        step02_trimgalore.r2_report,
+        flatten(step03_posttrim_fastqc.html_reports),
+        flatten(step03_posttrim_fastqc.zip_reports),
+        step04_star_align.log_final,
+        step05_rseqc.rseqc_summary
       ]),
       report_title = "RNA-seq Pipeline QC Report"
   }
 
   output {
-    Array[Array[File]] pretrim_fastqc_html = pretrim_fastqc.html_reports
-    Array[Array[File]] pretrim_fastqc_zip = pretrim_fastqc.zip_reports
-    Array[File] trimgalore_r1_trimmed = trimgalore_paired.r1_trimmed
-    Array[File] trimgalore_r2_trimmed = trimgalore_paired.r2_trimmed
-    Array[File] trimgalore_r1_report = trimgalore_paired.r1_report
-    Array[File] trimgalore_r2_report = trimgalore_paired.r2_report
-    Array[Array[File]] posttrim_fastqc_html = posttrim_fastqc.html_reports
-    Array[Array[File]] posttrim_fastqc_zip = posttrim_fastqc.zip_reports
-    Array[File] star_bam = align_two_pass.bam
-    Array[File] star_bai = align_two_pass.bai
-    Array[File] star_gene_counts = align_two_pass.gene_counts
-    Array[File] star_log_final = align_two_pass.log_final
-    Array[File] star_log_progress = align_two_pass.log_progress
-    Array[File] star_log = align_two_pass.log
-    Array[File] star_sj = align_two_pass.sj_out
-    Array[File] rseqc_qc_summary = run_rseqc.rseqc_summary
-    File combined_counts_matrix = combine_count_matrices.counts_matrix
-    File sample_metadata = combine_count_matrices.sample_metadata
-    File deseq2_all_results = run_deseq2.deseq2_results
-    File deseq2_significant_results = run_deseq2.deseq2_significant
-    File deseq2_normalized_counts = run_deseq2.deseq2_normalized_counts
-    File deseq2_pca_plot = run_deseq2.deseq2_pca_plot
-    File deseq2_volcano_plot = run_deseq2.deseq2_volcano_plot
-    File deseq2_heatmap = run_deseq2.deseq2_heatmap
-    File deseq2_compiled_results = compile_deseq2_results.compiled_results
-    File multiqc_report = run_multiqc.html_report
-    File multiqc_data = run_multiqc.data_dir
+    Array[Array[File]] pretrim_fastqc_html = step01_pretrim_fastqc.html_reports
+    Array[Array[File]] pretrim_fastqc_zip = step01_pretrim_fastqc.zip_reports
+    Array[File] trimgalore_r1_trimmed = step02_trimgalore.r1_trimmed
+    Array[File] trimgalore_r2_trimmed = step02_trimgalore.r2_trimmed
+    Array[File] trimgalore_r1_report = step02_trimgalore.r1_report
+    Array[File] trimgalore_r2_report = step02_trimgalore.r2_report
+    Array[Array[File]] posttrim_fastqc_html = step03_posttrim_fastqc.html_reports
+    Array[Array[File]] posttrim_fastqc_zip = step03_posttrim_fastqc.zip_reports
+    Array[File] star_bam = step04_star_align.bam
+    Array[File] star_bai = step04_star_align.bai
+    Array[File] star_gene_counts = step04_star_align.gene_counts
+    Array[File] star_log_final = step04_star_align.log_final
+    Array[File] star_log_progress = step04_star_align.log_progress
+    Array[File] star_log = step04_star_align.log
+    Array[File] star_sj = step04_star_align.sj_out
+    Array[File] rseqc_qc_summary = step05_rseqc.rseqc_summary
+    File combined_counts_matrix = step06_combine_counts.counts_matrix
+    File sample_metadata = step06_combine_counts.sample_metadata
+    File deseq2_all_results = step07_deseq2.deseq2_results
+    File deseq2_significant_results = step07_deseq2.deseq2_significant
+    File deseq2_normalized_counts = step07_deseq2.deseq2_normalized_counts
+    File deseq2_pca_plot = step07_deseq2.deseq2_pca_plot
+    File deseq2_volcano_plot = step07_deseq2.deseq2_volcano_plot
+    File deseq2_heatmap = step07_deseq2.deseq2_heatmap
+    File deseq2_compiled_results = step08_compile_results.compiled_results
+    File multiqc_report = step09_multiqc.html_report
+    File multiqc_data = step09_multiqc.data_dir
   }
 }

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -9,13 +9,6 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as multiqc_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
 
-struct SampleInfo {
-    String name
-    File r1
-    File r2
-    String condition
-}
-
 struct RefGenome {
     String name
     File fasta
@@ -59,7 +52,11 @@ workflow rnaseq {
   }
 
   parameter_meta {
-    samples: "List of sample objects, each containing name, r1/r2 fastq files, and condition information"
+    samples_tsv: "Tab-separated file with columns: name, r1, r2, condition (header row required). Alternative to providing separate arrays."
+    sample_names: "Array of sample names (use with r1_fastqs, r2_fastqs, conditions as alternative to samples_tsv)"
+    r1_fastqs: "Array of R1 FASTQ file paths, one per sample"
+    r2_fastqs: "Array of R2 FASTQ file paths, one per sample"
+    conditions: "Array of condition labels for each sample (e.g., 'control', 'treatment')"
     reference_genome: "Reference genome object containing name, fasta, and gtf files"
     reference_level: "Reference level for DESeq2 contrast (e.g., 'control' when comparing treatment vs. control)"
     contrast: "DESeq2 contrast string in the format 'condition,treatment,control'"
@@ -71,7 +68,13 @@ workflow rnaseq {
   }
 
   input {
-    Array[SampleInfo] samples
+    # Option 1: Provide a TSV file with columns name, r1, r2, condition
+    File? samples_tsv
+    # Option 2: Provide separate arrays directly
+    Array[String]? sample_names
+    Array[File]? r1_fastqs
+    Array[File]? r2_fastqs
+    Array[String]? conditions
     RefGenome reference_genome
     String reference_level = ""
     String contrast = ""
@@ -81,6 +84,15 @@ workflow rnaseq {
     Int star_memory_gb = 64
     Int genome_sa_index_nbases = 14
   }
+
+  # Parse sample information from TSV if provided (skip header row).
+  # TSV format: tab-separated with header row (name, r1, r2, condition).
+  Array[Array[String]] tsv_rows = if defined(samples_tsv) then read_tsv(select_first([samples_tsv])) else []
+  Array[Array[String]] tsv_data = if length(tsv_rows) > 1 then tsv_rows[1:] else []
+
+  # Determine number of samples from whichever input method was used
+  Int n_samples = if defined(sample_names) then length(select_first([sample_names])) else length(tsv_data)
+  Array[Int] sample_indices = range(n_samples)
 
   # Normalize GTF to ensure exon features exist for every transcript.
   # This is critical for bacterial NCBI GTFs which only have CDS rows —
@@ -104,21 +116,23 @@ workflow rnaseq {
       gtf_file = normalize_gtf.normalized_gtf
   }
 
-  scatter (sample in samples) {
-    String sample_name = sample.name
-    String sample_condition = sample.condition
+  scatter (idx in sample_indices) {
+    String sample_name = if defined(sample_names) then select_first([sample_names])[idx] else tsv_data[idx][0]
+    File sample_r1 = if defined(r1_fastqs) then select_first([r1_fastqs])[idx] else tsv_data[idx][1]
+    File sample_r2 = if defined(r2_fastqs) then select_first([r2_fastqs])[idx] else tsv_data[idx][2]
+    String sample_condition = if defined(conditions) then select_first([conditions])[idx] else tsv_data[idx][3]
 
     # Step 1: Pre-trim FastQC
     call fastqc_tasks.run_fastqc as pretrim_fastqc { input:
-        r1_fastq = sample.r1,
-        r2_fastq = sample.r2
+        r1_fastq = sample_r1,
+        r2_fastq = sample_r2
     }
 
     # Step 2: Trim Galore adapter/quality trimming
     call trimgalore_tasks.trimgalore_paired { input:
-        sample_name = sample.name,
-        r1_fastq = sample.r1,
-        r2_fastq = sample.r2,
+        sample_name = sample_name,
+        r1_fastq = sample_r1,
+        r2_fastq = sample_r2,
         quality = trim_quality,
         length = trim_length
     }
@@ -134,14 +148,14 @@ workflow rnaseq {
         star_genome_tar = build_index.star_index_tar,
         r1 = trimgalore_paired.r1_trimmed,
         r2 = trimgalore_paired.r2_trimmed,
-        name = sample.name + "." + reference_genome.name,
+        name = sample_name + "." + reference_genome.name,
         cpu_cores = star_cpu,
         memory_gb = star_memory_gb
     }
 
     # Step 5: RSeQC alignment quality control
     call rseqc_tasks.run_rseqc { input:
-        sample_name = sample.name,
+        sample_name = sample_name,
         bam_file = align_two_pass.bam,
         bam_index = align_two_pass.bai,
         ref_bed = gtf2bed.bed_file

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -85,13 +85,14 @@ workflow rnaseq {
     Int genome_sa_index_nbases = 14
   }
 
-  # Parse sample information from TSV if provided (skip header row).
+  # Parse sample information from TSV if provided.
   # TSV format: tab-separated with header row (name, r1, r2, condition).
+  # Header row is skipped by offsetting indices by +1 in the scatter below.
   Array[Array[String]] tsv_rows = if defined(samples_tsv) then read_tsv(select_first([samples_tsv])) else []
-  Array[Array[String]] tsv_data = if length(tsv_rows) > 1 then tsv_rows[1:] else []
 
   # Determine number of samples from whichever input method was used
-  Int n_samples = if defined(sample_names) then length(select_first([sample_names])) else length(tsv_data)
+  # For TSV: subtract 1 to exclude the header row
+  Int n_samples = if defined(sample_names) then length(select_first([sample_names])) else (length(tsv_rows) - 1)
   Array[Int] sample_indices = range(n_samples)
 
   # Normalize GTF to ensure exon features exist for every transcript.
@@ -117,10 +118,11 @@ workflow rnaseq {
   }
 
   scatter (idx in sample_indices) {
-    String sample_name = if defined(sample_names) then select_first([sample_names])[idx] else tsv_data[idx][0]
-    File sample_r1 = if defined(r1_fastqs) then select_first([r1_fastqs])[idx] else tsv_data[idx][1]
-    File sample_r2 = if defined(r2_fastqs) then select_first([r2_fastqs])[idx] else tsv_data[idx][2]
-    String sample_condition = if defined(conditions) then select_first([conditions])[idx] else tsv_data[idx][3]
+    # Resolve sample fields: +1 offset on tsv_rows skips the header row
+    String sample_name = if defined(sample_names) then select_first([sample_names])[idx] else tsv_rows[idx + 1][0]
+    File sample_r1 = if defined(r1_fastqs) then select_first([r1_fastqs])[idx] else tsv_rows[idx + 1][1]
+    File sample_r2 = if defined(r2_fastqs) then select_first([r2_fastqs])[idx] else tsv_rows[idx + 1][2]
+    String sample_condition = if defined(conditions) then select_first([conditions])[idx] else tsv_rows[idx + 1][3]
 
     # Step 1: Pre-trim FastQC
     call fastqc_tasks.run_fastqc as pretrim_fastqc { input:

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -46,6 +46,9 @@ workflow rnaseq {
         deseq2_pca_plot: "Principal Component Analysis plot of samples based on expression patterns",
         deseq2_volcano_plot: "Volcano plot showing log fold change vs. statistical significance",
         deseq2_heatmap: "Heatmap of differentially expressed genes across samples",
+        deseq2_ma_plot: "MA plot showing log fold change vs. mean expression",
+        deseq2_ma_plot_shrunk: "MA plot with shrunken log fold changes (empty if shrinkage not applied)",
+        deseq2_results_shrunk: "DESeq2 results with shrunken log fold changes (empty if shrinkage not applied)",
         deseq2_compiled_results: "Combined CSV with DESeq2 statistics, normalized counts, and gene annotations",
         multiqc_report: "MultiQC interactive HTML report aggregating all QC metrics",
         multiqc_data: "MultiQC data directory with parsed metrics from all tools",
@@ -67,6 +70,9 @@ workflow rnaseq {
     star_cpu: "Number of CPU cores for STAR alignment tasks"
     star_memory_gb: "Memory allocation in GB for STAR alignment tasks"
     genome_sa_index_nbases: "Length of the SA pre-indexing string for STAR (typically 10-15, scales with genome size)"
+    min_counts: "Minimum number of counts a gene must have to pass DESeq2 pre-filtering"
+    min_samples: "Minimum number of samples that must meet min_counts threshold (0 = use total counts instead)"
+    shrinkage_method: "LFC shrinkage method for DESeq2: apeglm, ashr, or normal (empty = no shrinkage)"
     organize_results: "Whether to reorganize all outputs into a clean directory structure tarball (duplicates data, increases storage)"
     include_bams: "Whether to include BAM/BAI files in the organized results tarball (can significantly increase output size)"
     include_trimmed_fastqs: "Whether to include trimmed FASTQ files in the organized results tarball (can significantly increase output size)"
@@ -88,6 +94,9 @@ workflow rnaseq {
     Int star_cpu = 8
     Int star_memory_gb = 64
     Int genome_sa_index_nbases = 14
+    Int min_counts = 10
+    Int min_samples = 0
+    String shrinkage_method = ""
     Boolean organize_results = false
     Boolean include_bams = false
     Boolean include_trimmed_fastqs = false
@@ -184,7 +193,10 @@ workflow rnaseq {
       counts_matrix = step06_combine_counts.counts_matrix,
       sample_metadata = step06_combine_counts.sample_metadata,
       reference_level = reference_level,
-      contrast = contrast
+      contrast = contrast,
+      min_counts = min_counts,
+      min_samples = min_samples,
+      shrinkage_method = shrinkage_method
   }
 
   # Step 8: Compile DESeq2 results with normalized counts and GTF annotations
@@ -267,6 +279,9 @@ workflow rnaseq {
     File deseq2_pca_plot = step07_deseq2.deseq2_pca_plot
     File deseq2_volcano_plot = step07_deseq2.deseq2_volcano_plot
     File deseq2_heatmap = step07_deseq2.deseq2_heatmap
+    File deseq2_ma_plot = step07_deseq2.deseq2_ma_plot
+    File deseq2_ma_plot_shrunk = step07_deseq2.deseq2_ma_plot_shrunk
+    File deseq2_results_shrunk = step07_deseq2.deseq2_results_shrunk
     File deseq2_compiled_results = step08_compile_results.compiled_results
     File multiqc_report = step09_multiqc.html_report
     File multiqc_data = step09_multiqc.data_dir
@@ -286,9 +301,35 @@ task organize_outputs {
 
   parameter_meta {
     sample_names: "Array of sample names used to create per-sample subdirectories"
+    pretrim_fastqc_html: "Pre-trim FastQC HTML reports to organize"
+    pretrim_fastqc_zip: "Pre-trim FastQC ZIP archives to organize"
+    trimgalore_r1_trimmed: "Trimmed R1 FASTQ files to organize"
+    trimgalore_r2_trimmed: "Trimmed R2 FASTQ files to organize"
+    trimgalore_r1_report: "Trim Galore R1 trimming reports to organize"
+    trimgalore_r2_report: "Trim Galore R2 trimming reports to organize"
+    posttrim_fastqc_html: "Post-trim FastQC HTML reports to organize"
+    posttrim_fastqc_zip: "Post-trim FastQC ZIP archives to organize"
+    star_bam: "STAR alignment BAM files to organize"
+    star_bai: "STAR alignment BAM index files to organize"
+    star_gene_counts: "STAR gene count files to organize"
+    star_log_final: "STAR final log files to organize"
+    rseqc_summary: "RSeQC quality control summary files to organize"
+    counts_matrix: "Combined gene count matrix to organize"
+    sample_metadata: "Sample metadata file to organize"
+    deseq2_results: "DESeq2 all-genes results to organize"
+    deseq2_significant: "DESeq2 significant results to organize"
+    deseq2_normalized_counts: "DESeq2 normalized counts to organize"
+    deseq2_pca_plot: "DESeq2 PCA plot to organize"
+    deseq2_volcano_plot: "DESeq2 volcano plot to organize"
+    deseq2_heatmap: "DESeq2 heatmap to organize"
+    deseq2_compiled_results: "DESeq2 compiled results CSV to organize"
+    multiqc_report: "MultiQC HTML report to organize"
+    multiqc_data: "MultiQC data directory to organize"
     include_bams: "Whether to include BAM/BAI files in the output tarball (can be very large)"
     include_trimmed_fastqs: "Whether to include trimmed FASTQ files in the output tarball (can be very large)"
     output_prefix: "Prefix for the output tarball filename"
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
   }
 
   input {


### PR DESCRIPTION
## Type of Change

- Enhancement to existing pipeline (ww-rnaseq)
- Enhancement to existing module (ww-deseq2)
- Documentation update

## Description

Incorporates collaborator feedback on the ww-rnaseq pipeline across several areas:

### ww-rnaseq pipeline
- **TSV sample inputs**: Users can now provide sample information as a tab-separated file (`samples_tsv`) instead of complex JSON struct arrays. Separate arrays (`sample_names`, `r1_fastqs`, `r2_fastqs`, `conditions`) are also supported as an alternative. The `SampleInfo` struct has been removed.
- **Numbered step aliases**: All task calls use numbered aliases (e.g., `step01_pretrim_fastqc`, `step02_trimgalore`) so output directories are clearly ordered by pipeline stage.
- **Optional output reorganization**: A new pipeline-local `organize_outputs` task packages all results into a clean `.tar.gz` with numbered directories and sample-named subdirectories. Controlled by `organize_results` (default: false), with `include_bams` and `include_trimmed_fastqs` flags to manage tarball size.
- **Additional DESeq2 options**: New pipeline inputs for `min_counts`, `min_samples`, and `shrinkage_method` were added to the DESeq2 step.
- Added example `samples.tsv` template file.

### ww-deseq2 module
- **New `compile_deseq2_results` task**: Merges DESeq2 results with normalized counts and GTF gene annotations (gene_name, gene_biotype, product) into a single comprehensive CSV.
- **MA plots**: `deseq2_analysis.R` now generates an MA plot (log2FC vs. mean expression) for every run.
- **Optional LFC shrinkage**: New `shrinkage_method` input supports `apeglm`, `ashr`, or `normal` methods via `lfcShrink()`. When applied, produces a shrunken MA plot and shrunken results CSV.
- **Configurable gene filtering**: New `min_counts` and `min_samples` inputs replace the hardcoded `rowSums >= 10` filter with a per-sample threshold (e.g., "keep genes with ≥10 counts in ≥3 samples").
- **Scripts extracted from Docker images**: `deseq2_analysis.R`, `combine_star_counts.py`, `compile_deseq2_results.py`, and `generate_pasilla_counts.R` now live in the module directory and are fetched via `curl` at runtime, replacing baked-in scripts from custom Docker images.
- **Docker image changes**: `combine_count_matrices` and `compile_deseq2_results` now use `python:3.12` (with `pandas==2.2.3` installed at runtime) instead of `getwilds/combine-counts:0.1.0`. `run_deseq2` remains on `getwilds/deseq2:1.40.2` but the baked-in R script should be removed from the image.

### Other changes
- **ww-testdata**: `generate_pasilla_counts` task now fetches `generate_pasilla_counts.R` from the ww-deseq2 module directory via `curl` instead of using a baked-in script.
- **CONTRIBUTING.md**: Relaxed pipeline task guidance to allow pipeline-local tasks when truly pipeline-specific.

## Related Issue

- Continues to address #274

## Testing

**How did you test these changes?**
- Ran `make lint` (sprocket + WOMtool) on ww-rnaseq and ww-deseq2
- Ran ww-deseq2 and ww-rnaseq testruns via GitHub Actions CI/CD (Sprocket)
- Tested TSV input method on HPC with real PAO1 RNA-seq data

**What workflow engine did you use?**
Sprocket (CI/CD), with HPC testing planned

**Did the tests pass?**
CI/CD tests passing; HPC validation in progress

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs-preview` to check documentation rendering (if applicable)

## Additional Context

- All import URLs and `curl` URLs pointing to `rnaseq-feedback` branch need to be switched back to `main` before merging.
- The `getwilds/deseq2:1.40.2` Docker image should be updated to remove the baked-in `deseq2_analysis.R` script to avoid confusion with the `curl`-fetched version.
- The `organize_outputs` task duplicates output files into the tarball. With default settings (no BAMs, no trimmed FASTQs), the overhead is ~200MB for 20 samples. With everything included, it scales to ~4-10 GB per sample.