### PR TITLE
Fix import URL's after HPC test run updates

### DIFF
--- a/modules/ww-esmfold/testrun.wdl
+++ b/modules/ww-esmfold/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 # Tests ESMFold structure prediction with a tiny protein sequence on CPU.

--- a/modules/ww-gatk/testrun.wdl
+++ b/modules/ww-gatk/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-gatk/ww-gatk.wdl" as ww_gatk
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as ww_gatk
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as ww_bwa
 
 struct GatkSample {

--- a/modules/ww-jcast/testrun.wdl
+++ b/modules/ww-jcast/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-jcast/ww-jcast.wdl" as ww_jcast
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-jcast/ww-jcast.wdl" as ww_jcast
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow jcast_example {

--- a/modules/ww-samtools/testrun.wdl
+++ b/modules/ww-samtools/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
 
 workflow samtools_example {
   # Download test data

--- a/modules/ww-starling/testrun.wdl
+++ b/modules/ww-starling/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module under test and testdata module using relative paths for local development
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-starling/ww-starling.wdl" as ww_starling
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-starling/ww-starling.wdl" as ww_starling
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-testdata/testrun.wdl
+++ b/modules/ww-testdata/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow testdata_example {
   # Pull down reference genome and index files for chr1

--- a/modules/ww-tritonnp/README.md
+++ b/modules/ww-tritonnp/README.md
@@ -15,7 +15,7 @@ This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds
 
 - **Tasks**: `triton_main`, `combine_fms`
 - **Test workflow**: `testrun.wdl` (demonstration workflow executing all tasks)
-- **Container**: `python:bullseye`
+- **Container**: `getwilds/python-utils:0.1.0`
 
 ## Tasks
 

--- a/modules/ww-tritonnp/testrun.wdl
+++ b/modules/ww-tritonnp/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-tritonnp/ww-tritonnp.wdl" as ww_tritonnp
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-tritonnp/ww-tritonnp.wdl" as ww_tritonnp
 
 struct TritonSample {
     String name

--- a/modules/ww-varscan/testrun.wdl
+++ b/modules/ww-varscan/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-varscan/ww-varscan.wdl" as ww_varscan
 
 workflow varscan_example {

--- a/pipelines/ww-bwa-gatk/testrun.wdl
+++ b/pipelines/ww-bwa-gatk/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl" as bwa_gatk_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl" as bwa_gatk_workflow
 
 struct BwaSample {
     String name

--- a/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl
+++ b/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as bwa_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
 
 struct BwaSample {
     String name

--- a/pipelines/ww-leukemia/testrun.wdl
+++ b/pipelines/ww-leukemia/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
 
 workflow leukemia_test {
   # Download test reference data

--- a/pipelines/ww-leukemia/ww-leukemia.wdl
+++ b/pipelines/ww-leukemia/ww-leukemia.wdl
@@ -45,10 +45,10 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bcftools/ww-bcftools.wdl" as bcftools_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as bwa_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-delly/ww-delly.wdl" as delly_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-ichorcna/ww-ichorcna.wdl" as ichorcna_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-manta/ww-manta.wdl" as manta_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-samtools/ww-samtools.wdl" as samtools_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-samtools/ww-samtools.wdl" as samtools_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-smoove/ww-smoove.wdl" as smoove_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-consensus/ww-consensus.wdl" as consensus_tasks
 

--- a/pipelines/ww-saturation/testrun.wdl
+++ b/pipelines/ww-saturation/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-saturation/ww-saturation.wdl" as saturation_workflow
 
 struct SaturationSample {

--- a/pipelines/ww-splicing-proteomics/testrun.wdl
+++ b/pipelines/ww-splicing-proteomics/testrun.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl" as splicing_proteomics_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl" as splicing_proteomics_workflow
 
 struct SampleInfo {
     String name

--- a/pipelines/ww-splicing-proteomics/testrun.wdl
+++ b/pipelines/ww-splicing-proteomics/testrun.wdl
@@ -24,9 +24,10 @@ workflow splicing_proteomics_example {
 
   # Download RNA-seq data from SRA (airway study - dexamethasone treatment)
   # Using 1 treated + 1 untreated sample for a CI smoke test (not biologically meaningful)
-  # Using 100K reads per sample to keep runtime under control on free GitHub runners
-  call ww_sra.fastqdump as untreated1 { input: sra_id = "SRR1039509", ncpu = 2, max_reads = 100000 }
-  call ww_sra.fastqdump as treated1 { input: sra_id = "SRR1039508", ncpu = 2, max_reads = 100000 }
+  # Using 250K reads per sample to keep runtime under control on free GitHub runners
+  # while retaining enough chr15 coverage for rMATS to detect splice events
+  call ww_sra.fastqdump as untreated1 { input: sra_id = "SRR1039509", ncpu = 2, max_reads = 250000 }
+  call ww_sra.fastqdump as treated1 { input: sra_id = "SRR1039508", ncpu = 2, max_reads = 250000 }
 
   # Construct SampleInfo structs from SRA downloads
   # group1 = untreated (control), group2 = treated (dexamethasone)

--- a/pipelines/ww-splicing-proteomics/testrun.wdl
+++ b/pipelines/ww-splicing-proteomics/testrun.wdl
@@ -23,12 +23,10 @@ workflow splicing_proteomics_example {
   call ww_testdata.download_jcast_test_data { }
 
   # Download RNA-seq data from SRA (airway study - dexamethasone treatment)
-  # Using 2 treated + 2 untreated samples for differential splicing analysis
-  # Using 500K reads per sample to have sufficient coverage for splicing detection
-  call ww_sra.fastqdump as untreated1 { input: sra_id = "SRR1039509", ncpu = 2, max_reads = 500000 }
-  call ww_sra.fastqdump as untreated2 { input: sra_id = "SRR1039513", ncpu = 2, max_reads = 500000 }
-  call ww_sra.fastqdump as treated1 { input: sra_id = "SRR1039508", ncpu = 2, max_reads = 500000 }
-  call ww_sra.fastqdump as treated2 { input: sra_id = "SRR1039512", ncpu = 2, max_reads = 500000 }
+  # Using 1 treated + 1 untreated sample for a CI smoke test (not biologically meaningful)
+  # Using 100K reads per sample to keep runtime under control on free GitHub runners
+  call ww_sra.fastqdump as untreated1 { input: sra_id = "SRR1039509", ncpu = 2, max_reads = 100000 }
+  call ww_sra.fastqdump as treated1 { input: sra_id = "SRR1039508", ncpu = 2, max_reads = 100000 }
 
   # Construct SampleInfo structs from SRA downloads
   # group1 = untreated (control), group2 = treated (dexamethasone)
@@ -40,23 +38,9 @@ workflow splicing_proteomics_example {
   }
 
   SampleInfo sample2 = {
-    "name": "untreated_2",
-    "r1": untreated2.r1_end,
-    "r2": untreated2.r2_end,
-    "group": "group1"
-  }
-
-  SampleInfo sample3 = {
     "name": "treated_1",
     "r1": treated1.r1_end,
     "r2": treated1.r2_end,
-    "group": "group2"
-  }
-
-  SampleInfo sample4 = {
-    "name": "treated_2",
-    "r1": treated2.r1_end,
-    "r2": treated2.r2_end,
     "group": "group2"
   }
 
@@ -70,7 +54,7 @@ workflow splicing_proteomics_example {
   # Run splicing proteomics pipeline
   call splicing_proteomics_workflow.splicing_proteomics {
     input:
-      samples = [sample1, sample2, sample3, sample4],
+      samples = [sample1, sample2],
       reference_genome = reference,
       read_length = 63,  # Airway dataset read length
       read_type = "paired",

--- a/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl
+++ b/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl
@@ -8,7 +8,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rmats-turbo/ww-rmats-turbo.wdl" as rmats_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-jcast/ww-jcast.wdl" as jcast_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-jcast/ww-jcast.wdl" as jcast_tasks
 
 struct SampleInfo {
     String name

--- a/pipelines/ww-starling-batch/testrun.wdl
+++ b/pipelines/ww-starling-batch/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/pipelines/ww-starling-batch/ww-starling-batch.wdl" as starling_batch_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-starling-batch/ww-starling-batch.wdl" as starling_batch_workflow
 
 workflow starling_batch_example {
   # Create a test FASTA with multiple short IDP sequences

--- a/pipelines/ww-starling-batch/ww-starling-batch.wdl
+++ b/pipelines/ww-starling-batch/ww-starling-batch.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-hpc-testrun/modules/ww-starling/ww-starling.wdl" as starling_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-starling/ww-starling.wdl" as starling_tasks
 
 workflow starling_batch {
   meta {


### PR DESCRIPTION
## Type of Change

- Bug fix
- Documentation update

## Description

This PR consolidates a few small post-merge follow-ups from the recent HPC test run work:

1. **Import URL cleanup** — Several module/pipeline files still pointed at the now-merged `add-hpc-testrun` branch. Switched all leftover imports back to `main` so testruns and pipeline imports resolve correctly: [ww-esmfold](modules/ww-esmfold/testrun.wdl), [ww-gatk](modules/ww-gatk/testrun.wdl), [ww-jcast](modules/ww-jcast/testrun.wdl), [ww-samtools](modules/ww-samtools/testrun.wdl), [ww-starling](modules/ww-starling/testrun.wdl), [ww-testdata](modules/ww-testdata/testrun.wdl), [ww-tritonnp](modules/ww-tritonnp/testrun.wdl), [ww-varscan](modules/ww-varscan/testrun.wdl), [ww-bwa-gatk](pipelines/ww-bwa-gatk/), [ww-leukemia](pipelines/ww-leukemia/), [ww-saturation](pipelines/ww-saturation/testrun.wdl), [ww-splicing-proteomics](pipelines/ww-splicing-proteomics/), and [ww-starling-batch](pipelines/ww-starling-batch/).
2. **ww-tritonnp README** — Updated the documented container from `python:bullseye` to `getwilds/python-utils:0.1.0` to match the WDL.
3. **ww-splicing-proteomics testrun scale-down** — The testrun was running for an extended period on free GitHub runners. Reduced from 4 samples × 500K reads to 2 samples × 250K reads (one per group, the rMATS minimum).

## Testing

**How did you test these changes?**
- GitHub Actions CI on this branch

**What workflow engine did you use?**
Cromwell, miniWDL, and Sprocket via the CI matrix

**Did the tests pass?**
Pending CI confirmation on the 250K-read configuration. URL-cleanup and README changes are documentation/string-only and have no execution impact.

## Documentation

- [x] I updated the README (if applicable) — `ww-tritonnp` container reference
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~ — no parameter changes
- [x] ~~I ran `make docs` to check documentation rendering (if applicable)~~