### PR TITLE
Removing dummy workflows used for Dockstore

### DIFF
--- a/modules/ww-aws-sso/ww-aws-sso.wdl
+++ b/modules/ww-aws-sso/ww-aws-sso.wdl
@@ -10,12 +10,6 @@
 
 version 1.0
 
-workflow ww_aws_sso {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task s3_download_file {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-bcftools/ww-bcftools.wdl
+++ b/modules/ww-bcftools/ww-bcftools.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_bcftools {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task mpileup_call {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-bowtie/ww-bowtie.wdl
+++ b/modules/ww-bowtie/ww-bowtie.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_bowtie {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task bowtie_build {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-bowtie2/ww-bowtie2.wdl
+++ b/modules/ww-bowtie2/ww-bowtie2.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_bowtie2 {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task bowtie2_build {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-cnvkit/ww-cnvkit.wdl
+++ b/modules/ww-cnvkit/ww-cnvkit.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_cnvkit {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task create_reference {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-colabfold/ww-colabfold.wdl
+++ b/modules/ww-colabfold/ww-colabfold.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_colabfold {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 #### TASK DEFINITIONS ####
 
 task download_weights {

--- a/modules/ww-deeptools/ww-deeptools.wdl
+++ b/modules/ww-deeptools/ww-deeptools.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_deeptools {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 #### TASK DEFINITIONS ####
 
 task bam_coverage {

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_deseq2 {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task combine_count_matrices {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-diamond/ww-diamond.wdl
+++ b/modules/ww-diamond/ww-diamond.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_diamond {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task make_database {
   meta {
     author: "Emma Bishop"

--- a/modules/ww-ena/ww-ena.wdl
+++ b/modules/ww-ena/ww-ena.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_ena {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task download_files {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-fastp/ww-fastp.wdl
+++ b/modules/ww-fastp/ww-fastp.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_fastp {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 #### TASK DEFINITIONS ####
 
 task fastp_paired {

--- a/modules/ww-gatk/ww-gatk.wdl
+++ b/modules/ww-gatk/ww-gatk.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_gatk {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task create_sequence_dictionary {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-gdc/ww-gdc.wdl
+++ b/modules/ww-gdc/ww-gdc.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_gdc {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task download_by_manifest {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-glimpse2/ww-glimpse2.wdl
+++ b/modules/ww-glimpse2/ww-glimpse2.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_glimpse2 {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task glimpse2_chunk {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-ichorcna/ww-ichorcna.wdl
+++ b/modules/ww-ichorcna/ww-ichorcna.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_ichorcna {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task readcounter_wig {
   meta {
     author: "Emma Bishop"

--- a/modules/ww-rmats-turbo/ww-rmats-turbo.wdl
+++ b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl
@@ -7,12 +7,6 @@
 
 version 1.0
 
-workflow ww_rmats_turbo {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task rmats {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-salmon/ww-salmon.wdl
+++ b/modules/ww-salmon/ww-salmon.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_salmon {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task build_index {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-samtools/ww-samtools.wdl
+++ b/modules/ww-samtools/ww-samtools.wdl
@@ -3,12 +3,6 @@
 
 version 1.0
 
-workflow ww_samtools {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task crams_to_fastq {
   meta {
     author: "Emma Bishop"

--- a/modules/ww-sourmash/ww-sourmash.wdl
+++ b/modules/ww-sourmash/ww-sourmash.wdl
@@ -3,12 +3,6 @@
 
 version 1.0
 
-workflow ww_sourmash {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task sketch {
   meta {
     author: "Emma Bishop"

--- a/modules/ww-star/ww-star.wdl
+++ b/modules/ww-star/ww-star.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_star {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task build_index {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-starling/ww-starling.wdl
+++ b/modules/ww-starling/ww-starling.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_starling {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 #### TASK DEFINITIONS ####
 
 task generate_ensemble {

--- a/modules/ww-strelka/ww-strelka.wdl
+++ b/modules/ww-strelka/ww-strelka.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_strelka {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task strelka_germline {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -4,12 +4,6 @@
 
 version 1.0
 
-workflow ww_testdata {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task download_ref_data {
   meta {
     author: "Taylor Firman"

--- a/modules/ww-trimgalore/ww-trimgalore.wdl
+++ b/modules/ww-trimgalore/ww-trimgalore.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_trimgalore {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 #### TASK DEFINITIONS ####
 
 task trimgalore_paired {

--- a/modules/ww-tritonnp/ww-tritonnp.wdl
+++ b/modules/ww-tritonnp/ww-tritonnp.wdl
@@ -3,12 +3,6 @@
 
 version 1.0
 
-workflow ww_tritonnp {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task triton_main {
   meta {
     author: "Chris Lo"

--- a/modules/ww-varscan/ww-varscan.wdl
+++ b/modules/ww-varscan/ww-varscan.wdl
@@ -5,12 +5,6 @@
 
 version 1.0
 
-workflow ww_varscan {
-  meta {
-    description: "Dummy workflow for Dockstore tool registration"
-  }
-}
-
 task somatic {
   meta {
     author: "Emma Bishop"


### PR DESCRIPTION
## Type of Change

- Other: cleanup of temporary Dockstore tool registration workaround

## Description

Removes the dummy `workflow` blocks that were temporarily added to 26 module WDLs to allow Dockstore tool registration. All 46 modules have now been successfully uploaded to Dockstore as tools, so this scaffolding can come out. Mirrors the cleanup previously done for `ww-bwa` in PR #330.

## Testing

**How did you test these changes?**
Pure deletion of parse-only scaffolding — no functional behavior changes. CI lint + multi-executor test runs cover correctness.

**What workflow engine did you use?**
CI (Cromwell, miniWDL, Sprocket).

**Did the tests pass?**
Pending CI.

## Documentation

- [x] ~~I updated the README (if applicable)~~
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~

## Additional Context

The diff is exactly symmetric with the previous PR's additions: 156 deletions across the same 26 files.