### PR TITLE
Add Zenodo DOI citation and register missing modules in Dockstore

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -165,6 +165,22 @@ tools:
       branches:
         - main
 
+  - name: ww-clair3
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-clair3/ww-clair3.wdl
+    readMePath: /modules/ww-clair3/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for germline variant calling using Clair3 deep learning models
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-cnvkit
     subclass: WDL
     primaryDescriptorPath: /modules/ww-cnvkit/ww-cnvkit.wdl
@@ -309,6 +325,22 @@ tools:
       branches:
         - main
 
+  - name: ww-esmfold
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-esmfold/ww-esmfold.wdl
+    readMePath: /modules/ww-esmfold/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for protein 3D structure prediction from amino acid sequences using ESMFold
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-fastp
     subclass: WDL
     primaryDescriptorPath: /modules/ww-fastp/ww-fastp.wdl
@@ -373,6 +405,22 @@ tools:
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for downloading files from the Genomic Data Commons
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
+  - name: ww-gffread
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-gffread/ww-gffread.wdl
+    readMePath: /modules/ww-gffread/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for GFF/GTF annotation file conversion and normalization using gffread
     enableAutoDois: true
     filters:
       branches:
@@ -687,6 +735,31 @@ tools:
       branches:
         - main
 
+  - name: ww-testdata
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-testdata/ww-testdata.wdl
+    readMePath: /modules/ww-testdata/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+      - name: Chris Lo
+        email: clo2@fredhutch.org
+        role: Data Science Trainer
+        affiliation: Fred Hutch Cancer Center
+    topic: WDL module for downloading and provisioning test data used across WILDS WDL module and pipeline test runs
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-trimgalore
     subclass: WDL
     primaryDescriptorPath: /modules/ww-trimgalore/ww-trimgalore.wdl
@@ -718,31 +791,6 @@ tools:
       branches:
         - main
 
-  - name: ww-testdata
-    subclass: WDL
-    primaryDescriptorPath: /modules/ww-testdata/ww-testdata.wdl
-    readMePath: /modules/ww-testdata/README.md
-    authors:
-      - name: Taylor Firman
-        email: tfirman@fredhutch.org
-        role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
-        orcid: 0009-0002-2052-1084
-      - name: Emma Bishop
-        email: ebishop@fredhutch.org
-        role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
-        orcid: 0000-0003-4484-3336
-      - name: Chris Lo
-        email: clo2@fredhutch.org
-        role: Data Science Trainer
-        affiliation: Fred Hutch Cancer Center
-    topic: WDL module for downloading and provisioning test data used across WILDS WDL module and pipeline test runs
-    enableAutoDois: true
-    filters:
-      branches:
-        - main
-
   - name: ww-varscan
     subclass: WDL
     primaryDescriptorPath: /modules/ww-varscan/ww-varscan.wdl
@@ -754,6 +802,22 @@ tools:
         affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for somatic variant calling using VarScan
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
+  - name: ww-viennarna
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-viennarna/ww-viennarna.wdl
+    readMePath: /modules/ww-viennarna/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for RNA secondary structure prediction using the ViennaRNA package
     enableAutoDois: true
     filters:
       branches:
@@ -934,6 +998,24 @@ workflows:
       branches:
         - main
 
+  - name: ww-splicing-proteomics
+    subclass: WDL
+    primaryDescriptorPath: /pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl
+    readMePath: /pipelines/ww-splicing-proteomics/README.md
+    testParameterFiles:
+      - /pipelines/ww-splicing-proteomics/inputs.json
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL pipeline for alternative splicing proteomics with STAR alignment, rMATS splicing, and JCAST translation
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-sra-salmon
     subclass: WDL
     primaryDescriptorPath: /pipelines/ww-sra-salmon/ww-sra-salmon.wdl
@@ -995,24 +1077,6 @@ workflows:
       branches:
         - main
 
-  - name: ww-starling-batch
-    subclass: WDL
-    primaryDescriptorPath: /pipelines/ww-starling-batch/ww-starling-batch.wdl
-    readMePath: /pipelines/ww-starling-batch/README.md
-    testParameterFiles:
-      - /pipelines/ww-starling-batch/inputs.json
-    authors:
-      - name: Taylor Firman
-        email: tfirman@fredhutch.org
-        role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
-        orcid: 0009-0002-2052-1084
-    topic: Batch ensemble generation pipeline splitting a protein FASTA into chunks for parallel STARLING processing
-    enableAutoDois: true
-    filters:
-      branches:
-        - main
-
   - name: ww-star-deseq2
     subclass: WDL
     primaryDescriptorPath: /pipelines/ww-star-deseq2/ww-star-deseq2.wdl
@@ -1041,21 +1105,20 @@ workflows:
       branches:
         - main
 
-  - name: ww-splicing-proteomics
+  - name: ww-starling-batch
     subclass: WDL
-    primaryDescriptorPath: /pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl
-    readMePath: /pipelines/ww-splicing-proteomics/README.md
+    primaryDescriptorPath: /pipelines/ww-starling-batch/ww-starling-batch.wdl
+    readMePath: /pipelines/ww-starling-batch/README.md
     testParameterFiles:
-      - /pipelines/ww-splicing-proteomics/inputs.json
+      - /pipelines/ww-starling-batch/inputs.json
     authors:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
-    topic: WDL pipeline for alternative splicing proteomics with STAR alignment, rMATS splicing, and JCAST translation
+    topic: Batch ensemble generation pipeline splitting a protein FASTA into chunks for parallel STARLING processing
     enableAutoDois: true
     filters:
       branches:
         - main
-

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,13 @@ date-released: "2026-03-31"
 license: MIT
 repository-code: "https://github.com/getwilds/wilds-wdl-library"
 url: "https://getwilds.org/wilds-wdl-library/"
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.19339693
+    description: "Concept DOI for all versions of the WILDS WDL Library"
+  - type: doi
+    value: 10.5281/zenodo.19339694
+    description: "DOI for version 0.2.0"
 contact:
   - email: wilds@fredhutch.org
     name: "Fred Hutch OCDO WILDS"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Project Status: Stable – Useable, full support, open to feedback, stable API.](https://getwilds.org/badges/badges/stable.svg)](https://getwilds.org/badges/#stable)
 [![WDL Executors](https://img.shields.io/badge/WDL-Cromwell%20%7C%20miniWDL%20%7C%20Sprocket-blue.svg)](https://github.com/getwilds/wilds-wdl-library)
 [![GitHub Release](https://img.shields.io/github/v/release/getwilds/wilds-wdl-library)](https://github.com/getwilds/wilds-wdl-library/releases)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19339693.svg)](https://doi.org/10.5281/zenodo.19339693)<br>
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19339693-blue)](https://doi.org/10.5281/zenodo.19339693)<br>
 [![Module Tests](https://github.com/getwilds/wilds-wdl-library/actions/workflows/modules-testrun.yml/badge.svg)](https://github.com/getwilds/wilds-wdl-library/actions/workflows/modules-testrun.yml)
 [![Pipeline Tests](https://github.com/getwilds/wilds-wdl-library/actions/workflows/pipelines-testrun.yml/badge.svg)](https://github.com/getwilds/wilds-wdl-library/actions/workflows/pipelines-testrun.yml)
 [![Linting](https://github.com/getwilds/wilds-wdl-library/actions/workflows/linting.yml/badge.svg)](https://github.com/getwilds/wilds-wdl-library/actions/workflows/linting.yml)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Project Status: Stable – Useable, full support, open to feedback, stable API.](https://getwilds.org/badges/badges/stable.svg)](https://getwilds.org/badges/#stable)
 [![WDL Executors](https://img.shields.io/badge/WDL-Cromwell%20%7C%20miniWDL%20%7C%20Sprocket-blue.svg)](https://github.com/getwilds/wilds-wdl-library)
-[![WDL](https://img.shields.io/badge/WDL-1.0-orange.svg)](https://openwdl.org/)
-[![GitHub Release](https://img.shields.io/github/v/release/getwilds/wilds-wdl-library)](https://github.com/getwilds/wilds-wdl-library/releases)<br>
+[![GitHub Release](https://img.shields.io/github/v/release/getwilds/wilds-wdl-library)](https://github.com/getwilds/wilds-wdl-library/releases)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19339693.svg)](https://doi.org/10.5281/zenodo.19339693)<br>
 [![Module Tests](https://github.com/getwilds/wilds-wdl-library/actions/workflows/modules-testrun.yml/badge.svg)](https://github.com/getwilds/wilds-wdl-library/actions/workflows/modules-testrun.yml)
 [![Pipeline Tests](https://github.com/getwilds/wilds-wdl-library/actions/workflows/pipelines-testrun.yml/badge.svg)](https://github.com/getwilds/wilds-wdl-library/actions/workflows/pipelines-testrun.yml)
 [![Linting](https://github.com/getwilds/wilds-wdl-library/actions/workflows/linting.yml/badge.svg)](https://github.com/getwilds/wilds-wdl-library/actions/workflows/linting.yml)
@@ -172,6 +172,27 @@ See our [Contributing Guidelines](.github/CONTRIBUTING.md) for detailed informat
 - **General Questions**: Contact the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org
 - **Documentation**: [Contributing Guidelines](.github/CONTRIBUTING.md)
 - **Fred Hutch Users**: [Scientific Computing Wiki](https://sciwiki.fredhutch.org/)
+
+## Citation
+
+If you use the WILDS WDL Library in your research, please cite it. The DOI below always resolves to the latest release; see the [Zenodo record](https://doi.org/10.5281/zenodo.19339693) for version-specific DOIs.
+
+> Firman, T., Bishop, E., et al. (2026). WILDS WDL Library [Computer software]. GitHub. https://doi.org/10.5281/zenodo.19339693
+
+BibTeX:
+
+```bibtex
+@software{wilds_wdl_library,
+  author    = {Firman, Taylor and Bishop, Emma and others},
+  title     = {WILDS WDL Library},
+  year      = {2026},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.19339693},
+  url       = {https://doi.org/10.5281/zenodo.19339693}
+}
+```
+
+A machine-readable citation is also available in [CITATION.cff](CITATION.cff), which GitHub uses to power the "Cite this repository" button in the sidebar.
 
 ## Dockstore
 

--- a/docs-README.md
+++ b/docs-README.md
@@ -12,7 +12,7 @@
 [![Project Status: Stable – Useable, full support, open to feedback, stable API.](https://getwilds.org/badges/badges/stable.svg)](https://getwilds.org/badges/#stable)
 [![WDL Executors](https://img.shields.io/badge/WDL-Cromwell%20%7C%20miniWDL%20%7C%20Sprocket-blue.svg)](https://github.com/getwilds/wilds-wdl-library)
 [![GitHub Release](https://img.shields.io/github/v/release/getwilds/wilds-wdl-library)](https://github.com/getwilds/wilds-wdl-library/releases)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19339693.svg)](https://doi.org/10.5281/zenodo.19339693)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19339693-blue)](https://doi.org/10.5281/zenodo.19339693)
 
 ---
 

--- a/docs-README.md
+++ b/docs-README.md
@@ -11,8 +11,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Project Status: Stable – Useable, full support, open to feedback, stable API.](https://getwilds.org/badges/badges/stable.svg)](https://getwilds.org/badges/#stable)
 [![WDL Executors](https://img.shields.io/badge/WDL-Cromwell%20%7C%20miniWDL%20%7C%20Sprocket-blue.svg)](https://github.com/getwilds/wilds-wdl-library)
-[![WDL](https://img.shields.io/badge/WDL-1.0-orange.svg)](https://openwdl.org/)
 [![GitHub Release](https://img.shields.io/github/v/release/getwilds/wilds-wdl-library)](https://github.com/getwilds/wilds-wdl-library/releases)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19339693.svg)](https://doi.org/10.5281/zenodo.19339693)
 
 ---
 
@@ -142,6 +142,12 @@ Large language models (primarily [Claude](https://www.anthropic.com/claude)) hav
 - **Additional Resources**:
   - [Contributing Guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) - How to contribute
   - [GitHub Repository](https://github.com/getwilds/wilds-wdl-library) - Source code and development
+
+---
+
+## Citation
+
+If you use the WILDS WDL Library in your research, please cite it via Zenodo: [10.5281/zenodo.19339693](https://doi.org/10.5281/zenodo.19339693). The DOI always resolves to the latest release; see the [GitHub README](https://github.com/getwilds/wilds-wdl-library#citation) for a copy-pasteable citation and BibTeX entry.
 
 ---
 


### PR DESCRIPTION
## Type of Change

- Documentation update
- Dockstore registration update

## Description

Wires up the newly-minted Zenodo DOI for the WILDS WDL Library and brings `.dockstore.yml` up to date with modules that hadn't been registered yet.

**Citation / DOI updates:**
- `CITATION.cff`: added an `identifiers` block with both the concept DOI ([10.5281/zenodo.19339693](https://doi.org/10.5281/zenodo.19339693), always resolves to latest) and the v0.2.0 version DOI ([10.5281/zenodo.19339694](https://doi.org/10.5281/zenodo.19339694)).
- `README.md`: replaced the hardcoded `WDL-1.0` badge with a Zenodo DOI badge (the multi-version WDL support work on the horizon would have made the WDL-1.0 badge stale anyway), and added a new `## Citation` section with a copy-pasteable text citation and BibTeX block. The citation section is much more discoverable than the small "Cite this repository" sidebar button.
- `docs-README.md`: same badge swap (DOI in, WDL-1.0 out) plus a brief citation pointer at the bottom that links back to the main README.

**Dockstore registration:**
- Added 4 missing module entries: `ww-clair3`, `ww-esmfold`, `ww-gffread`, `ww-viennarna` (all sole-author Taylor Firman based on git log + WDL meta blocks).
- Re-sorted both `tools:` and `workflows:` sections alphabetically per the convention in `CLAUDE.md` (this moved `ww-testdata`, `ww-splicing-proteomics`, and `ww-starling-batch` to their correct slots).
- Intentionally skipped `ww-template` (scaffolding, not a real tool) and `ww-rnaseq` (still being updated on another branch).

## Documentation

- [x] I updated the README (if applicable)
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~
- [x] I ran `make docs-preview` to check documentation rendering (if applicable)

## Additional Context

- The concept DOI (`10.5281/zenodo.19339693`) was used for the README badge, the citation text, and BibTeX so it auto-updates with future releases. The version DOI is also recorded in `CITATION.cff` for users who want to pin to v0.2.0 specifically.
- Worth a glance from a reviewer: the topic strings on the four newly-added Dockstore entries (`ww-clair3`, `ww-esmfold`, `ww-gffread`, `ww-viennarna`) are first drafts — feel free to tweak in this PR or a follow-up.
- The `ww-rnaseq` pipeline is intentionally still missing from `.dockstore.yml` and should be added as part of https://github.com/getwilds/wilds-wdl-library/pull/331