### PR TITLE
Adding initial draft of repo-stats GitHub Action

### DIFF
--- a/.github/scripts/collect_repo_stats.py
+++ b/.github/scripts/collect_repo_stats.py
@@ -1,0 +1,110 @@
+"""Collect GitHub repository traffic stats and merge them into CSV history.
+
+Reads the views/clones/referrers/paths endpoints for the repo named in the
+GITHUB_REPOSITORY env var and writes results into ./data/. Daily-granularity
+endpoints (views, clones) are merged into a single CSV per metric, with
+later snapshots overwriting earlier rows for the same date. Top-10
+endpoints (referrers, paths) only return a current snapshot, so each run
+writes a dated JSON file under data/referrers/ and data/paths/.
+
+Auth uses the GH_TOKEN env var (set to GITHUB_TOKEN in the workflow).
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import pandas as pd
+
+API_ROOT = "https://api.github.com"
+DATA_DIR = Path("data")
+
+
+def gh_get(path: str) -> dict:
+    token = os.environ["GH_TOKEN"]
+    req = Request(
+        f"{API_ROOT}/{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urlopen(req) as resp:
+        return json.load(resp)
+
+
+def merge_daily(metric: str, repo: str) -> None:
+    """Fetch a daily-granularity metric and merge it into data/<metric>.csv."""
+    payload = gh_get(f"repos/{repo}/traffic/{metric}")
+    fresh = pd.DataFrame(payload[metric])
+    if not fresh.empty:
+        fresh["date"] = fresh["timestamp"].str[:10]
+        fresh = fresh[["date", "count", "uniques"]]
+
+    csv_path = DATA_DIR / f"{metric}.csv"
+    if csv_path.exists():
+        history = pd.read_csv(csv_path, dtype={"date": str})
+        # Drop overlapping dates from history so the fresh snapshot wins
+        history = history[~history["date"].isin(fresh["date"])]
+        merged = pd.concat([history, fresh], ignore_index=True)
+    else:
+        merged = fresh
+
+    merged = merged.sort_values("date").reset_index(drop=True)
+    merged.to_csv(csv_path, index=False)
+
+
+def snapshot_top(metric: str, repo: str, today: str) -> None:
+    """Fetch a top-N metric and write a dated JSON snapshot."""
+    out_dir = DATA_DIR / metric
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = gh_get(f"repos/{repo}/traffic/popular/{metric}")
+    (out_dir / f"{today}.json").write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def plot_metric(metric: str) -> None:
+    """Render a simple line chart of count + uniques over time."""
+    csv_path = DATA_DIR / f"{metric}.csv"
+    if not csv_path.exists():
+        return
+    df = pd.read_csv(csv_path, parse_dates=["date"])
+    if df.empty:
+        return
+
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.plot(df["date"], df["count"], label="Total", marker="o", markersize=3)
+    ax.plot(df["date"], df["uniques"], label="Unique", marker="o", markersize=3)
+    ax.set_title(f"{metric.capitalize()} over time")
+    ax.set_ylabel(metric.capitalize())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    fig.autofmt_xdate()
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(DATA_DIR / f"{metric}.png", dpi=120)
+    plt.close(fig)
+
+
+def main() -> int:
+    repo = os.environ["GITHUB_REPOSITORY"]
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    DATA_DIR.mkdir(exist_ok=True)
+
+    merge_daily("views", repo)
+    merge_daily("clones", repo)
+    snapshot_top("referrers", repo, today)
+    snapshot_top("paths", repo, today)
+
+    plot_metric("views")
+    plot_metric("clones")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -1,0 +1,68 @@
+name: Repo Traffic Stats
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run daily at 23:30 UTC (captures a full UTC day before the API rolls over)
+    - cron: '30 23 * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout repo-stats branch
+        uses: actions/checkout@v4
+        with:
+          ref: repo-stats
+        continue-on-error: true
+
+      -
+        name: Initialize repo-stats branch on first run
+        run: |
+          if [ ! -d .git ]; then
+            git init -b repo-stats
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      -
+        name: Fetch collection script from main
+        run: |
+          mkdir -p .github/scripts
+          curl -fsSL \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/.github/scripts/collect_repo_stats.py" \
+            -o .github/scripts/collect_repo_stats.py
+
+      -
+        name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      -
+        name: Install dependencies
+        run: pip install pandas matplotlib
+
+      -
+        name: Collect traffic stats
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python .github/scripts/collect_repo_stats.py
+
+      -
+        name: Commit and push
+        run: |
+          set -eo pipefail
+          git add data/
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "Update traffic stats $(date -u +%Y-%m-%d)"
+          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" \
+            HEAD:repo-stats


### PR DESCRIPTION
## Type of Change

- Other: CI/automation (new GitHub Actions workflow + helper script)

## Description

Adds a self-contained workflow that captures GitHub's repository traffic stats beyond the built-in 14-day rolling window, so we can track WILDS WDL Library adoption over time (views, clones, top referrers, top paths).

The workflow runs daily at 23:30 UTC (and on `workflow_dispatch`) and calls a small Python script that:

- Fetches the [GitHub Traffic API](https://docs.github.com/en/rest/metrics/traffic) endpoints for views, clones, popular referrers, and popular paths
- Merges daily-granularity views/clones into rolling CSV histories under `data/` (later snapshots overwrite overlapping rolling-window dates)
- Writes per-day JSON snapshots for the top-10 referrers/paths endpoints, since those endpoints only return current state with no history
- Renders simple matplotlib line charts (`views.png`, `clones.png`) so the trend is glanceable directly in the GitHub web UI

All output is committed to a dedicated `repo-stats` branch — no third-party services, no PAT required (uses the built-in `GITHUB_TOKEN`), no data leaves the repo. We chose this DIY approach over off-the-shelf actions like [jgehrcke/github-repo-stats](https://github.com/marketplace/actions/github-repo-stats) for trust and flexibility reasons (no third-party action accessing a `repo`-scoped PAT).

## Testing

**How did you test these changes?**
Not yet end-to-end. `workflow_dispatch` and `schedule` triggers only fire from workflows on the default branch, so the first real run will happen after merge. Plan: dispatch manually from the Actions tab once on `main` and confirm the `repo-stats` branch is created with `data/views.csv`, `data/clones.csv`, the PNG charts, and dated JSON snapshots under `data/referrers/` and `data/paths/`.

**What workflow engine did you use?**
N/A — this is GitHub Actions infrastructure, not a WDL change.

**Did the tests pass?**
N/A pre-merge; will verify post-merge as described above.

## Additional Context

- New Python dependencies (`pandas`, `matplotlib`) are installed only inside this workflow — no impact on existing CI jobs or local dev.
- Uses only the built-in `GITHUB_TOKEN` with `contents: write` permission scoped to the workflow.
- Output lives on a separate `repo-stats` branch so it never clutters `main`.
- First-run note for reviewers: graphs will start with only ~14 days of history (whatever's in GitHub's rolling window at that moment) and grow from there.