### PR TITLE
Fix repo-stats GitHub Action by switching to PAT

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  administration: read
 
 jobs:
   collect:

--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  administration: read
 
 jobs:
   collect:
@@ -51,7 +50,7 @@ jobs:
       -
         name: Collect traffic stats
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GHRS_GITHUB_API_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python .github/scripts/collect_repo_stats.py
 


### PR DESCRIPTION
## Type of Change

- Bug fix (CI/automation): unblocks the `Repo Traffic Stats` workflow that was added in the previous PR

## Description

The `Repo Traffic Stats` workflow merged in the previous PR was failing on its [first manually-triggered run](https://github.com/getwilds/wilds-wdl-library/actions/runs/25187673153) with `HTTP 403 Forbidden` when calling the [GitHub Traffic API](https://docs.github.com/en/rest/metrics/traffic) endpoints (`/traffic/views`, `/traffic/clones`, etc.).

**Root cause:** the traffic endpoints require push-level/administration access, which the workflow's default `GITHUB_TOKEN` cannot grant — even after explicitly adding `administration: read` to the workflow's `permissions:` block, GitHub still [rejected `administration` as an unrecognized scope](https://github.com/getwilds/wilds-wdl-library/actions/runs/25188295734).

**Fix:** swap the script's `GH_TOKEN` env var from `secrets.GITHUB_TOKEN` to `secrets.GHRS_GITHUB_API_TOKEN`, a fine-grained PAT scoped to this single repo with the minimum permissions needed:

- Administration: Read (unblocks the traffic API)
- Contents: Read and write (push to the `repo-stats` branch)
- Metadata: Read (auto-required)

This keeps the blast radius small relative to a classic `repo`-scoped PAT — the token can only touch `wilds-wdl-library` and only do the two things the workflow needs.

## Testing

**How did you test these changes?**
[Manually dispatched](https://github.com/getwilds/wilds-wdl-library/actions/runs/25188683927) from the Actions tab and the workflow ran end-to-end: the `repo-stats` branch was created on the remote and `data/views.csv`, `data/clones.csv`, the matching `.png` charts, and dated JSON snapshots under `data/referrers/` and `data/paths/` were all committed successfully.

**What workflow engine did you use?**
N/A — this is GitHub Actions infrastructure, not a WDL change.

**Did the tests pass?**
Yes. The workflow now completes successfully.

## Additional Context

- A fine-grained PAT named `GHRS_GITHUB_API_TOKEN` must exist as a repo secret for this workflow to run. If/when it expires, regenerate with the same three permissions (Administration: Read, Contents: Read+Write, Metadata: Read) scoped only to this repo and update the secret value.