### PR TITLE
Fixing HPC test run GH comment and adding retry logic

### DIFF
--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -24,6 +24,7 @@
 #   BRANCH=my-feature-branch  # Defaults to "main"
 #   TYPE=modules|pipelines    # Defaults to "all"
 #   NAME=ww-toolname          # Run a single module/pipeline (defaults to all)
+#   NUM_RETRIES=N             # Retry failed testruns up to N times (defaults to 0)
 #
 # To create the tracking issue (one-time setup):
 #   gh issue create \
@@ -56,9 +57,10 @@ cd "${CLONE_DIR}"
 # ---- Run testruns ----
 export TYPE="${TYPE:-all}"
 NAME="${NAME:-*}"
-echo "Starting WILDS WDL test runs at ${RUN_DATE} (type: ${TYPE}, name: ${NAME})"
+NUM_RETRIES="${NUM_RETRIES:-0}"
+echo "Starting WILDS WDL test runs at ${RUN_DATE} (type: ${TYPE}, name: ${NAME}, retries: ${NUM_RETRIES})"
 SPROCKET_CONFIG="${SPROCKET_CONFIG:-.github/configs/sprocket-hpc.toml}"
-make run_sprocket TYPE="${TYPE}" NAME="${NAME}" SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
+make run_sprocket TYPE="${TYPE}" NAME="${NAME}" NUM_RETRIES="${NUM_RETRIES}" SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
 
 # ---- Post results to GitHub ----
 python3 .github/scripts/hpc_testrun_report.py "${LOGFILE}" "${ISSUE_NUMBER}" --repo "${REPO}"

--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -23,6 +23,7 @@
 # Optional:
 #   BRANCH=my-feature-branch  # Defaults to "main"
 #   TYPE=modules|pipelines    # Defaults to "all"
+#   NAME=ww-toolname          # Run a single module/pipeline (defaults to all)
 #
 # To create the tracking issue (one-time setup):
 #   gh issue create \
@@ -43,7 +44,7 @@ REPO="getwilds/wilds-wdl-library"
 # ---- Environment setup ----
 # Update these module versions as needed for your HPC
 module purge
-module load sprocket/0.23.0 Apptainer/1.1.6
+module load sprocket/0.23.0 Apptainer/1.1.6 gh/2.86.0
 
 # ---- Clone fresh copy of the repo ----
 BRANCH="${BRANCH:-main}"
@@ -54,9 +55,10 @@ cd "${CLONE_DIR}"
 
 # ---- Run testruns ----
 export TYPE="${TYPE:-all}"
-echo "Starting WILDS WDL test runs at ${RUN_DATE} (type: ${TYPE})"
+NAME="${NAME:-*}"
+echo "Starting WILDS WDL test runs at ${RUN_DATE} (type: ${TYPE}, name: ${NAME})"
 SPROCKET_CONFIG="${SPROCKET_CONFIG:-.github/configs/sprocket-hpc.toml}"
-make run_sprocket TYPE="${TYPE}" SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
+make run_sprocket TYPE="${TYPE}" NAME="${NAME}" SPROCKET_CONFIG="${SPROCKET_CONFIG}" 2>&1 | tee "${LOGFILE}" || true
 
 # ---- Post results to GitHub ----
 python3 .github/scripts/hpc_testrun_report.py "${LOGFILE}" "${ISSUE_NUMBER}" --repo "${REPO}"

--- a/.github/scripts/hpc_testrun_report.py
+++ b/.github/scripts/hpc_testrun_report.py
@@ -92,7 +92,7 @@ def post_comment(comment: str, issue_number: str, repo: str) -> None:
     subprocess.run(
         ["gh", "issue", "comment", issue_number, "--repo", repo, "--body-file", "-"],
         input=comment,
-        text=True,
+        universal_newlines=True,
         check=True,
     )
     print(f"Results posted to {repo}#{issue_number}")

--- a/.github/scripts/hpc_testrun_report.py
+++ b/.github/scripts/hpc_testrun_report.py
@@ -88,16 +88,14 @@ def build_comment(results: dict, run_date: str, slurm_job_id: str, run_type: str
 
 
 def post_comment(comment: str, issue_number: str, repo: str) -> None:
-    """Post the comment to the GitHub issue using the gh REST API."""
+    """Post the comment to the GitHub issue using the gh CLI."""
     subprocess.run(
-        [
-            "gh", "api",
-            "repos/{}/issues/{}/comments".format(repo, issue_number),
-            "-f", "body={}".format(comment),
-        ],
+        ["gh", "issue", "comment", issue_number, "--repo", repo, "--body-file", "-"],
+        input=comment,
+        text=True,
         check=True,
     )
-    print("Results posted to {}#{}".format(repo, issue_number))
+    print(f"Results posted to {repo}#{issue_number}")
 
 
 def main():

--- a/.github/scripts/launch-hpc-testrun.sh
+++ b/.github/scripts/launch-hpc-testrun.sh
@@ -13,5 +13,5 @@ export WORK_DIR=/path/to/scratch/wilds-testrun
 SBATCH_SCRIPT=/path/to/hpc-testrun.sbatch
 
 # Submit modules and pipelines as separate SLURM jobs
-TYPE=modules sbatch "${SBATCH_SCRIPT}"
-TYPE=pipelines sbatch "${SBATCH_SCRIPT}"
+TYPE=modules NUM_RETRIES=2 sbatch "${SBATCH_SCRIPT}"
+TYPE=pipelines NUM_RETRIES=2 sbatch "${SBATCH_SCRIPT}"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SPROCKET_MIN ?= 0.22.0
 SPROCKET_CONFIG ?=
 SPROCKET_CONFIG_FLAG := $(if $(SPROCKET_CONFIG),-c $(SPROCKET_CONFIG),)
 TYPE ?= all
+NUM_RETRIES ?= 0
 
 .PHONY: help
 help: ## Show this help message
@@ -152,20 +153,32 @@ lint: lint_sprocket lint_miniwdl lint_womtool lint_cirro ## Run all linting chec
 
 ##@ Run
 
-run_sprocket: check_sprocket check_name ## Run sprocket on testrun.wdl files (use NAME=foo, TYPE=modules|pipelines, SPROCKET_CONFIG=path)
+run_sprocket: check_sprocket check_name ## Run sprocket on testrun.wdl files (use NAME=foo, TYPE=modules|pipelines, SPROCKET_CONFIG=path, NUM_RETRIES=N)
 	@echo "Running sprocket on testrun.wdl files..."
 	@failed=""; \
 	dirs=""; \
+	max_attempts=$$(($(NUM_RETRIES) + 1)); \
 	if [ "$(TYPE)" = "modules" ] || [ "$(TYPE)" = "all" ]; then dirs="$$dirs modules/$(NAME)/"; fi; \
 	if [ "$(TYPE)" = "pipelines" ] || [ "$(TYPE)" = "all" ]; then dirs="$$dirs pipelines/$(NAME)/"; fi; \
 	for dir in $$dirs; do \
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
-			echo "... Running $$(basename $$dir)"; \
+			name=$$(basename $$dir); \
+			echo "... Running $$name"; \
 			entrypoint=$$(grep '^workflow ' "$$dir/testrun.wdl" | awk '{print $$2}' | tr -d '{'); \
 			echo "... Using entrypoint: $$entrypoint"; \
-			if ! sprocket run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
-				failed="$$failed $$(basename $$dir)"; \
-				echo "... FAILED: $$(basename $$dir) (sprocket)"; \
+			attempt=1; passed=0; \
+			while [ $$attempt -le $$max_attempts ]; do \
+				if [ $$attempt -gt 1 ]; then echo "[retry] Attempt $$attempt/$$max_attempts for $$name"; fi; \
+				if sprocket run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
+					passed=1; break; \
+				fi; \
+				attempt=$$((attempt + 1)); \
+			done; \
+			if [ $$passed -eq 0 ]; then \
+				failed="$$failed $$name"; \
+				echo "... FAILED: $$name (sprocket, after $$max_attempts attempts)"; \
+			elif [ $$attempt -gt 1 ]; then \
+				echo "[retry] $$name passed on attempt $$attempt"; \
 			fi; \
 		fi; \
 	done; \


### PR DESCRIPTION
## Type of Change

- Bug fix
- Other (HPC test run tooling improvements)

## Description

Cleans up and extends the HPC monthly test run scripts:

- **Fix `gh` CLI comment upload.** Switched `hpc_testrun_report.py` from `gh api repos/.../comments -f body=...` to the cleaner `gh issue comment <num> --repo <repo> --body-file -` form, piping the body via stdin. The HPC system now has `gh` 2.86.0 available, so the older workaround is no longer needed. Also kept compatibility with the HPC's Python 3.6 by using `universal_newlines=True` instead of the 3.7+ `text=True` alias.
- **Single-module/pipeline test submissions.** Plumbed `NAME` through `hpc-testrun.sbatch` so a one-off run can target a specific module or pipeline (e.g., `NAME=ww-bwa sbatch ...`), defaulting to all when unset.
- **Retry logic for transient failures.** Added a `NUM_RETRIES` knob (default `0`) to `make run_sprocket` that retries a failing testrun up to N additional times. Useful for shared HPC infra where transient issues can mask whether a failure is real. The report parser is unaffected — each module still emits exactly one `... Running` and at most one `... FAILED:` marker, with retry attempts logged under a `[retry]` prefix the parser ignores. Plumbed through `hpc-testrun.sbatch` and set to `NUM_RETRIES=2` in the cron launch script.

## Testing

**How did you test these changes?**
Pushed the branch and submitted an HPC test run targeting a single module (`ww-bwa`) via `BRANCH=fix-hpc-run-gh NAME=ww-bwa sbatch ...`. The GitHub comment was successfully posted to the tracking issue, confirming the `gh` CLI fix and the Python 3.6 compatibility fix. The retry path was not exercised because `ww-bwa` passed on the first attempt, but the code path is additive and defaults to no retries (preserving prior behavior).

**What workflow engine did you use?**
Sprocket on the Fred Hutch HPC.

**Did the tests pass?**
Yes — `ww-bwa` passed and the result comment was posted to the tracking issue.

## Documentation

- [x] I updated the README (if applicable) — N/A, no user-facing module/pipeline changes
- [x] I added/updated parameter descriptions in the WDL (if applicable) — N/A
- [x] I ran `make docs-preview` to check documentation rendering (if applicable) — N/A

## Additional Context

- The retry logic was added only to `run_sprocket` since that's what the HPC test run uses. Easy to extend to `run_miniwdl` / `run_cromwell` later if needed.
- `NUM_RETRIES` defaults to `0`, so existing CI and local workflows are unchanged.
- The cron launch script (`launch-hpc-testrun.sh`) now passes `NUM_RETRIES=2` to both the modules and pipelines submissions.