### PR TITLE
Fixing GTF parsing in DESeq2 compiling task of ww-rnaseq

### DIFF
--- a/modules/ww-deseq2/README.md
+++ b/modules/ww-deseq2/README.md
@@ -29,7 +29,7 @@ All scripts are fetched from this repository at runtime via `curl`. This keeps t
 |--------|---------|----------|-------------|
 | [`combine_star_counts.py`](combine_star_counts.py) | `combine_count_matrices` | Python | Reads individual STAR `ReadsPerGene.out.tab` files, extracts the specified count column (unstranded, forward, or reverse), merges them into a single gene-by-sample count matrix, and writes a sample metadata file for DESeq2 |
 | [`deseq2_analysis.R`](deseq2_analysis.R) | `run_deseq2` | R | Runs the full DESeq2 pipeline: reads counts and metadata, applies configurable gene filtering, fits the DESeq2 model, extracts results with optional log fold change shrinkage, generates MA/PCA/volcano/heatmap plots, and writes results CSVs |
-| [`compile_deseq2_results.py`](compile_deseq2_results.py) | `compile_deseq2_results` | Python | Merges the all-genes results CSV with normalized counts on gene ID, parses GTF annotations (gene_name, gene_biotype, product), and joins them into a single comprehensive output CSV |
+| [`compile_deseq2_results.py`](compile_deseq2_results.py) | `compile_deseq2_results` | Python | Merges the all-genes results CSV with normalized counts on gene ID, parses GTF annotations (gene_name, gene_biotype, product, locus_tag, db_xref) by walking every feature row and aggregating per gene_id, and joins them into a single comprehensive output CSV. Handles GTFs without `gene` rows (e.g. UCSC ncbiRefSeq) and NCBI's `gene "name"` attribute (promoted to `gene_name`). |
 | [`generate_pasilla_counts.R`](generate_pasilla_counts.R) | `generate_pasilla_counts` (in ww-testdata) | R | Generates synthetic STAR-format count files from the Bioconductor Pasilla dataset for testing; creates individual `ReadsPerGene.out.tab` files with realistic header statistics |
 
 ## Tasks
@@ -90,13 +90,13 @@ Merges DESeq2 differential expression results with normalized counts and gene an
 **Inputs:**
 - `deseq2_results` (File): DESeq2 all-genes results CSV (output of `run_deseq2`)
 - `normalized_counts` (File): DESeq2 normalized counts CSV (output of `run_deseq2`)
-- `gtf_file` (File): GTF annotation file for extracting gene descriptions
+- `gtf_file` (File): GTF annotation file for extracting gene descriptions. Use the original (non-normalized) GTF so NCBI/Ensembl-specific attributes like `gene_biotype`, `product`, and `locus_tag` are preserved.
 - `output_name` (String): Name for the output CSV file (default: "deseq2_compiled_results.csv")
 - `memory_gb` (Int): Memory allocation in GB (default: 4)
 - `cpu_cores` (Int): Number of CPU cores (default: 1)
 
 **Outputs:**
-- `compiled_results` (File): Combined CSV with DESeq2 statistics, normalized counts, and gene annotations (gene_name, gene_biotype, product where available)
+- `compiled_results` (File): Combined CSV with DESeq2 statistics, normalized counts, and gene annotations (gene_name, gene_biotype, product, locus_tag, db_xref where available; columns that are entirely empty are dropped)
 
 ## Usage as a Module
 

--- a/modules/ww-deseq2/compile_deseq2_results.py
+++ b/modules/ww-deseq2/compile_deseq2_results.py
@@ -44,35 +44,52 @@ def extract_attr(attributes, key):
     return None
 
 
+ATTR_KEYS = ["gene_name", "gene", "gene_biotype", "product", "locus_tag", "db_xref"]
+
+
 def parse_gtf_annotations(gtf_path):
-    """Parse gene annotations from a GTF file."""
-    records = []
+    """Parse gene annotations from a GTF file.
+
+    Walks every feature row (gene/transcript/exon/CDS/etc.), keys by gene_id,
+    and takes the first non-null value seen per attribute. Handles GTFs that
+    lack `gene` rows (e.g. UCSC ncbiRefSeq) and NCBI's `gene "name"` attribute
+    (used in place of Ensembl's `gene_name`).
+    """
+    by_gene = {}
     with open(gtf_path, "r") as f:
         for line in f:
             if line.startswith("#"):
                 continue
-            fields = line.strip().split("\t")
-            if len(fields) < 9 or fields[2] != "gene":
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 9:
                 continue
             attrs = fields[8]
-            record = {
-                "gene_id": extract_attr(attrs, "gene_id"),
-                "gene_name": extract_attr(attrs, "gene_name"),
-                "gene_biotype": extract_attr(attrs, "gene_biotype"),
-                "product": extract_attr(attrs, "product"),
-            }
-            records.append(record)
+            gene_id = extract_attr(attrs, "gene_id")
+            if not gene_id:
+                continue
+            if gene_id not in by_gene:
+                by_gene[gene_id] = {"gene_id": gene_id}
+            for key in ATTR_KEYS:
+                if by_gene[gene_id].get(key):
+                    continue
+                value = extract_attr(attrs, key)
+                if value:
+                    by_gene[gene_id][key] = value
 
-    if not records:
+    if not by_gene:
         return pd.DataFrame(columns=["gene_id"])
 
-    annotations = pd.DataFrame(records)
+    # NCBI GTFs use `gene "name"` instead of `gene_name "name"`; promote it.
+    for gene_id in by_gene:
+        if not by_gene[gene_id].get("gene_name") and by_gene[gene_id].get("gene"):
+            by_gene[gene_id]["gene_name"] = by_gene[gene_id]["gene"]
+
+    annotations = pd.DataFrame(list(by_gene.values()))
+    annotations = annotations.drop(columns=["gene"], errors="ignore")
     # Remove columns that are entirely empty, but always keep gene_id
     keep_cols = [c for c in annotations.columns
                  if c == "gene_id" or annotations[c].notna().any()]
     annotations = annotations[keep_cols]
-    # Deduplicate by gene_id
-    annotations = annotations.drop_duplicates(subset="gene_id")
     return annotations
 
 

--- a/modules/ww-deseq2/testrun.wdl
+++ b/modules/ww-deseq2/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as ww_deseq2
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/fix-rnaseq-annotations/modules/ww-deseq2/ww-deseq2.wdl" as ww_deseq2
 
 workflow deseq2_example {
   # Generate test data

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -196,7 +196,7 @@ task compile_deseq2_results {
     set -eo pipefail
 
     curl -so compile_deseq2_results.py \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/compile_deseq2_results.py"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/fix-rnaseq-annotations/modules/ww-deseq2/compile_deseq2_results.py"
 
     python compile_deseq2_results.py \
       --results "~{deseq2_results}" \

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -60,7 +60,8 @@ This pipeline extends the simpler `ww-star-deseq2` pipeline with upstream read Q
 
 10. **DESeq2 — Compiled Results** (using `ww-deseq2` module):
     - Merges differential expression results with normalized counts
-    - Annotates genes with descriptions from the GTF (gene_name, gene_biotype, product)
+    - Annotates genes with descriptions from the original (non-normalized) GTF (gene_name, gene_biotype, product, locus_tag, db_xref where available)
+    - Walks every feature row and aggregates per gene_id, so it works on GTFs without `gene` rows (e.g. UCSC ncbiRefSeq) and on NCBI GTFs that use the `gene "name"` attribute instead of `gene_name`
     - Produces a single comprehensive CSV for downstream use
 
 11. **MultiQC — Aggregated Reporting** (using `ww-multiqc` module):
@@ -241,7 +242,7 @@ The pipeline produces comprehensive outputs from all modules:
 | `deseq2_ma_plot` | MA plot of log fold change vs. mean expression | ww-deseq2 |
 | `deseq2_ma_plot_shrunk` | MA plot with shrunken LFC (empty if shrinkage not applied) | ww-deseq2 |
 | `deseq2_results_shrunk` | DESeq2 results with shrunken LFC (empty if shrinkage not applied) | ww-deseq2 |
-| `deseq2_compiled_results` | Combined CSV with DESeq2 stats, normalized counts, and gene annotations | ww-deseq2 |
+| `deseq2_compiled_results` | Combined CSV with DESeq2 stats, normalized counts, and gene annotations (gene_name, gene_biotype, product, locus_tag, db_xref where available) | ww-deseq2 |
 | `multiqc_report` | Aggregated interactive HTML QC report | ww-multiqc |
 | `multiqc_data` | MultiQC parsed metrics data directory | ww-multiqc |
 | `organized_results` | (Optional) Tarball with all outputs organized by step and sample | pipeline-local |

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/fix-rnaseq-annotations/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
 
 struct RefGenome {
     String name

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -5,7 +5,7 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bedparse/ww-bedparse.wdl" as bedparse_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rseqc/ww-rseqc.wdl" as rseqc_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/fix-rnaseq-annotations/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as multiqc_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
 
@@ -215,7 +215,7 @@ workflow rnaseq {
   call deseq2_tasks.compile_deseq2_results as step08_compile_results { input:
       deseq2_results = step07_deseq2.deseq2_results,
       normalized_counts = step07_deseq2.deseq2_normalized_counts,
-      gtf_file = normalize_gtf.normalized_gtf
+      gtf_file = reference_genome.gtf
   }
 
   # Step 9: MultiQC aggregation of all QC reports


### PR DESCRIPTION
## Type of Change

- Bug fix
- Documentation update

## Description

Fixes the `compile_deseq2_results` task in the `ww-rnaseq` pipeline (step 8), which was producing compiled CSVs with no GTF annotation columns (`gene_name`, `gene_biotype`, `product`, etc.) — only `gene_id` and the DESeq2/counts columns made it through.

Two compounding issues were responsible:

1. **Pipeline was passing the normalized GTF.** Step 8 was wired to `normalize_gtf.normalized_gtf` from `ww-gffread`. That task strips all `gene`-type rows before running gffread, and gffread's output doesn't preserve arbitrary attributes like `gene_biotype` or `product` on `transcript`/`exon` lines. By the time the GTF reached the Python parser, the annotation attributes were gone.
2. **Python parser only read `gene`-type rows.** `compile_deseq2_results.py` had `if fields[2] != "gene": continue`, so on any GTF without `gene` rows (UCSC ncbiRefSeq, normalized GTFs, etc.) it produced an empty annotations DataFrame.

Additionally, NCBI bacterial GTFs (e.g. PAO1) use `gene "name"` rather than Ensembl/GENCODE's `gene_name "name"`, which the parser wasn't checking for.

**Changes:**

- `pipelines/ww-rnaseq/ww-rnaseq.wdl`: pass the original `reference_genome.gtf` to `compile_deseq2_results` instead of the normalized GTF, so the original attributes survive.
- `modules/ww-deseq2/compile_deseq2_results.py`: rewrite `parse_gtf_annotations` to walk every feature row (not just `gene`), key by `gene_id`, and take the first non-null value seen per attribute. Adds `locus_tag` and `db_xref` to the extracted attributes, and promotes NCBI's `gene` attribute to `gene_name` when the latter is absent. Empty columns are still dropped from the final output.
- READMEs for `ww-deseq2` and `ww-rnaseq` updated to reflect the new column set, the use of the original GTF, and the GTF-flavor handling.

## Testing

**How did you test these changes?**

Ran the updated pipeline on a PAO1 dataset (NCBI RefSeq GTF, classic bacterial layout). The compiled output now includes `gene_id`, `gene_biotype`, `locus_tag`, `db_xref`, `product`, and `gene_name` (with NCBI's `gene` attribute correctly promoted, e.g. `vqsM`, `pvdA`), alongside the DESeq2 statistics and per-sample normalized counts. Spot-checked rows like `PA2227` to confirm annotation values match the source GTF.

**What workflow engine did you use?**

Cromwell via PROOF

**Did the tests pass?**

Yes — the previously-missing annotation columns now appear in `deseq2_compiled_results.csv`.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~