### PR TITLE
Adding support for WDL v1.2

### DIFF
--- a/.github/configs/sprocket-hpc.toml
+++ b/.github/configs/sprocket-hpc.toml
@@ -4,10 +4,12 @@ run.experimental_features_enabled = true
 # Set the default backend to Slurm + Apptainer.
 run.backends.default.type = "slurm_apptainer"
 
-# Bind-mount the host's Lmod, modulefile tree, and software tree into the
-# Apptainer container so tasks loaded via `module load` find their binaries.
+# Enable GPU execution with Apptainer (--nv) and bind-mount the host's Lmod, 
+# modulefile tree, and software tree into the Apptainer container 
+# so tasks loaded via `module load` find their binaries.
 # Update these paths for your HPC.
 run.backends.default.extra_apptainer_exec_args = [
+    "--nv",
     "--bind", "/app/lmod:/app/lmod",
     "--bind", "/app/modules/all:/app/modules/all",
     "--bind", "/app/software:/app/software",
@@ -17,3 +19,6 @@ run.backends.default.extra_apptainer_exec_args = [
 
 # Define CPU slurm partition as necessary ("campus-new" or "short" for FH users)
 run.backends.default.default_slurm_partition.name = "campus-new"
+
+# Define GPU slurm partition as necessary ("campus-new", "short", or "chorus" for FH users)
+run.backends.default.gpu_slurm_partition.name = "campus-new"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -63,6 +63,10 @@ jobs:
         echo "Validating WDL files using WOMtool."
         files=$(find modules pipelines -name '*.wdl' 2>/dev/null || true)
         for file in $files; do
+          if grep -qE '^version 1\.2' "$file"; then
+            echo "  [---] Skipping $file (WDL 1.2 not supported by WOMtool) [---]"
+            continue
+          fi
           echo "  [***] Validating $file [***]"
           java -jar womtool-86.jar validate "$file"
           EXITCODE=$(($? || EXITCODE))

--- a/.github/workflows/testrun-reusable.yml
+++ b/.github/workflows/testrun-reusable.yml
@@ -71,6 +71,10 @@ jobs:
       run: |
         item_dir="${{ inputs.item_type }}/${{ matrix.item }}"
         wdl_file="$item_dir/testrun.wdl"
+        if grep -qE '^version 1\.2' "$wdl_file"; then
+          echo "Skipping ${{ inputs.item_type }}/${{ matrix.item }} (WDL 1.2 not supported by miniwdl; covered by Sprocket)"
+          exit 0
+        fi
         echo "Running ${{ inputs.item_type }}/${{ matrix.item }} with miniwdl..."
         miniwdl run "$wdl_file"
 
@@ -116,6 +120,10 @@ jobs:
       run: |
         item_dir="${{ inputs.item_type }}/${{ matrix.item }}"
         wdl_file="$item_dir/testrun.wdl"
+        if grep -qE '^version 1\.2' "$wdl_file"; then
+          echo "Skipping ${{ inputs.item_type }}/${{ matrix.item }} (WDL 1.2 not supported by Cromwell; covered by Sprocket)"
+          exit 0
+        fi
         echo "Running ${{ inputs.item_type }}/${{ matrix.item }} with Cromwell..."
         java -Dconfig.file=.github/configs/cromwell.conf -jar cromwell-92.jar run "$wdl_file"
 

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,10 @@ lint_womtool: check_java check_womtool check_name ## Run WOMtool validate on mod
 	@echo "Running WOMtool validate..."
 	@set -e; for file in modules/$(NAME)/*.wdl pipelines/$(NAME)/*.wdl; do \
 		if [ -f "$$file" ]; then \
+			if grep -qE '^version 1\.2' "$$file"; then \
+				echo "Skipping $$file (WDL 1.2 not supported by WOMtool)"; \
+				continue; \
+			fi; \
 			echo "Validating $$file"; \
 			java -jar $(WOMTOOL_JAR) validate "$$file"; \
 		fi; \

--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -50,7 +50,7 @@ Runs Clair3 to call germline variants from aligned reads using deep learning pil
 - `ctg_name` (String?, optional): Contig/chromosome name to restrict calling
 - `include_all_ctgs` (Boolean, default=false): Call on all contigs (required for non-human species)
 - `pileup_only` (Boolean, default=false): Use only the pileup model for faster variant calling (skips full-alignment stage)
-- `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for Clair3 inference. Note: the `gpus` runtime attribute is specified as a string (e.g., `"1"`) rather than an integer, as required by Fred Hutch PROOF/Cromwell configuration, but can be adjusted as necessary.
+- `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for Clair3 inference (requests GPU in runtime). See [GPU Execution Across Environments](#gpu-execution-across-environments) for backend-specific configuration.
 - `cpu_cores` (Int, default=8): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=32): Memory allocated for the task in GB
 
@@ -63,6 +63,8 @@ Runs Clair3 to call germline variants from aligned reads using deep learning pil
 ## Usage as a Module
 
 ### Importing into Your Workflow
+
+The example below imports from `refs/heads/main`, which always points at the latest version of the module. For reproducible workflows, you can pin the import to a specific release tag (`refs/tags/v0.3.0`) or commit SHA (`<full-sha>`) by swapping `refs/heads/main` in the URL — just make sure the tag or commit you pin to actually contains this module.
 
 ```wdl
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-clair3/ww-clair3.wdl" as clair3_tasks
@@ -199,6 +201,27 @@ This module uses the `getwilds/clair3:2.0.0` container image, which includes:
 - `cpu_cores`: Clair3 parallelizes by splitting chromosomes into chunks (4 threads each)
 - `memory_gb`: Increase for high-coverage samples or when calling on many contigs
 - For targeted sequencing with BED files, lower resources may be sufficient
+
+## GPU Execution Across Environments
+
+GPU scheduling is not standardized across WDL executors, so the way GPUs are requested in the `runtime` section depends on where the workflow is run. This module ships configured for the standard `gpu: Boolean` key under WDL 1.2, which works with recent versions of miniWDL, Sprocket, and Cromwell in cloud/local environments — and with Sprocket on the Fred Hutch HPC.
+
+If you'd rather run through PROOF (the Fred Hutch point-and-click interface for Cromwell on HPC), two modifications are required because PROOF's Cromwell deployment targets WDL 1.0:
+
+1. **Downgrade the WDL version** from `version 1.2` to `version 1.0` at the top of `ww-clair3.wdl`.
+2. **Switch the runtime key** from `gpu` to `gpus` (an integer count passed as a string) in the `run_clair3` task. The task already includes the alternate line as a comment for convenience:
+
+   ```wdl
+   runtime {
+     docker: "getwilds/clair3:2.0.0"
+     # gpu: gpu_enabled
+     gpus: if gpu_enabled then "1" else "0"
+     cpu: cpu_cores
+     memory: "~{memory_gb} GB"
+   }
+   ```
+
+If you're on Fred Hutch HPC and don't need the PROOF UI, you can keep the module as-is and submit via Sprocket. For other HPC or cloud backends, check that backend's documentation for its expected GPU runtime attribute — some engines also accept `gpuCount`, `gpuType`, or backend-specific keys via `hints`.
 
 ## Contributing
 

--- a/modules/ww-clair3/testrun.wdl
+++ b/modules/ww-clair3/testrun.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.2
 
 # Import module in question as well as the testdata module for automatic demo functionality
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-clair3/ww-clair3.wdl" as ww_clair3

--- a/modules/ww-clair3/testrun_hpc.wdl
+++ b/modules/ww-clair3/testrun_hpc.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.2
 
 # HPC test workflow for ww-clair3. Mirrors testrun.wdl coverage but exercises
 # the GPU code path on realistic input data — intended to validate end-to-end

--- a/modules/ww-clair3/testrun_hpc.wdl
+++ b/modules/ww-clair3/testrun_hpc.wdl
@@ -1,0 +1,141 @@
+version 1.0
+
+# HPC test workflow for ww-clair3. Mirrors testrun.wdl coverage but exercises
+# the GPU code path on realistic input data — intended to validate end-to-end
+# behavior on Fred Hutch HPC infrastructure (Sprocket or PROOF).
+
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-clair3/ww-clair3.wdl" as ww_clair3
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+
+#### TEST WORKFLOW DEFINITION ####
+
+workflow clair3_example {
+  # Download full chr1 reference and BAM test data for a realistic call set
+  call ww_testdata.download_ref_data as download_reference { input:
+    chromo = "chr1"
+  }
+
+  call ww_testdata.download_bam_data as download_bam { input:
+    filename = "sample1.bam"
+  }
+
+  # Pileup-only mode with GPU
+  call ww_clair3.run_clair3 { input:
+    sample_name = "sample1",
+    input_bam = download_bam.bam,
+    input_bam_index = download_bam.bai,
+    ref_fasta = download_reference.fasta,
+    ref_fasta_index = download_reference.fasta_index,
+    platform = "ilmn",
+    model_path = "/opt/models/ilmn",
+    bed_file = download_reference.bed,
+    pileup_only = true,
+    gpu_enabled = true,
+    cpu_cores = 4,
+    memory_gb = 16
+  }
+
+  # Full-alignment mode with gVCF output and GPU
+  call ww_clair3.run_clair3 as run_clair3_gvcf { input:
+    sample_name = "sample1_gvcf",
+    input_bam = download_bam.bam,
+    input_bam_index = download_bam.bai,
+    ref_fasta = download_reference.fasta,
+    ref_fasta_index = download_reference.fasta_index,
+    platform = "ilmn",
+    model_path = "/opt/models/ilmn",
+    bed_file = download_reference.bed,
+    gvcf_enabled = true,
+    gpu_enabled = true,
+    cpu_cores = 4,
+    memory_gb = 16
+  }
+
+  call validate_outputs { input:
+      pileup_vcf = run_clair3.output_vcf,
+      full_vcf = run_clair3_gvcf.output_vcf,
+      gvcfs = run_clair3_gvcf.output_gvcf
+  }
+
+  output {
+    File output_vcf = run_clair3.output_vcf
+    File output_vcf_index = run_clair3.output_vcf_index
+    File output_gvcf_vcf = run_clair3_gvcf.output_vcf
+    File output_gvcf_vcf_index = run_clair3_gvcf.output_vcf_index
+    Array[File] output_gvcf = run_clair3_gvcf.output_gvcf
+    Array[File] output_gvcf_index = run_clair3_gvcf.output_gvcf_index
+    File validation_report = validate_outputs.report
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that Clair3 produced non-empty VCF and gVCF outputs"
+    outputs: {
+        report: "Validation report summarizing record counts and file checks"
+    }
+  }
+
+  parameter_meta {
+    pileup_vcf: "VCF file from pileup-only run_clair3 invocation"
+    full_vcf: "VCF file from full-alignment run_clair3 invocation"
+    gvcfs: "Array of gVCF files from full-alignment run_clair3 invocation"
+  }
+
+  input {
+    File pileup_vcf
+    File full_vcf
+    Array[File] gvcfs
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== Clair3 HPC Validation Report ===" > validation_report.txt
+    echo "" >> validation_report.txt
+
+    validation_passed=true
+
+    pileup_records=$(zcat ~{pileup_vcf} | grep -vc "^#" || true)
+    echo "Pileup VCF variant records: ${pileup_records}" >> validation_report.txt
+    if [ "${pileup_records}" -eq 0 ]; then
+      echo "WARNING: pileup VCF has no variant records" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    full_records=$(zcat ~{full_vcf} | grep -vc "^#" || true)
+    echo "Full-alignment VCF variant records: ${full_records}" >> validation_report.txt
+    if [ "${full_records}" -eq 0 ]; then
+      echo "WARNING: full-alignment VCF has no variant records" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    gvcf_count=$(echo "~{sep=' ' gvcfs}" | wc -w)
+    echo "gVCF files produced: ${gvcf_count}" >> validation_report.txt
+    if [ "${gvcf_count}" -eq 0 ]; then
+      echo "WARNING: no gVCF files produced" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    echo "" >> validation_report.txt
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [ "${validation_passed}" = "true" ]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    cpu: 1
+    memory: "2 GB"
+  }
+}

--- a/modules/ww-clair3/testrun_hpc.wdl
+++ b/modules/ww-clair3/testrun_hpc.wdl
@@ -4,8 +4,8 @@ version 1.2
 # the GPU code path on realistic input data — intended to validate end-to-end
 # behavior on Fred Hutch HPC infrastructure (Sprocket or PROOF).
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-clair3/ww-clair3.wdl" as ww_clair3
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/wdl-v1.2-support/modules/ww-clair3/ww-clair3.wdl" as ww_clair3
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-clair3/ww-clair3.wdl
+++ b/modules/ww-clair3/ww-clair3.wdl
@@ -3,7 +3,7 @@
 ## sequencing data. Uses a two-stage pileup and full-alignment approach
 ## for high-accuracy SNP and indel calling from ONT, PacBio, and Illumina reads.
 
-version 1.0
+version 1.2
 
 #### TASK DEFINITIONS ####
 
@@ -109,8 +109,10 @@ task run_clair3 {
 
   runtime {
     docker: "getwilds/clair3:2.0.0"
+    gpu: gpu_enabled
+    # For use in PROOF, switch to using the 'gpus' parameter
+    # gpus: if gpu_enabled then "1" else "0"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
   }
 }

--- a/modules/ww-colabfold/README.md
+++ b/modules/ww-colabfold/README.md
@@ -53,7 +53,7 @@ Predict protein structures from amino acid sequences using ColabFold (AlphaFold2
 - `extra_flags` (String, default=""): Additional colabfold_batch flags
 - `cpu_cores` (Int, default=8): CPU cores
 - `memory_gb` (Int, default=48): Memory in GB
-- `gpu_enabled` (Boolean, default=true): Enable GPU for prediction (controls JAX CPU/GPU mode and PROOF GPU allocation)
+- `gpu_enabled` (Boolean, default=true): Enable GPU for prediction (controls JAX CPU/GPU mode and the GPU runtime attribute). See [GPU Execution Across Environments](#gpu-execution-across-environments) for backend-specific configuration.
 
 **Outputs:**
 - `results_tarball` (File): Compressed tarball containing all ColabFold outputs (PDB files, PAE/pLDDT plots, coverage plots, prediction metrics)
@@ -61,6 +61,8 @@ Predict protein structures from amino acid sequences using ColabFold (AlphaFold2
 ## Usage as a Module
 
 ### Importing into Your Workflow
+
+The example below imports from `refs/heads/main`, which always points at the latest version of the module. For reproducible workflows, you can pin the import to a specific release tag (`refs/tags/v0.3.0`) or commit SHA (`<full-sha>`) by swapping `refs/heads/main` in the URL — just make sure the tag or commit you pin to actually contains this module.
 
 ```wdl
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-colabfold/ww-colabfold.wdl" as colabfold_tasks
@@ -186,17 +188,30 @@ The CI test workflow (`testrun.wdl`) runs on CPU (`gpu_enabled = false`) with mi
 
 `testrun_hpc.wdl` mirrors the regular testrun's structure but uses a realistic-size protein (76-residue ubiquitin via `ww-testdata.create_realistic_protein_fasta`) and full production settings: GPU enabled, AMBER relaxation on, 5 models, 3 recycles. It is intended to be exercised on Fred Hutch HPC (via Sprocket directly or via PROOF after applying the WDL 1.0 / `gpus` swap described above) and includes a validation task that confirms PDB output files are present.
 
-## GPU Configuration
+## GPU Execution Across Environments
 
 The `gpu_enabled` input controls two things:
-1. **JAX execution mode**: When `false`, sets `JAX_PLATFORMS=cpu` to force CPU-only execution
-2. **PROOF GPU allocation**: Translates to the `gpus` runtime attribute (`"1"` or `"0"`), which is specific to PROOF's Cromwell configuration. Other executors like miniWDL and Sprocket silently ignore this attribute.
+1. **JAX execution mode**: When `false`, sets `JAX_PLATFORMS=cpu` to force CPU-only execution.
+2. **WDL runtime GPU attribute**: Translates to the standard `gpu: Boolean` key in the `runtime` block.
 
-### For PROOF Users
-GPU allocation works automatically with the default (`gpu_enabled = true`). ColabFold only supports a single GPU for structure prediction.
+GPU scheduling is not standardized across WDL executors, so the way GPUs are requested in the `runtime` section depends on where the workflow is run. This module ships configured for the standard `gpu: Boolean` key under WDL 1.2, which works with recent versions of miniWDL, Sprocket, and Cromwell in cloud/local environments — and with Sprocket on the Fred Hutch HPC. ColabFold only supports a single GPU for structure prediction.
 
-### For Other Executors
-Configure GPU passthrough at the engine level (e.g., Docker `--gpus` flag). Set `gpu_enabled = true` to ensure ColabFold uses the GPU via JAX.
+If you'd rather run through PROOF (the Fred Hutch point-and-click interface for Cromwell on HPC), two modifications are required because PROOF's Cromwell deployment targets WDL 1.0:
+
+1. **Downgrade the WDL version** from `version 1.2` to `version 1.0` at the top of `ww-colabfold.wdl`.
+2. **Switch the runtime key** from `gpu` to `gpus` (an integer count passed as a string) in the `colabfold_predict` task. The task already includes the alternate line as a comment for convenience:
+
+   ```wdl
+   runtime {
+     docker: "getwilds/colabfold:1.5.5"
+     # gpu: gpu_enabled
+     gpus: if gpu_enabled then "1" else "0"
+     cpu: cpu_cores
+     memory: "~{memory_gb} GB"
+   }
+   ```
+
+If you're on Fred Hutch HPC and don't need the PROOF UI, you can keep the module as-is and submit via Sprocket. For other HPC or cloud backends, check that backend's documentation for its expected GPU runtime attribute — some engines also accept `gpuCount`, `gpuType`, or backend-specific keys via `hints`.
 
 ### CPU-Only Mode
 Set `gpu_enabled = false` to force CPU execution via `JAX_PLATFORMS=cpu`. This is functional but significantly slower and intended primarily for testing.

--- a/modules/ww-colabfold/testrun.wdl
+++ b/modules/ww-colabfold/testrun.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.2
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-colabfold/ww-colabfold.wdl" as ww_colabfold
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata

--- a/modules/ww-colabfold/testrun_hpc.wdl
+++ b/modules/ww-colabfold/testrun_hpc.wdl
@@ -1,0 +1,117 @@
+version 1.0
+
+# HPC test workflow for ww-colabfold. Mirrors testrun.wdl coverage but uses
+# realistic protein input and full GPU + AMBER settings — intended to validate
+# end-to-end ColabFold behavior on Fred Hutch HPC infrastructure.
+
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-colabfold/ww-colabfold.wdl" as ww_colabfold
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+
+#### TEST WORKFLOW DEFINITION ####
+
+workflow colabfold_example {
+  # Use a realistic-size protein (human ubiquitin, 76 residues) instead of a tiny peptide
+  call ww_testdata.create_realistic_protein_fasta { }
+
+  # Download AlphaFold2 model weights
+  call ww_colabfold.download_weights { input:
+      cpu_cores = 2,
+      memory_gb = 8
+  }
+
+  # Production-style ColabFold prediction on GPU with AMBER relaxation
+  call ww_colabfold.colabfold_predict { input:
+      fasta_file = create_realistic_protein_fasta.test_fasta,
+      weights_tarball = download_weights.weights_tarball,
+      output_prefix = "test_ubiquitin",
+      num_recycle = 3,
+      num_models = 5,
+      num_seeds = 1,
+      msa_mode = "mmseqs2_uniref_env",
+      use_amber = true,
+      stop_at_score = 85,
+      use_gpu_relax = true,
+      model_type = "auto",
+      gpu_enabled = true,
+      cpu_cores = 8,
+      memory_gb = 48
+  }
+
+  call validate_outputs { input:
+      results_tarball = colabfold_predict.results_tarball
+  }
+
+  output {
+    File colabfold_weights = download_weights.weights_tarball
+    File colabfold_results = colabfold_predict.results_tarball
+    File validation_report = validate_outputs.report
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that ColabFold prediction generated expected output files"
+    outputs: {
+        report: "Validation report summarizing file checks and prediction results"
+    }
+  }
+
+  parameter_meta {
+    results_tarball: "Compressed tarball of ColabFold prediction results to validate"
+  }
+
+  input {
+    File results_tarball
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== ColabFold HPC Validation Report ===" > validation_report.txt
+    echo "" >> validation_report.txt
+
+    tar -xzf ~{results_tarball}
+
+    validation_passed=true
+
+    if [ -d "results" ]; then
+      file_count=$(find results/ -type f | wc -l)
+      echo "Results directory: found ${file_count} files" >> validation_report.txt
+    else
+      echo "Results directory: MISSING" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    pdb_count=$(find results/ -name "*.pdb" 2>/dev/null | wc -l)
+    echo "PDB structure files: ${pdb_count}" >> validation_report.txt
+    if [ "${pdb_count}" -eq 0 ]; then
+      echo "WARNING: No PDB files found" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    echo "" >> validation_report.txt
+    echo "--- Output Files ---" >> validation_report.txt
+    find results/ -type f -exec ls -lh {} \; >> validation_report.txt 2>/dev/null || true
+
+    echo "" >> validation_report.txt
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [ "${validation_passed}" = "true" ]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    cpu: 1
+    memory: "2 GB"
+  }
+}

--- a/modules/ww-colabfold/testrun_hpc.wdl
+++ b/modules/ww-colabfold/testrun_hpc.wdl
@@ -4,8 +4,8 @@ version 1.2
 # realistic protein input and full GPU + AMBER settings — intended to validate
 # end-to-end ColabFold behavior on Fred Hutch HPC infrastructure.
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-colabfold/ww-colabfold.wdl" as ww_colabfold
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/wdl-v1.2-support/modules/ww-colabfold/ww-colabfold.wdl" as ww_colabfold
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-colabfold/testrun_hpc.wdl
+++ b/modules/ww-colabfold/testrun_hpc.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.2
 
 # HPC test workflow for ww-colabfold. Mirrors testrun.wdl coverage but uses
 # realistic protein input and full GPU + AMBER settings — intended to validate

--- a/modules/ww-colabfold/ww-colabfold.wdl
+++ b/modules/ww-colabfold/ww-colabfold.wdl
@@ -3,7 +3,7 @@
 ## Designed to be a modular component within the WILDS ecosystem that can be used
 ## independently or integrated with other WILDS workflows.
 
-version 1.0
+version 1.2
 
 #### TASK DEFINITIONS ####
 
@@ -164,8 +164,10 @@ task colabfold_predict {
 
   runtime {
     docker: "getwilds/colabfold:1.5.5"
+    gpu: gpu_enabled
+    # For use in PROOF, switch to using the 'gpus' parameter
+    # gpus: if gpu_enabled then "1" else "0"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
   }
 }

--- a/modules/ww-deepvariant/README.md
+++ b/modules/ww-deepvariant/README.md
@@ -35,6 +35,7 @@ Runs DeepVariant to call germline variants from aligned reads. Optionally produc
 - `model_type` (String, default="WGS"): Sequencing model type (WGS, WES, PACBIO, ONT_R104, HYBRID_PACBIO_ILLUMINA, MASSEQ)
 - `output_gvcf_enabled` (Boolean, default=false): Whether to also produce a gVCF file for downstream joint genotyping
 - `regions` (String?, optional): Genomic regions to restrict variant calling
+- `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for the `call_variants` stage. Switches the Docker image to the GPU-tagged build and requests a GPU in runtime. See [GPU Execution Across Environments](#gpu-execution-across-environments) for backend-specific configuration.
 - `cpu_cores` (Int, default=8): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=32): Memory allocated for the task in GB
 
@@ -47,6 +48,8 @@ Runs DeepVariant to call germline variants from aligned reads. Optionally produc
 ## Usage as a Module
 
 ### Importing into Your Workflow
+
+The example below imports from `refs/heads/main`, which always points at the latest version of the module. For reproducible workflows, you can pin the import to a specific release tag (`refs/tags/v0.3.0`) or commit SHA (`<full-sha>`) by swapping `refs/heads/main` in the URL — just make sure the tag or commit you pin to actually contains this module.
 
 ```wdl
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deepvariant/ww-deepvariant.wdl" as deepvariant_tasks
@@ -112,6 +115,19 @@ call deepvariant_tasks.run_deepvariant {
 }
 ```
 
+**GPU-accelerated variant calling:**
+```wdl
+call deepvariant_tasks.run_deepvariant {
+  input:
+    sample_name = "gpu_sample",
+    input_bam = wgs_bam,
+    input_bam_index = wgs_bai,
+    ref_fasta = ref_fasta,
+    ref_fasta_index = ref_fasta_index,
+    gpu_enabled = true
+}
+```
+
 ### Integration Examples
 
 This module integrates seamlessly with other WILDS components:
@@ -148,7 +164,11 @@ The test workflow automatically:
 
 ## Docker Container
 
-This module uses the `google/deepvariant:1.10.0` container image, which includes:
+This module uses Google's official DeepVariant container images (CPU and GPU variants are selected automatically based on `gpu_enabled`):
+- `google/deepvariant:1.10.0` — CPU build (default)
+- `google/deepvariant:1.10.0-gpu` — GPU build, used when `gpu_enabled = true`
+
+Both images include:
 - DeepVariant variant caller (v1.10.0)
 - Pre-trained CNN models for WGS, WES, PacBio, and ONT
 - All necessary dependencies for variant calling
@@ -171,6 +191,29 @@ This module uses the `google/deepvariant:1.10.0` container image, which includes
 - `cpu_cores`: DeepVariant benefits significantly from multi-core processing via `--num_shards`
 - `memory_gb`: WGS typically needs 32+ GB; WES can use less (16 GB)
 - For production WGS at 30x coverage, consider 16+ cores and 64 GB memory
+
+## GPU Execution Across Environments
+
+DeepVariant's `call_variants` stage (the CNN inference step) supports GPU acceleration, with reported speedups of ~5x for that stage. The other stages (`make_examples`, `postprocess_variants`) remain CPU-bound regardless. GPU acceleration is opt-in via `gpu_enabled = true`, which both selects the GPU-tagged Docker image and requests a GPU in the runtime block.
+
+GPU scheduling is not standardized across WDL executors, so the way GPUs are requested in the `runtime` section depends on where the workflow is run. This module ships configured for the standard `gpu: Boolean` key under WDL 1.2, which works with recent versions of miniWDL, Sprocket, and Cromwell in cloud/local environments — and with Sprocket on the Fred Hutch HPC.
+
+If you'd rather run through PROOF (the Fred Hutch point-and-click interface for Cromwell on HPC), two modifications are required because PROOF's Cromwell deployment targets WDL 1.0:
+
+1. **Downgrade the WDL version** from `version 1.2` to `version 1.0` at the top of `ww-deepvariant.wdl`.
+2. **Switch the runtime key** from `gpu` to `gpus` (an integer count passed as a string) in the `run_deepvariant` task. The task already includes the alternate line as a comment for convenience:
+
+   ```wdl
+   runtime {
+     docker: if gpu_enabled then "google/deepvariant:1.10.0-gpu" else "google/deepvariant:1.10.0"
+     # gpu: gpu_enabled
+     gpus: if gpu_enabled then "1" else "0"
+     cpu: cpu_cores
+     memory: "~{memory_gb} GB"
+   }
+   ```
+
+If you're on Fred Hutch HPC and don't need the PROOF UI, you can keep the module as-is and submit via Sprocket. For other HPC or cloud backends, check that backend's documentation for its expected GPU runtime attribute — some engines also accept `gpuCount`, `gpuType`, or backend-specific keys via `hints`.
 
 ## Contributing
 

--- a/modules/ww-deepvariant/testrun.wdl
+++ b/modules/ww-deepvariant/testrun.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.2
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deepvariant/ww-deepvariant.wdl" as ww_deepvariant
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata

--- a/modules/ww-deepvariant/testrun_hpc.wdl
+++ b/modules/ww-deepvariant/testrun_hpc.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.2
 
 # HPC test workflow for ww-deepvariant. Mirrors testrun.wdl coverage with
 # GPU acceleration enabled — intended to validate end-to-end behavior on

--- a/modules/ww-deepvariant/testrun_hpc.wdl
+++ b/modules/ww-deepvariant/testrun_hpc.wdl
@@ -4,8 +4,8 @@ version 1.2
 # GPU acceleration enabled — intended to validate end-to-end behavior on
 # Fred Hutch HPC infrastructure (Sprocket or PROOF).
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-deepvariant/ww-deepvariant.wdl" as ww_deepvariant
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/wdl-v1.2-support/modules/ww-deepvariant/ww-deepvariant.wdl" as ww_deepvariant
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 struct DeepVariantSample {
     String name

--- a/modules/ww-deepvariant/testrun_hpc.wdl
+++ b/modules/ww-deepvariant/testrun_hpc.wdl
@@ -1,0 +1,161 @@
+version 1.0
+
+# HPC test workflow for ww-deepvariant. Mirrors testrun.wdl coverage with
+# GPU acceleration enabled — intended to validate end-to-end behavior on
+# Fred Hutch HPC infrastructure (Sprocket or PROOF).
+
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-deepvariant/ww-deepvariant.wdl" as ww_deepvariant
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+
+struct DeepVariantSample {
+    String name
+    File bam
+    File bai
+}
+
+workflow deepvariant_example {
+  # Download chr1 reference and BAM test data
+  call ww_testdata.download_ref_data as download_reference { input:
+    chromo = "chr1"
+  }
+
+  call ww_testdata.download_bam_data as download_bam_1 { input:
+    filename = "sample1.bam"
+  }
+
+  call ww_testdata.download_bam_data as download_bam_2 { input:
+    filename = "sample2.bam"
+  }
+
+  Array[DeepVariantSample] samples = [
+    {
+      "name": "sample1",
+      "bam": download_bam_1.bam,
+      "bai": download_bam_1.bai
+    },
+    {
+      "name": "sample2",
+      "bam": download_bam_2.bam,
+      "bai": download_bam_2.bai
+    }
+  ]
+
+  # Scatter VCF-only DeepVariant calls across samples on GPU
+  scatter (sample in samples) {
+    call ww_deepvariant.run_deepvariant { input:
+      sample_name = sample.name,
+      input_bam = sample.bam,
+      input_bam_index = sample.bai,
+      ref_fasta = download_reference.fasta,
+      ref_fasta_index = download_reference.fasta_index,
+      model_type = "WGS",
+      regions = "chr1",
+      gpu_enabled = true,
+      cpu_cores = 8,
+      memory_gb = 32
+    }
+  }
+
+  # gVCF call on the first sample, also on GPU
+  call ww_deepvariant.run_deepvariant as run_deepvariant_gvcf { input:
+    sample_name = "sample1_gvcf",
+    input_bam = download_bam_1.bam,
+    input_bam_index = download_bam_1.bai,
+    ref_fasta = download_reference.fasta,
+    ref_fasta_index = download_reference.fasta_index,
+    model_type = "WGS",
+    output_gvcf_enabled = true,
+    regions = "chr1",
+    gpu_enabled = true,
+    cpu_cores = 8,
+    memory_gb = 32
+  }
+
+  call validate_outputs { input:
+      vcfs = run_deepvariant.output_vcf,
+      gvcf_vcf = run_deepvariant_gvcf.output_vcf,
+      gvcfs = run_deepvariant_gvcf.output_gvcf
+  }
+
+  output {
+    Array[File] output_vcfs = run_deepvariant.output_vcf
+    Array[File] output_vcf_indices = run_deepvariant.output_vcf_index
+    File output_gvcf_vcf = run_deepvariant_gvcf.output_vcf
+    Array[File] output_gvcfs = run_deepvariant_gvcf.output_gvcf
+    File validation_report = validate_outputs.report
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that DeepVariant produced non-empty VCF and gVCF outputs"
+    outputs: {
+        report: "Validation report summarizing record counts and file checks"
+    }
+  }
+
+  parameter_meta {
+    vcfs: "Array of per-sample VCF files from scattered run_deepvariant calls"
+    gvcf_vcf: "VCF file from the gVCF-enabled run_deepvariant invocation"
+    gvcfs: "Array of gVCF files from the gVCF-enabled run_deepvariant invocation"
+  }
+
+  input {
+    Array[File] vcfs
+    File gvcf_vcf
+    Array[File] gvcfs
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== DeepVariant HPC Validation Report ===" > validation_report.txt
+    echo "" >> validation_report.txt
+
+    validation_passed=true
+
+    for vcf in ~{sep=' ' vcfs}; do
+      records=$(zcat "${vcf}" | grep -vc "^#" || true)
+      echo "Sample VCF ${vcf}: ${records} variant records" >> validation_report.txt
+      if [ "${records}" -eq 0 ]; then
+        echo "WARNING: VCF ${vcf} has no variant records" >> validation_report.txt
+        validation_passed=false
+      fi
+    done
+
+    gvcf_vcf_records=$(zcat ~{gvcf_vcf} | grep -vc "^#" || true)
+    echo "gVCF-mode VCF variant records: ${gvcf_vcf_records}" >> validation_report.txt
+    if [ "${gvcf_vcf_records}" -eq 0 ]; then
+      echo "WARNING: gVCF-mode VCF has no variant records" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    gvcf_count=$(echo "~{sep=' ' gvcfs}" | wc -w)
+    echo "gVCF files produced: ${gvcf_count}" >> validation_report.txt
+    if [ "${gvcf_count}" -eq 0 ]; then
+      echo "WARNING: no gVCF files produced" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    echo "" >> validation_report.txt
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [ "${validation_passed}" = "true" ]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    cpu: 1
+    memory: "2 GB"
+  }
+}

--- a/modules/ww-deepvariant/ww-deepvariant.wdl
+++ b/modules/ww-deepvariant/ww-deepvariant.wdl
@@ -2,7 +2,7 @@
 ## Google's deep-learning-based germline variant caller for next-generation
 ## DNA sequencing data. Supports WGS, WES, PacBio, and ONT sequencing technologies.
 
-version 1.0
+version 1.2
 
 #### TASK DEFINITIONS ####
 
@@ -38,6 +38,7 @@ task run_deepvariant {
     model_type: "Sequencing model type: WGS, WES, PACBIO, ONT_R104, HYBRID_PACBIO_ILLUMINA, or MASSEQ"
     output_gvcf_enabled: "Whether to also produce a gVCF file for downstream joint genotyping"
     regions: "Optional genomic regions to restrict variant calling (e.g., chr1)"
+    gpu_enabled: "Enable GPU acceleration for the call_variants stage (uses the GPU-tagged DeepVariant image and requests GPU in runtime)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
   }
@@ -51,6 +52,7 @@ task run_deepvariant {
     String model_type = "WGS"
     Boolean output_gvcf_enabled = false
     String? regions
+    Boolean gpu_enabled = false
     Int cpu_cores = 8
     Int memory_gb = 32
   }
@@ -76,7 +78,10 @@ task run_deepvariant {
   }
 
   runtime {
-    docker: "google/deepvariant:1.10.0"
+    docker: if gpu_enabled then "google/deepvariant:1.10.0-gpu" else "google/deepvariant:1.10.0"
+    gpu: gpu_enabled
+    # For use in PROOF, switch to using the 'gpus' parameter
+    # gpus: if gpu_enabled then "1" else "0"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-esmfold/README.md
+++ b/modules/ww-esmfold/README.md
@@ -42,6 +42,8 @@ Predict protein 3D structures from amino acid sequences using ESMFold.
 
 ### Importing into Your Workflow
 
+The example below imports from `refs/heads/main`, which always points at the latest version of the module. For reproducible workflows, you can pin the import to a specific release tag (`refs/tags/v0.3.0`) or commit SHA (`<full-sha>`) by swapping `refs/heads/main` in the URL — just make sure the tag or commit you pin to actually contains this module.
+
 ```wdl
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-esmfold/ww-esmfold.wdl" as esmfold_tasks
 
@@ -144,6 +146,27 @@ This module uses the `getwilds/esmfold:2.0.0` container image, which includes:
 - `gpu_enabled`: Set to `true` for production use; `false` for testing
 - `chunk_size`: Reduce (64 or 32) for very long sequences to manage memory usage
 - `cpu_offload`: Enable for sequences that exceed GPU memory
+
+## GPU Execution Across Environments
+
+GPU scheduling is not standardized across WDL executors, so the way GPUs are requested in the `runtime` section depends on where the workflow is run. This module ships configured for the standard `gpu: Boolean` key under WDL 1.2, which works with recent versions of miniWDL, Sprocket, and Cromwell in cloud/local environments.
+
+For execution on the Fred Hutch HPC (PROOF), two modifications are required:
+
+1. **Downgrade the WDL version** from `version 1.2` to `version 1.0` at the top of `ww-esmfold.wdl`. PROOF's Cromwell configuration targets WDL 1.0.
+2. **Switch the runtime key** from `gpu` to `gpus` (an integer count) in the `esmfold_predict` task. The task already includes the alternate line as a comment for convenience:
+
+   ```wdl
+   runtime {
+     docker: "getwilds/esmfold:2.0.0"
+     # gpu: if gpu_enabled then true else false
+     gpus: if gpu_enabled then "1" else "0"
+     cpu: cpu_cores
+     memory: "~{memory_gb} GB"
+   }
+   ```
+
+If you're running on a different HPC or cloud backend, check that backend's documentation for its expected GPU runtime attribute — some engines also accept `gpuCount`, `gpuType`, or backend-specific keys via `hints`.
 
 ## Support and Feedback
 

--- a/modules/ww-esmfold/README.md
+++ b/modules/ww-esmfold/README.md
@@ -149,24 +149,24 @@ This module uses the `getwilds/esmfold:2.0.0` container image, which includes:
 
 ## GPU Execution Across Environments
 
-GPU scheduling is not standardized across WDL executors, so the way GPUs are requested in the `runtime` section depends on where the workflow is run. This module ships configured for the standard `gpu: Boolean` key under WDL 1.2, which works with recent versions of miniWDL, Sprocket, and Cromwell in cloud/local environments.
+GPU scheduling is not standardized across WDL executors, so the way GPUs are requested in the `runtime` section depends on where the workflow is run. This module ships configured for the standard `gpu: Boolean` key under WDL 1.2, which works with recent versions of miniWDL, Sprocket, and Cromwell in cloud/local environments — and with Sprocket on the Fred Hutch HPC.
 
-For execution on the Fred Hutch HPC (PROOF), two modifications are required:
+If you'd rather run through PROOF (the Fred Hutch point-and-click interface for Cromwell on HPC), two modifications are required because PROOF's Cromwell deployment targets WDL 1.0:
 
-1. **Downgrade the WDL version** from `version 1.2` to `version 1.0` at the top of `ww-esmfold.wdl`. PROOF's Cromwell configuration targets WDL 1.0.
-2. **Switch the runtime key** from `gpu` to `gpus` (an integer count) in the `esmfold_predict` task. The task already includes the alternate line as a comment for convenience:
+1. **Downgrade the WDL version** from `version 1.2` to `version 1.0` at the top of `ww-esmfold.wdl`.
+2. **Switch the runtime key** from `gpu` to `gpus` (an integer count passed as a string) in the `esmfold_predict` task. The task already includes the alternate line as a comment for convenience:
 
    ```wdl
    runtime {
      docker: "getwilds/esmfold:2.0.0"
-     # gpu: if gpu_enabled then true else false
+     # gpu: gpu_enabled
      gpus: if gpu_enabled then "1" else "0"
      cpu: cpu_cores
      memory: "~{memory_gb} GB"
    }
    ```
 
-If you're running on a different HPC or cloud backend, check that backend's documentation for its expected GPU runtime attribute — some engines also accept `gpuCount`, `gpuType`, or backend-specific keys via `hints`.
+If you're on Fred Hutch HPC and don't need the PROOF UI, you can keep the module as-is and submit via Sprocket. For other HPC or cloud backends, check that backend's documentation for its expected GPU runtime attribute — some engines also accept `gpuCount`, `gpuType`, or backend-specific keys via `hints`.
 
 ## Support and Feedback
 

--- a/modules/ww-esmfold/testrun_hpc.wdl
+++ b/modules/ww-esmfold/testrun_hpc.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.2
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata

--- a/modules/ww-esmfold/ww-esmfold.wdl
+++ b/modules/ww-esmfold/ww-esmfold.wdl
@@ -84,13 +84,10 @@ task esmfold_predict {
 
   runtime {
     docker: "getwilds/esmfold:2.0.0"
+    cpu: cpu_cores
+    gpu: gpu_enabled
     # For use in PROOF, switch to using the 'gpus' parameter
     # gpus: if gpu_enabled then "1" else "0"
-    cpu: cpu_cores
     memory: "~{memory_gb} GB"
-  }
-
-  hints {
-    gpu: gpu_enabled
   }
 }

--- a/modules/ww-esmfold/ww-esmfold.wdl
+++ b/modules/ww-esmfold/ww-esmfold.wdl
@@ -84,10 +84,13 @@ task esmfold_predict {
 
   runtime {
     docker: "getwilds/esmfold:2.0.0"
-    gpu: if gpu_enabled then true else false
     # For use in PROOF, switch to using the 'gpus' parameter
     # gpus: if gpu_enabled then "1" else "0"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
+  }
+
+  hints {
+    gpu: gpu_enabled
   }
 }

--- a/modules/ww-esmfold/ww-esmfold.wdl
+++ b/modules/ww-esmfold/ww-esmfold.wdl
@@ -4,7 +4,7 @@
 ## Designed to be a modular component within the WILDS ecosystem that can be used
 ## independently or integrated with other WILDS workflows.
 
-version 1.0
+version 1.2
 
 #### TASK DEFINITIONS ####
 
@@ -84,8 +84,10 @@ task esmfold_predict {
 
   runtime {
     docker: "getwilds/esmfold:2.0.0"
+    gpu: if gpu_enabled then true else false
+    # For use in PROOF, switch to using the 'gpus' parameter
+    # gpus: if gpu_enabled then "1" else "0"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
   }
 }

--- a/modules/ww-esmfold/ww-esmfold.wdl
+++ b/modules/ww-esmfold/ww-esmfold.wdl
@@ -5,6 +5,7 @@
 ## independently or integrated with other WILDS workflows.
 
 version 1.2
+# For use in PROOF, downgrade to version 1.0
 
 #### TASK DEFINITIONS ####
 

--- a/modules/ww-starling/README.md
+++ b/modules/ww-starling/README.md
@@ -27,7 +27,7 @@ Generate a structural ensemble for an intrinsically disordered protein sequence.
 - `sequence` (String): Amino acid sequence string for the disordered protein region
 - `sample_name` (String): Name identifier for the output files
 - `num_conformations` (Int, default=400): Number of conformations to generate in the ensemble
-- `gpu_enabled` (Boolean, default=true): Enable GPU for STARLING inference (sets device to cuda and requests GPU in runtime)
+- `gpu_enabled` (Boolean, default=true): Enable GPU for STARLING inference (sets device to cuda and requests GPU in runtime). See [GPU Execution Across Environments](#gpu-execution-across-environments) for backend-specific configuration.
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
 
@@ -43,7 +43,7 @@ Generate structural ensembles for multiple protein sequences from a FASTA file.
 **Inputs:**
 - `fasta_file` (File): FASTA file containing one or more protein sequences
 - `num_conformations` (Int, default=400): Number of conformations to generate per sequence in the ensemble
-- `gpu_enabled` (Boolean, default=true): Enable GPU for STARLING inference (sets device to cuda and requests GPU in runtime)
+- `gpu_enabled` (Boolean, default=true): Enable GPU for STARLING inference (sets device to cuda and requests GPU in runtime). See [GPU Execution Across Environments](#gpu-execution-across-environments) for backend-specific configuration.
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
 
@@ -81,6 +81,8 @@ Query metadata and summary information from a STARLING ensemble file.
 ## Usage as a Module
 
 ### Importing into Your Workflow
+
+The example below imports from `refs/heads/main`, which always points at the latest version of the module. For reproducible workflows, you can pin the import to a specific release tag (`refs/tags/v0.3.0`) or commit SHA (`<full-sha>`) by swapping `refs/heads/main` in the URL — just make sure the tag or commit you pin to actually contains this module.
 
 ```wdl
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-starling/ww-starling.wdl" as starling_tasks
@@ -180,6 +182,31 @@ This module uses the `getwilds/starling:2.0.0a3` container image, which should i
 - `cpu_cores`: Increase for longer sequences or larger ensembles
 - `memory_gb`: Increase for very long disordered regions (>200 residues)
 - `num_conformations`: More conformations provide better sampling but take longer
+
+## GPU Execution Across Environments
+
+The `gpu_enabled` input controls two things in the GPU-using tasks (`generate_ensemble` and `generate_ensemble_batch`):
+1. **STARLING device selection**: When `true`, passes `-d cuda` to STARLING; when `false`, passes `-d cpu`.
+2. **WDL runtime GPU attribute**: Translates to the standard `gpu: Boolean` key in the `runtime` block.
+
+GPU scheduling is not standardized across WDL executors, so the way GPUs are requested in the `runtime` section depends on where the workflow is run. This module ships configured for the standard `gpu: Boolean` key under WDL 1.2, which works with recent versions of miniWDL, Sprocket, and Cromwell in cloud/local environments — and with Sprocket on the Fred Hutch HPC.
+
+If you'd rather run through PROOF (the Fred Hutch point-and-click interface for Cromwell on HPC), two modifications are required because PROOF's Cromwell deployment targets WDL 1.0:
+
+1. **Downgrade the WDL version** from `version 1.2` to `version 1.0` at the top of `ww-starling.wdl`.
+2. **Switch the runtime key** from `gpu` to `gpus` (an integer count passed as a string) in both `generate_ensemble` and `generate_ensemble_batch`. Each task already includes the alternate line as a comment for convenience:
+
+   ```wdl
+   runtime {
+     docker: "getwilds/starling:2.0.0a3"
+     # gpu: gpu_enabled
+     gpus: if gpu_enabled then "1" else "0"
+     cpu: cpu_cores
+     memory: "~{memory_gb} GB"
+   }
+   ```
+
+If you're on Fred Hutch HPC and don't need the PROOF UI, you can keep the module as-is and submit via Sprocket. For other HPC or cloud backends, check that backend's documentation for its expected GPU runtime attribute — some engines also accept `gpuCount`, `gpuType`, or backend-specific keys via `hints`.
 
 ## Contributing
 

--- a/modules/ww-starling/testrun.wdl
+++ b/modules/ww-starling/testrun.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.2
 
 # Import module under test and testdata module using relative paths for local development
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-starling/ww-starling.wdl" as ww_starling

--- a/modules/ww-starling/testrun_hpc.wdl
+++ b/modules/ww-starling/testrun_hpc.wdl
@@ -4,8 +4,8 @@ version 1.2
 # enabled on the inference tasks and the module's default 400 conformations
 # — intended to validate end-to-end behavior on Fred Hutch HPC infrastructure.
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-starling/ww-starling.wdl" as ww_starling
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/wdl-v1.2-support/modules/ww-starling/ww-starling.wdl" as ww_starling
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-starling/testrun_hpc.wdl
+++ b/modules/ww-starling/testrun_hpc.wdl
@@ -1,0 +1,149 @@
+version 1.0
+
+# HPC test workflow for ww-starling. Mirrors testrun.wdl coverage with GPU
+# enabled on the inference tasks and the module's default 400 conformations
+# — intended to validate end-to-end behavior on Fred Hutch HPC infrastructure.
+
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-starling/ww-starling.wdl" as ww_starling
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+
+#### TEST WORKFLOW DEFINITION ####
+
+workflow starling_example {
+  # p53 N-terminal transactivation domain (residues 1-39) — a well-studied IDP
+  String test_sequence = "MEEPQSDPSVEPPLSQETFSDLWKLLPENNVLSPLPSQA"
+
+  # Single-sequence ensemble generation on GPU
+  call ww_starling.generate_ensemble { input:
+    sequence = test_sequence,
+    sample_name = "test_p53_ntad",
+    num_conformations = 400,
+    gpu_enabled = true,
+    cpu_cores = 4,
+    memory_gb = 8
+  }
+
+  # Ensemble metadata query (CPU-only task)
+  call ww_starling.ensemble_info { input:
+    starling_file = generate_ensemble.starling_file,
+    sample_name = "test_p53_ntad"
+  }
+
+  # Multi-sequence batch ensemble generation on GPU
+  call ww_testdata.create_test_idp_fasta { }
+
+  call ww_starling.generate_ensemble_batch { input:
+    fasta_file = create_test_idp_fasta.test_fasta,
+    num_conformations = 400,
+    gpu_enabled = true,
+    cpu_cores = 4,
+    memory_gb = 8
+  }
+
+  # FASTA splitting (CPU-only task)
+  call ww_starling.split_fasta { input:
+    fasta_file = create_test_idp_fasta.test_fasta,
+    sequences_per_batch = 2
+  }
+
+  call validate_outputs { input:
+      starling_file = generate_ensemble.starling_file,
+      pdb_file = generate_ensemble.pdb_file,
+      xtc_file = generate_ensemble.xtc_file,
+      info_file = ensemble_info.info_file,
+      batch_starling_files = generate_ensemble_batch.starling_files,
+      split_batch_files = split_fasta.batch_files
+  }
+
+  output {
+    File starling_file = generate_ensemble.starling_file
+    File pdb_file = generate_ensemble.pdb_file
+    File xtc_file = generate_ensemble.xtc_file
+    File info_file = ensemble_info.info_file
+    Array[File] batch_starling_files = generate_ensemble_batch.starling_files
+    Array[File] batch_pdb_files = generate_ensemble_batch.pdb_files
+    Array[File] batch_xtc_files = generate_ensemble_batch.xtc_files
+    Array[File] split_batch_files = split_fasta.batch_files
+    File validation_report = validate_outputs.report
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that STARLING produced expected ensemble, conversion, info, and split outputs"
+    outputs: {
+        report: "Validation report summarizing file checks"
+    }
+  }
+
+  parameter_meta {
+    starling_file: "STARLING ensemble file from single-sequence generate_ensemble"
+    pdb_file: "PDB topology file from single-sequence generate_ensemble"
+    xtc_file: "XTC trajectory file from single-sequence generate_ensemble"
+    info_file: "Metadata file from ensemble_info"
+    batch_starling_files: "Array of STARLING ensemble files from generate_ensemble_batch"
+    split_batch_files: "Array of FASTA batch files from split_fasta"
+  }
+
+  input {
+    File starling_file
+    File pdb_file
+    File xtc_file
+    File info_file
+    Array[File] batch_starling_files
+    Array[File] split_batch_files
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== STARLING HPC Validation Report ===" > validation_report.txt
+    echo "" >> validation_report.txt
+
+    validation_passed=true
+
+    for f in ~{starling_file} ~{pdb_file} ~{xtc_file} ~{info_file}; do
+      if [ -s "${f}" ]; then
+        echo "OK: ${f} ($(wc -c < "${f}") bytes)" >> validation_report.txt
+      else
+        echo "MISSING/EMPTY: ${f}" >> validation_report.txt
+        validation_passed=false
+      fi
+    done
+
+    batch_count=$(echo "~{sep=' ' batch_starling_files}" | wc -w)
+    echo "Batch ensemble files produced: ${batch_count}" >> validation_report.txt
+    if [ "${batch_count}" -eq 0 ]; then
+      echo "WARNING: no batch ensemble files produced" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    split_count=$(echo "~{sep=' ' split_batch_files}" | wc -w)
+    echo "FASTA batch files produced: ${split_count}" >> validation_report.txt
+    if [ "${split_count}" -eq 0 ]; then
+      echo "WARNING: no FASTA batch files produced" >> validation_report.txt
+      validation_passed=false
+    fi
+
+    echo "" >> validation_report.txt
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [ "${validation_passed}" = "true" ]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    cpu: 1
+    memory: "2 GB"
+  }
+}

--- a/modules/ww-starling/testrun_hpc.wdl
+++ b/modules/ww-starling/testrun_hpc.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.2
 
 # HPC test workflow for ww-starling. Mirrors testrun.wdl coverage with GPU
 # enabled on the inference tasks and the module's default 400 conformations

--- a/modules/ww-starling/ww-starling.wdl
+++ b/modules/ww-starling/ww-starling.wdl
@@ -3,7 +3,7 @@
 ## disordered protein regions using a latent-space probabilistic denoising
 ## diffusion model with a Vision Transformer architecture.
 
-version 1.0
+version 1.2
 
 #### TASK DEFINITIONS ####
 
@@ -76,9 +76,11 @@ task generate_ensemble {
 
   runtime {
     docker: "getwilds/starling:2.0.0a3"
+    gpu: gpu_enabled
+    # For use in PROOF, switch to using the 'gpus' parameter
+    # gpus: if gpu_enabled then "1" else "0"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
   }
 }
 
@@ -150,9 +152,11 @@ task generate_ensemble_batch {
 
   runtime {
     docker: "getwilds/starling:2.0.0a3"
+    gpu: gpu_enabled
+    # For use in PROOF, switch to using the 'gpus' parameter
+    # gpus: if gpu_enabled then "1" else "0"
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
   }
 }
 

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -1418,6 +1418,49 @@ FASTA
   }
 }
 
+task create_realistic_protein_fasta {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Create a single-domain protein FASTA file (human ubiquitin, 76 residues) for realistic structure-prediction tests on HPC"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
+    outputs: {
+        test_fasta: "FASTA file containing a realistic single-domain test protein (human ubiquitin, UniProt P0CG48 residues 1-76)"
+    }
+  }
+
+  parameter_meta {
+    cpu_cores: "Number of CPU cores to use"
+    memory_gb: "Memory allocation in GB for the task"
+  }
+
+  input {
+    Int cpu_cores = 1
+    Int memory_gb = 2
+  }
+
+  command <<<
+    set -eo pipefail
+
+    # Human ubiquitin (76 residues, UniProt P0CG48 residues 1-76) - canonical
+    # single-domain benchmark protein; folds in seconds on a single GPU.
+    cat > test_protein.fasta <<'FASTA'
+>test_ubiquitin
+MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG
+FASTA
+  >>>
+
+  output {
+    File test_fasta = "test_protein.fasta"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}
+
 task download_glimpse2_genetic_map {
   meta {
     author: "Taylor Firman"

--- a/pipelines/ww-leukemia/testrun_hpc.wdl
+++ b/pipelines/ww-leukemia/testrun_hpc.wdl
@@ -1,0 +1,99 @@
+version 1.0
+
+# HPC variant of the ww-leukemia pipeline testrun. Mirrors testrun.wdl but
+# runs the full pipeline including annotation steps (skip_annotations = false).
+# CI/CD on GitHub runners cannot pull the large annotation Docker images, so
+# this end-to-end variant is intended to be exercised on Fred Hutch HPC
+# infrastructure (Sprocket or PROOF).
+
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
+
+workflow leukemia_test {
+  # Download test reference data
+  call ww_testdata.download_ref_data { }
+
+  # Download test CRAM data
+  call ww_testdata.download_cram_data {
+    input:
+      ref_fasta = download_ref_data.fasta
+  }
+
+  # Download GATK resource files
+  call ww_testdata.download_dbsnp_vcf {
+    input:
+      region = "chr1:1-50000000",
+      filter_name = "chr1"
+  }
+
+  call ww_testdata.download_known_indels_vcf {
+    input:
+      region = "chr1:1-50000000",
+      filter_name = "chr1"
+  }
+
+  call ww_testdata.download_gnomad_vcf {
+    input:
+      region = "chr1:1-50000000",
+      filter_name = "chr1"
+  }
+
+  # Download ichorCNA reference data
+  call ww_testdata.download_ichor_data { }
+
+  # Call the leukemia workflow with test data, running the full annotation pipeline
+  call leukemia.ww_leukemia {
+    input:
+      ref_fasta = download_ref_data.fasta,
+      ref_fasta_index = download_ref_data.fasta_index,
+      ref_dict = download_ref_data.dict,
+      dbsnp_vcf = download_dbsnp_vcf.dbsnp_vcf,
+      af_only_gnomad = download_gnomad_vcf.gnomad_vcf,
+      wig_gc = download_ichor_data.wig_gc,
+      wig_map = download_ichor_data.wig_map,
+      panel_of_norm_rds = download_ichor_data.panel_of_norm_rds,
+      centromeres = download_ichor_data.centromeres,
+      known_indels_sites_vcfs = [download_known_indels_vcf.known_indels_vcf],
+      samples = [
+        object {
+          name: "test_sample",
+          cramfiles: [download_cram_data.cram]
+        }
+      ],
+      ref_name = "hg38",
+      annovar_protocols = "refGene",
+      annovar_operation = "g",
+      # ichorCNA chromosome settings for chr1-only test data
+      ichorcna_chromosomes = ["chr1"],
+      ichorcna_chrs_string = "c('1')",
+      # Testing-friendly resource settings
+      scatter_count = 2,  # Small scatter for testing
+      high_intensity_cpus = 2,  # Reduced from production default of 8
+      high_intensity_memory_gb = 4,  # Reduced from production default of 16
+      standard_cpus = 2,  # Reduced from production default of 4
+      standard_memory_gb = 4,  # Reduced from production default of 8
+      # Run full annotation pipeline (CI/CD skips this due to Docker image size)
+      skip_annotations = false
+  }
+
+  output {
+    # Core variant calling outputs
+    Array[File] haplotype_vcf = ww_leukemia.haplotype_vcf
+    Array[File] mutect_vcf = ww_leukemia.mutect_vcf
+    Array[File] mpileup_vcf = ww_leukemia.mpileup_vcf
+    Array[File] manta_sv_vcf = ww_leukemia.manta_sv_vcf
+    Array[File] ichorcna_genomewide_pdf = ww_leukemia.ichorcna_genomewide_pdf
+
+    # Annotation outputs (populated when skip_annotations = false)
+    Array[File] mutect_annotated_vcf = ww_leukemia.mutect_annotated_vcf
+    Array[File] mutect_annotated_table = ww_leukemia.mutect_annotated_table
+    Array[File] haplotype_annotated_vcf = ww_leukemia.haplotype_annotated_vcf
+    Array[File] haplotype_annotated_table = ww_leukemia.haplotype_annotated_table
+    Array[File] mpileup_annotated_vcf = ww_leukemia.mpileup_annotated_vcf
+    Array[File] mpileup_annotated_table = ww_leukemia.mpileup_annotated_table
+    Array[File] consensus_variants = ww_leukemia.consensus_variants
+    Array[File] manta_sv_annotated_tsv = ww_leukemia.manta_sv_annotated_tsv
+    Array[File] smoove_sv_annotated_tsv = ww_leukemia.smoove_sv_annotated_tsv
+    Array[File] delly_sv_annotated_tsv = ww_leukemia.delly_sv_annotated_tsv
+  }
+}

--- a/pipelines/ww-leukemia/testrun_hpc.wdl
+++ b/pipelines/ww-leukemia/testrun_hpc.wdl
@@ -6,8 +6,8 @@ version 1.0
 # this end-to-end variant is intended to be exercised on Fred Hutch HPC
 # infrastructure (Sprocket or PROOF).
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
 
 workflow leukemia_test {
   # Download test reference data

--- a/pipelines/ww-starling-batch/testrun_hpc.wdl
+++ b/pipelines/ww-starling-batch/testrun_hpc.wdl
@@ -1,0 +1,28 @@
+version 1.0
+
+# HPC variant of the ww-starling-batch pipeline testrun. Mirrors testrun.wdl
+# but enables GPU on the underlying STARLING calls and uses the module's
+# default 400 conformations — intended to validate end-to-end behavior on
+# Fred Hutch HPC infrastructure (Sprocket or PROOF).
+
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/pipelines/ww-starling-batch/ww-starling-batch.wdl" as starling_batch_workflow
+
+workflow starling_batch_example {
+  call ww_testdata.create_test_idp_fasta { }
+
+  call starling_batch_workflow.starling_batch { input:
+    fasta_file = create_test_idp_fasta.test_fasta,
+    sequences_per_batch = 2,
+    num_conformations = 400,
+    gpu_enabled = true,
+    cpu_cores = 4,
+    memory_gb = 8
+  }
+
+  output {
+    Array[Array[File]] starling_files = starling_batch.starling_files
+    Array[Array[File]] pdb_files = starling_batch.pdb_files
+    Array[Array[File]] xtc_files = starling_batch.xtc_files
+  }
+}

--- a/pipelines/ww-starling-batch/testrun_hpc.wdl
+++ b/pipelines/ww-starling-batch/testrun_hpc.wdl
@@ -5,8 +5,8 @@ version 1.0
 # default 400 conformations — intended to validate end-to-end behavior on
 # Fred Hutch HPC infrastructure (Sprocket or PROOF).
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/split-cicd-hpc-testruns/pipelines/ww-starling-batch/ww-starling-batch.wdl" as starling_batch_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-starling-batch/ww-starling-batch.wdl" as starling_batch_workflow
 
 workflow starling_batch_example {
   call ww_testdata.create_test_idp_fasta { }


### PR DESCRIPTION
## Type of Change

- WDL v1.2 adoption for GPU-enabled modules
- New testing convention: separate `testrun_hpc.wdl` files for HPC-only test runs
- Module update (`ww-cellranger` HPC execution strategies)
- New `ww-testdata` task (`create_realistic_protein_fasta`)
- CI/infrastructure changes (discovery script, Makefile, Sprocket HPC config)
- Documentation update

## Description

This branch introduces a clean split between CI/CD test workflows and HPC test workflows, and migrates GPU-enabled modules to WDL v1.2 so they can express GPU requirements in a portable, engine-supported way.

**WDL v1.2 GPU runtime convention.** [`ww-clair3`](modules/ww-clair3/ww-clair3.wdl), [`ww-colabfold`](modules/ww-colabfold/ww-colabfold.wdl), [`ww-deepvariant`](modules/ww-deepvariant/ww-deepvariant.wdl), [`ww-esmfold`](modules/ww-esmfold/ww-esmfold.wdl), and [`ww-starling`](modules/ww-starling/ww-starling.wdl) now declare `version 1.2` and use the `gpu: Boolean` runtime key (with the `gpus: String` form left as a commented PROOF/Cromwell fallback). This is the form Sprocket understands natively for Slurm + Apptainer GPU scheduling.

**Dual test-workflow convention (`testrun.wdl` + `testrun_hpc.wdl`).** Some modules cannot run meaningfully on a GitHub Actions runner — they need a GPU, an HPC environment-module like `CellRanger/10.0.0`, or more memory than CI provides. Rather than excluding them from CI in a hard-coded list, modules and pipelines can now ship a `testrun_hpc.wdl` alongside (or instead of) `testrun.wdl`. Discovery rules:

| Files present | CI runs | HPC runs |
|---|---|---|
| `testrun.wdl` only | `testrun.wdl` | `testrun.wdl` |
| both | `testrun.wdl` | `testrun_hpc.wdl` |
| `testrun_hpc.wdl` only | skipped | `testrun_hpc.wdl` |

This is implemented in [`discover_wdls.py`](.github/scripts/discover_wdls.py) (now takes a `ci|hpc` target argument and the old `CI_EXCLUDED_ITEMS` list is gone), surfaced through `make run_sprocket TARGET=hpc` (and the equivalent for miniwdl/Cromwell), and documented in [CONTRIBUTING.md](.github/CONTRIBUTING.md), [modules/README.md](modules/README.md), and [pipelines/README.md](pipelines/README.md). HPC test workflows were added for `ww-clair3`, `ww-colabfold`, `ww-deepvariant`, `ww-starling`, `ww-cellranger`, `ww-esmfold` (which becomes HPC-only — its old `testrun.wdl` was renamed to `testrun_hpc.wdl`), plus the `ww-leukemia`, `ww-starling-batch`, and `ww-sra-cellranger` pipelines.

**CellRanger HPC execution strategies.** [`ww-cellranger`](modules/ww-cellranger/ww-cellranger.wdl) now exposes two engine-specific HPC tasks instead of a single `run_count_hpc`:
- `run_count_hpc_cromwell` — no `docker` runtime key, so Cromwell runs the task directly on the compute node where `module load CellRanger/10.0.0` works natively.
- `run_count_hpc_sprocket` — runs inside a minimal `getwilds/lua:5.3.6` container so the host's Lmod (bind-mounted in via the new [`sprocket-hpc.toml`](.github/configs/sprocket-hpc.toml) settings) can execute under Apptainer, while the licensed Cell Ranger binary itself is bind-mounted from the host. The new Sprocket config adds `--nv` for GPU, the bind mounts for `/app/lmod`, `/app/modules/all`, and `/app/software`, and default/GPU Slurm partitions.

[`ww-sra-cellranger`](pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl) was updated to pick the right HPC task based on the executor.

**New `ww-testdata` task: `create_realistic_protein_fasta`.** Human ubiquitin (UniProt P0CG48 residues 1-76) is the canonical "real but cheap" benchmark for protein structure-prediction tools — large enough to meaningfully exercise full inference paths (AMBER relaxation, multi-model averaging) but small enough to fold in seconds on a single GPU. The existing 20-residue Trp-cage from `create_test_protein_fasta` stays in place for CI; `ww-esmfold` and `ww-colabfold` HPC testruns use ubiquitin instead.

**CI compatibility shims.** [WOMtool validation](.github/workflows/linting.yml) and the miniwdl/Cromwell test-run jobs in [`testrun-reusable.yml`](.github/workflows/testrun-reusable.yml) now skip files declaring `version 1.2`, since neither engine supports it yet — Sprocket covers them in CI, and HPC runs use Sprocket as well.

**Housekeeping.** Moved [`cromwell.conf`](.github/configs/cromwell.conf) into `.github/configs/` alongside `sprocket-hpc.toml`. CellRanger HPC Sprocket task was downgraded to `getwilds/lua:5.3.6` (more reliable than the 5.4 image for this use case).

## Related Issue

<!-- placeholder -->

## Testing

**How did you test these changes?**

- Sprocket lint passes on all modified modules and pipelines (`make lint NAME=...`).
- CI/CD test runs (`testrun.wdl` via miniWDL, Cromwell, and Sprocket) pass for all modified items in GitHub Actions, with WDL 1.2 files correctly skipped by miniWDL/Cromwell/WOMtool and exercised by Sprocket.
- HPC test runs (`testrun_hpc.wdl` via Sprocket on Fred Hutch HPC) were used to validate the new dual-task CellRanger strategy, GPU runtime convention across `ww-clair3`/`ww-colabfold`/`ww-deepvariant`/`ww-esmfold`/`ww-starling`, and the new `create_realistic_protein_fasta` task.
- `ww-deepvariant`'s CI `testrun.wdl` was tuned down to avoid an OOM on the GitHub runner.

**What workflow engine did you use?**

- GitHub Actions CI: miniWDL, Cromwell, and Sprocket (Sprocket-only for v1.2 files).
- Fred Hutch HPC: Sprocket on Slurm + Apptainer using the new `sprocket-hpc.toml` config.

**Did the tests pass?**

Yes — both the CI matrix and the HPC test runs.

## Documentation

- [x] I updated the README (if applicable) — `modules/README.md`, `pipelines/README.md`, `.github/CONTRIBUTING.md`, plus per-module READMEs for every module/pipeline that gained a `testrun_hpc.wdl` or changed task names, and `ww-testdata/README.md` for the new task.
- [x] I added/updated parameter descriptions in the WDL (if applicable) — new `cellranger_module` parameter, `gpu_enabled`-driven runtime fields, and full `meta`/`parameter_meta` for `create_realistic_protein_fasta`.
- [ ] I ran `make docs-preview` to check documentation rendering (if applicable) — `.sprocketignore` updated to exclude `testrun_hpc.wdl` from doc builds; preview not re-run.

## Additional Context

- **WDL v1.2 is a one-way door for some engines.** Modules that move to `version 1.2` for the `gpu: Boolean` runtime key cannot be linted by WOMtool or executed by miniWDL/Cromwell today. The CI matrix handles this by skipping v1.2 files in those engines and relying on Sprocket — but downstream consumers running older engines should pin to a pre-v1.2 tag for affected modules until their engine catches up.
- **PROOF compatibility.** Each v1.2 runtime block keeps a commented `gpus: if gpu_enabled then "1" else "0"` line so PROOF users (which uses Cromwell-on-HPC) can downgrade to v1.0 with a one-line swap. The `ww-esmfold` header carries an explicit "downgrade to version 1.0 for PROOF" comment.
- **`run_count_hpc` was renamed, not deprecated.** Any external callers of `ww-cellranger.run_count_hpc` will need to choose between `run_count_hpc_cromwell` and `run_count_hpc_sprocket` — the old task no longer exists.
- **Sprocket HPC config has site-specific paths.** The bind mounts in `.github/configs/sprocket-hpc.toml` (`/app/lmod`, `/app/modules/all`, `/app/software`) and the partition names (`campus-new`) are Fred Hutch–specific defaults; the comments call this out for users adapting the config to their own HPC.