### PR TITLE
Follow up from `sprocket` version upgrade

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -242,7 +242,7 @@ sprocket lint \
   testrun.wdl
 
 # Test running (use testrun.wdl for execution tests)
-sprocket run testrun.wdl --entrypoint toolname_example
+sprocket run testrun.wdl
 miniwdl run testrun.wdl
 ```
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install Sprocket
         run: |
-          cargo-binstall sprocket --version 0.24.0 -y
+          cargo-binstall sprocket --version 0.25.0 -y
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -80,7 +80,7 @@ jobs:
       run: which shellcheck || sudo apt-get install -y shellcheck
     - 
       name: Sprocket Linting
-      uses: stjude-rust-labs/sprocket-action@v0.24.0
+      uses: stjude-rust-labs/sprocket-action@v0.25.0
       with:
         action: lint
 

--- a/.github/workflows/testrun-reusable.yml
+++ b/.github/workflows/testrun-reusable.yml
@@ -155,14 +155,11 @@ jobs:
     -
       name: Install Sprocket
       run: |
-        cargo-binstall sprocket --version 0.24.0 -y
-        cargo install --git https://github.com/getwilds/wdlparse --tag v0.0.5
+        cargo-binstall sprocket --version 0.25.0 -y
     -
       name: Run workflow with Sprocket
       run: |
         item_dir="${{ inputs.item_type }}/${{ matrix.item }}"
         wdl_file="$item_dir/testrun.wdl"
-        # Extract entrypoint from the WDL file
-        entrypoint=$(wdlparse parse --format json "$wdl_file" | jq -r '.wdl.workflows[].name')
-        echo "Running ${{ inputs.item_type }}/${{ matrix.item }} with Sprocket using entrypoint: $entrypoint"
-        sprocket run "$wdl_file" --target "$entrypoint"
+        echo "Running ${{ inputs.item_type }}/${{ matrix.item }} with Sprocket"
+        sprocket run "$wdl_file"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WOMTOOL_JAR ?= womtool-$(WOMTOOL).jar
 CROMWELL ?= 92
 CROMWELL_JAR ?= cromwell-$(CROMWELL).jar
 MINIWDL ?= 1.13.0
-SPROCKET_MIN ?= 0.22.0
+SPROCKET_MIN ?= 0.25.0
 SPROCKET_CONFIG ?=
 SPROCKET_CONFIG_FLAG := $(if $(SPROCKET_CONFIG),-c $(SPROCKET_CONFIG),)
 TYPE ?= all
@@ -164,12 +164,10 @@ run_sprocket: check_sprocket check_name ## Run sprocket on testrun.wdl files (us
 		if [ -d "$$dir" ] && [ -f "$$dir/testrun.wdl" ]; then \
 			name=$$(basename $$dir); \
 			echo "... Running $$name"; \
-			entrypoint=$$(grep '^workflow ' "$$dir/testrun.wdl" | awk '{print $$2}' | tr -d '{'); \
-			echo "... Using entrypoint: $$entrypoint"; \
 			attempt=1; passed=0; \
 			while [ $$attempt -le $$max_attempts ]; do \
 				if [ $$attempt -gt 1 ]; then echo "[retry] Attempt $$attempt/$$max_attempts for $$name"; fi; \
-				if sprocket run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl" --target $$entrypoint; then \
+				if sprocket run $(SPROCKET_CONFIG_FLAG) "$$dir/testrun.wdl"; then \
 					passed=1; break; \
 				fi; \
 				attempt=$$((attempt + 1)); \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ curl -O https://raw.githubusercontent.com/getwilds/wilds-wdl-library/main/pipeli
 # Option 2: Download directly from GitHub by navigating to the file and clicking the download button
 
 # Modify inputs.json as necessary for your data, then run via the command line or PROOF's point-and-click interface
-sprocket run ww-sra-star.wdl inputs.json
+sprocket run ww-sra-star.wdl @inputs.json
 ```
 
 ### Using the Full Repository
@@ -72,7 +72,7 @@ sprocket run testrun.wdl
 
 # Run a pipeline (modify inputs.json as necessary)
 cd ../../pipelines/ww-sra-star
-sprocket run ww-sra-star.wdl inputs.json
+sprocket run ww-sra-star.wdl @inputs.json
 ```
 
 ### Importing into Your Workflows

--- a/docs-README.md
+++ b/docs-README.md
@@ -71,7 +71,7 @@ curl -O https://raw.githubusercontent.com/getwilds/wilds-wdl-library/main/pipeli
 # Option 2: Download directly from GitHub by navigating to the file and clicking the download button
 
 # Modify inputs.json as necessary for your data, then run via the command line or PROOF's point-and-click interface
-sprocket run ww-sra-star.wdl inputs.json
+sprocket run ww-sra-star.wdl @inputs.json
 ```
 
 ### Running Components Locally
@@ -89,7 +89,7 @@ sprocket run testrun.wdl
 
 # Run a pipeline (modify inputs.json as necessary)
 cd ../../pipelines/ww-sra-star
-sprocket run ww-sra-star.wdl inputs.json
+sprocket run ww-sra-star.wdl @inputs.json
 ```
 
 ---

--- a/modules/ww-annotsv/README.md
+++ b/modules/ww-annotsv/README.md
@@ -90,7 +90,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint annotsv_example
+sprocket run testrun.wdl
 ```
 
 ## Configuration Guidelines

--- a/modules/ww-annovar/README.md
+++ b/modules/ww-annovar/README.md
@@ -81,7 +81,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint annovar_example
+sprocket run testrun.wdl
 ```
 
 ## Annotation Configuration

--- a/modules/ww-aws-sso/README.md
+++ b/modules/ww-aws-sso/README.md
@@ -242,7 +242,7 @@ The `aws_sso_example` test workflow requires no input parameters and automatical
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint aws_sso_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-bcftools/README.md
+++ b/modules/ww-bcftools/README.md
@@ -119,7 +119,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint bcftools_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically downloads test data using the `ww-testdata` module and runs variant calling without requiring any input parameters.

--- a/modules/ww-bedparse/README.md
+++ b/modules/ww-bedparse/README.md
@@ -115,7 +115,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint bedparse_example
+sprocket run testrun.wdl
 ```
 
 The test workflow:

--- a/modules/ww-bedtools/README.md
+++ b/modules/ww-bedtools/README.md
@@ -147,7 +147,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint bedtools_example
+sprocket run testrun.wdl
 ```
 
 ### Automatic Test Data

--- a/modules/ww-bowtie/README.md
+++ b/modules/ww-bowtie/README.md
@@ -118,7 +118,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint bowtie_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-bowtie2/README.md
+++ b/modules/ww-bowtie2/README.md
@@ -156,7 +156,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint bowtie2_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -116,7 +116,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint bwa_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:

--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -155,7 +155,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint clair3_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-colabfold/README.md
+++ b/modules/ww-colabfold/README.md
@@ -172,7 +172,7 @@ The module includes a test workflow (`testrun.wdl`) that downloads weights and p
 miniwdl run modules/ww-colabfold/testrun.wdl
 
 # Using Sprocket
-sprocket run modules/ww-colabfold/testrun.wdl --entrypoint colabfold_example
+sprocket run modules/ww-colabfold/testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run modules/ww-colabfold/testrun.wdl

--- a/modules/ww-consensus/README.md
+++ b/modules/ww-consensus/README.md
@@ -84,7 +84,7 @@ java -jar cromwell.jar run testrun.wdl -i inputs-test.json
 miniwdl run testrun.wdl -i inputs-test.json
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint consensus_example -i inputs-test.json
+sprocket run testrun.wdl @inputs-test.json
 ```
 
 Note: Testing requires annotated variant tables from the three callers as input.

--- a/modules/ww-consensus/README.md
+++ b/modules/ww-consensus/README.md
@@ -78,16 +78,14 @@ The module includes a test workflow that demonstrates the consensus processing t
 
 ```bash
 # Using Cromwell
-java -jar cromwell.jar run testrun.wdl -i inputs-test.json
+java -jar cromwell.jar run testrun.wdl
 
 # Using miniWDL
-miniwdl run testrun.wdl -i inputs-test.json
+miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl @inputs-test.json
+sprocket run testrun.wdl
 ```
-
-Note: Testing requires annotated variant tables from the three callers as input.
 
 ## Input Requirements
 

--- a/modules/ww-deeptools/README.md
+++ b/modules/ww-deeptools/README.md
@@ -242,7 +242,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint deeptools_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-deepvariant/README.md
+++ b/modules/ww-deepvariant/README.md
@@ -128,7 +128,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint deepvariant_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-delly/README.md
+++ b/modules/ww-delly/README.md
@@ -132,7 +132,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint delly_example
+sprocket run testrun.wdl
 ```
 
 ### Automatic Test Data

--- a/modules/ww-deseq2/README.md
+++ b/modules/ww-deseq2/README.md
@@ -191,7 +191,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint deseq2_example
+sprocket run testrun.wdl
 ```
 
 ### Test Data Workflow

--- a/modules/ww-ena/README.md
+++ b/modules/ww-ena/README.md
@@ -251,7 +251,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint ena_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-esmfold/README.md
+++ b/modules/ww-esmfold/README.md
@@ -104,7 +104,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run on an HPC or
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint esmfold_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-fastp/README.md
+++ b/modules/ww-fastp/README.md
@@ -144,7 +144,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint fastp_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-gatk/README.md
+++ b/modules/ww-gatk/README.md
@@ -390,7 +390,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint gatk_example
+sprocket run testrun.wdl
 ```
 
 ### Test Data Workflow

--- a/modules/ww-gdc/README.md
+++ b/modules/ww-gdc/README.md
@@ -171,7 +171,7 @@ The module includes a test workflow ([testrun.wdl](testrun.wdl)) that demonstrat
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint gdc_client_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-glimpse2/README.md
+++ b/modules/ww-glimpse2/README.md
@@ -255,7 +255,7 @@ miniwdl run testrun.wdl
 java -jar cromwell.jar run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint glimpse2_example
+sprocket run testrun.wdl
 ```
 
 ### Custom Testing with Inputs

--- a/modules/ww-ichorcna/README.md
+++ b/modules/ww-ichorcna/README.md
@@ -134,7 +134,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint ichorcna_example
+sprocket run testrun.wdl
 ```
 
 ### Automatic Demo Mode

--- a/modules/ww-jcast/README.md
+++ b/modules/ww-jcast/README.md
@@ -121,7 +121,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 
 ```bash
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint jcast_example
+sprocket run testrun.wdl
 
 # Using miniWDL
 miniwdl run testrun.wdl

--- a/modules/ww-manta/README.md
+++ b/modules/ww-manta/README.md
@@ -116,7 +116,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint manta_example
+sprocket run testrun.wdl
 ```
 
 ### Automatic Test Data

--- a/modules/ww-multiqc/README.md
+++ b/modules/ww-multiqc/README.md
@@ -97,7 +97,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint multiqc_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-rmats-turbo/README.md
+++ b/modules/ww-rmats-turbo/README.md
@@ -226,7 +226,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 
 ```bash
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint rmats_turbo_example
+sprocket run testrun.wdl
 
 # Using miniWDL
 miniwdl run testrun.wdl

--- a/modules/ww-rseqc/README.md
+++ b/modules/ww-rseqc/README.md
@@ -138,7 +138,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 
 ```bash
 # Using Sprocket (recommended)
-sprocket run testrun.wdl --entrypoint rseqc_example
+sprocket run testrun.wdl
 
 # Using miniWDL
 miniwdl run testrun.wdl

--- a/modules/ww-samtools/README.md
+++ b/modules/ww-samtools/README.md
@@ -130,7 +130,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint samtools_example
+sprocket run testrun.wdl
 ```
 
 ## Requirements

--- a/modules/ww-shapemapper/README.md
+++ b/modules/ww-shapemapper/README.md
@@ -167,7 +167,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint shapemapper_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-sjl/README.md
+++ b/modules/ww-sjl/README.md
@@ -75,7 +75,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl --entrypoint sjl_example
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint sjl_example
+sprocket run testrun.wdl
 ```
 
 ## Reproducibility

--- a/modules/ww-spades/README.md
+++ b/modules/ww-spades/README.md
@@ -85,7 +85,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint spades_example
+sprocket run testrun.wdl
 ```
 
 ## Requirements

--- a/modules/ww-sra/README.md
+++ b/modules/ww-sra/README.md
@@ -112,7 +112,7 @@ The `sra_example` test workflow in `testrun.wdl` requires no input parameters an
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint sra_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-starling/README.md
+++ b/modules/ww-starling/README.md
@@ -138,7 +138,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint starling_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-template/README.md
+++ b/modules/ww-template/README.md
@@ -94,7 +94,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint template_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-trimgalore/README.md
+++ b/modules/ww-trimgalore/README.md
@@ -128,7 +128,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint trimgalore_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-tritonnp/README.md
+++ b/modules/ww-tritonnp/README.md
@@ -139,7 +139,7 @@ The module includes a test workflow ([testrun.wdl](testrun.wdl)) that automatica
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint tritonnp_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-umi-tools/README.md
+++ b/modules/ww-umi-tools/README.md
@@ -115,7 +115,7 @@ The module includes a test workflow (`testrun.wdl`) that runs end-to-end with no
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint umi_tools_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/modules/ww-viennarna/README.md
+++ b/modules/ww-viennarna/README.md
@@ -143,7 +143,7 @@ The module includes a test workflow (`testrun.wdl`) that can be run independentl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint viennarna_example
+sprocket run testrun.wdl
 
 # Using Cromwell
 java -jar cromwell.jar run testrun.wdl

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -84,7 +84,7 @@ curl -O https://raw.githubusercontent.com/getwilds/wilds-wdl-library/main/pipeli
 # Option 2: Download directly from GitHub by navigating to the file and clicking the download button
 
 # Modify inputs.json as necessary for your data, then run via the command line or PROOF's point-and-click interface
-sprocket run ww-sra-star.wdl inputs.json
+sprocket run ww-sra-star.wdl @inputs.json
 ```
 
 This works because all pipelines import modules using GitHub URLs, so your WDL executor fetches dependencies automatically.
@@ -124,7 +124,7 @@ cd pipelines/ww-sra-star
 
 # Run with your preferred executor using the example inputs.json as a starting point:
 # Sprocket
-sprocket run ww-sra-star.wdl inputs.json
+sprocket run ww-sra-star.wdl @inputs.json
 # Cromwell
 java -jar cromwell.jar run ww-sra-star.wdl --inputs inputs.json
 # miniWDL

--- a/pipelines/ww-bwa-gatk/README.md
+++ b/pipelines/ww-bwa-gatk/README.md
@@ -75,7 +75,7 @@ java -jar cromwell.jar run ww-bwa-gatk.wdl --inputs inputs.json --options option
 miniwdl run ww-bwa-gatk.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-bwa-gatk.wdl inputs.json
+sprocket run ww-bwa-gatk.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users

--- a/pipelines/ww-ena-star/README.md
+++ b/pipelines/ww-ena-star/README.md
@@ -81,7 +81,7 @@ java -jar cromwell.jar run ww-ena-star.wdl --inputs inputs.json --options option
 miniwdl run ww-ena-star.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-ena-star.wdl inputs.json
+sprocket run ww-ena-star.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users
@@ -199,7 +199,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint ena_star_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:

--- a/pipelines/ww-fastq-to-cram/README.md
+++ b/pipelines/ww-fastq-to-cram/README.md
@@ -86,7 +86,7 @@ java -jar cromwell.jar run ww-fastq-to-cram.wdl -i inputs.json
 miniwdl run ww-fastq-to-cram.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-fastq-to-cram.wdl -i inputs.json
+sprocket run ww-fastq-to-cram.wdl @inputs.json
 ```
 
 ### Running on Cirro

--- a/pipelines/ww-imputation/README.md
+++ b/pipelines/ww-imputation/README.md
@@ -102,7 +102,7 @@ java -jar cromwell.jar run ww-imputation.wdl --inputs inputs.json
 miniwdl run ww-imputation.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-imputation.wdl inputs.json
+sprocket run ww-imputation.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users

--- a/pipelines/ww-jetlag/README.md
+++ b/pipelines/ww-jetlag/README.md
@@ -81,7 +81,7 @@ java -jar cromwell.jar run ww-jetlag.wdl --inputs inputs.json
 miniwdl run ww-jetlag.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-jetlag.wdl inputs.json
+sprocket run ww-jetlag.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users
@@ -120,7 +120,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl --entrypoint jetlag_example
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint jetlag_example
+sprocket run testrun.wdl
 ```
 
 ## Acknowledgments

--- a/pipelines/ww-leukemia/README.md
+++ b/pipelines/ww-leukemia/README.md
@@ -97,7 +97,7 @@ java -jar cromwell.jar run ww-leukemia.wdl --inputs inputs.json --options option
 miniwdl run ww-leukemia.wdl -i inputs.json
 
 # Sprocket
-sprocket run ww-leukemia.wdl inputs.json
+sprocket run ww-leukemia.wdl @inputs.json
 ```
 
 ### Input Parameters
@@ -320,7 +320,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint leukemia_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:

--- a/pipelines/ww-proseq/README.md
+++ b/pipelines/ww-proseq/README.md
@@ -89,7 +89,7 @@ samtools faidx merged.fa
 miniwdl run ww-proseq.wdl --input inputs.json
 
 # Using Sprocket
-sprocket run ww-proseq.wdl --inputs inputs.json --entrypoint proseq
+sprocket run ww-proseq.wdl @inputs.json
 
 # Using Cromwell
 java -jar cromwell.jar run ww-proseq.wdl --inputs inputs.json
@@ -174,7 +174,7 @@ The `testrun.wdl` is zero-config:
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint proseq_example
+sprocket run testrun.wdl
 ```
 
 It:

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -162,7 +162,7 @@ java -jar cromwell.jar run ww-rnaseq.wdl --inputs inputs.json --options options.
 miniwdl run ww-rnaseq.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-rnaseq.wdl inputs.json
+sprocket run ww-rnaseq.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users
@@ -271,7 +271,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint rnaseq_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:

--- a/pipelines/ww-saturation/README.md
+++ b/pipelines/ww-saturation/README.md
@@ -111,7 +111,7 @@ java -jar cromwell.jar run ww-saturation.wdl --inputs inputs.json --options opti
 miniwdl run ww-saturation.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-saturation.wdl inputs.json
+sprocket run ww-saturation.wdl @inputs.json
 ```
 
 ### Running the Test Workflow

--- a/pipelines/ww-splicing-proteomics/README.md
+++ b/pipelines/ww-splicing-proteomics/README.md
@@ -116,7 +116,7 @@ java -jar cromwell.jar run ww-splicing-proteomics.wdl --inputs inputs.json --opt
 miniwdl run ww-splicing-proteomics.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-splicing-proteomics.wdl inputs.json
+sprocket run ww-splicing-proteomics.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users
@@ -259,7 +259,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint splicing_proteomics_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -89,7 +89,7 @@ java -jar cromwell.jar run ww-sra-cellranger.wdl --inputs inputs.json
 miniwdl run ww-sra-cellranger.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-sra-cellranger.wdl inputs.json
+sprocket run ww-sra-cellranger.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users
@@ -153,7 +153,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint sra_cellranger_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:

--- a/pipelines/ww-sra-salmon/README.md
+++ b/pipelines/ww-sra-salmon/README.md
@@ -84,7 +84,7 @@ java -jar cromwell.jar run ww-sra-salmon.wdl --inputs inputs.json --options opti
 miniwdl run ww-sra-salmon.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-sra-salmon.wdl inputs.json
+sprocket run ww-sra-salmon.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users
@@ -207,7 +207,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint sra_salmon_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:

--- a/pipelines/ww-sra-star/README.md
+++ b/pipelines/ww-sra-star/README.md
@@ -79,7 +79,7 @@ java -jar cromwell.jar run ww-sra-star.wdl --inputs inputs.json --options option
 miniwdl run ww-sra-star.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-sra-star.wdl inputs.json
+sprocket run ww-sra-star.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users
@@ -207,7 +207,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint sra_star_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:

--- a/pipelines/ww-star-deseq2/README.md
+++ b/pipelines/ww-star-deseq2/README.md
@@ -103,7 +103,7 @@ java -jar cromwell.jar run ww-star-deseq2.wdl --inputs inputs.json --options opt
 miniwdl run ww-star-deseq2.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-star-deseq2.wdl inputs.json
+sprocket run ww-star-deseq2.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users
@@ -210,7 +210,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint star_deseq2_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:

--- a/pipelines/ww-starling-batch/README.md
+++ b/pipelines/ww-starling-batch/README.md
@@ -67,7 +67,7 @@ java -jar cromwell.jar run ww-starling-batch.wdl --inputs inputs.json
 miniwdl run ww-starling-batch.wdl -i inputs.json
 
 # Using Sprocket
-sprocket run ww-starling-batch.wdl inputs.json
+sprocket run ww-starling-batch.wdl @inputs.json
 ```
 
 ### For Fred Hutch Users
@@ -118,7 +118,7 @@ java -jar cromwell.jar run testrun.wdl
 miniwdl run testrun.wdl
 
 # Using Sprocket
-sprocket run testrun.wdl --entrypoint starling_batch_example
+sprocket run testrun.wdl
 ```
 
 The test workflow automatically:


### PR DESCRIPTION
## Type of Change

- Documentation update
- Other: CI/Makefile maintenance (sprocket version bump + flag cleanup)

## Description

Bundles the remaining sprocket 0.22 → 0.25 upgrade tasks that were deferred from PR #350 (the `sprocket doc` post-processing cleanup), now that sprocket 0.25.0 is out. Three related changes, all downstream of the same version bump:

1. **Bump sprocket to 0.25.0 in lockstep** across local-dev and CI:
   - `Makefile`: `SPROCKET_MIN ?= 0.22.0` → `0.25.0`
   - `.github/workflows/build-docs.yml`: `cargo-binstall sprocket --version 0.24.0` → `0.25.0`
   - `.github/workflows/testrun-reusable.yml`: `cargo-binstall sprocket --version 0.24.0` → `0.25.0`
   - `.github/workflows/linting.yml`: `stjude-rust-labs/sprocket-action@v0.24.0` → `v0.25.0`

2. **Switch README examples to `@inputs.json` syntax.** Sprocket 0.24.0 made `@`-prefixed input files mandatory (to disambiguate from bare array values). All `sprocket run <wdl> inputs.json` examples are updated to `sprocket run <wdl> @inputs.json`. `pipelines/ww-fastq-to-cram` and `modules/ww-consensus` also had stale `-i inputs.json` forms — converted to the positional `@` form.

3. **Drop `--target` / `--entrypoint` from single-workflow invocations.** Sprocket 0.23.0 made `--target` optional when a document contains a single workflow (true for every `testrun.wdl` in this repo), and `--entrypoint` was already renamed to `--target` back in 0.21.0. Dropping the flag entirely is cleaner than keeping a name that's two releases stale.
   - `.github/workflows/testrun-reusable.yml`: removed the wdlparse install + entrypoint-extraction step; the Sprocket run step is now a one-liner.
   - `Makefile`: removed the `grep '^workflow ' ... awk` extraction in `run_sprocket`.
   - 41 README files (`.github/CONTRIBUTING.md`, all pipeline READMEs, all module READMEs that had `sprocket run testrun.wdl --entrypoint X_example` examples).

Refs: [sprocket 0.23 (optional `--target` for single-workflow docs)](https://github.com/stjude-rust-labs/sprocket/releases), [sprocket 0.24 (`@inputs.json` requirement)](https://github.com/stjude-rust-labs/sprocket/releases).

## Testing

**How did you test these changes?**

Spot-checked the modified Makefile target to confirm it still parses, and grepped the repo to verify no stale sprocket flags or version strings remained. 

Also manually kicked off a full run of the [modules](https://github.com/getwilds/wilds-wdl-library/actions/runs/26065795590) and [pipelines](https://github.com/getwilds/wilds-wdl-library/actions/runs/26065979182) test run workflows via GitHub Actions just in case.

CI will exercise the full multi-executor testrun matrix.

**What workflow engine did you use?**

Sprocket 0.25.0 (target version). CI will validate Cromwell, miniWDL, and Sprocket.

**Did the tests pass?**

Linting CI passes as seen below. Both test run GitHub Actions are in progress...

## Documentation

- [x] I updated the README (if applicable) — 41 READMEs touched for `sprocket run` example syntax
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~ N/A, no WDL changes
- [x] I ran `make docs` to check documentation rendering (if applicable)