### PR TITLE
Switching import URL's back to `main`

### DIFF
--- a/.github/scripts/hpc-testrun.sbatch
+++ b/.github/scripts/hpc-testrun.sbatch
@@ -47,7 +47,7 @@ REPO="getwilds/wilds-wdl-library"
 # ---- Environment setup ----
 # Update these module versions as needed for your HPC
 module purge
-module load sprocket/0.23.0 Apptainer/1.1.6 gh/2.86.0
+module load sprocket/0.25.0 Apptainer/1.1.6 gh/2.86.0
 
 # Apptainer cache and tmp directories — defaults under WORK_DIR so the cache
 # lives on the same filesystem as the run (avoids filling $HOME) and is scoped

--- a/modules/ww-cellranger/testrun_hpc.wdl
+++ b/modules/ww-cellranger/testrun_hpc.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-cellranger/ww-cellranger.wdl" as ww_cellranger
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellranger/ww-cellranger.wdl" as ww_cellranger
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC variant of the Cell Ranger testrun. Calls run_count_hpc_sprocket

--- a/modules/ww-esmfold/testrun_hpc.wdl
+++ b/modules/ww-esmfold/testrun_hpc.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC-only ESMFold test: predicts the structure of a small test protein.

--- a/pipelines/ww-leukemia/testrun_hpc.wdl
+++ b/pipelines/ww-leukemia/testrun_hpc.wdl
@@ -6,7 +6,7 @@ version 1.0
 # this end-to-end variant is intended to be exercised on Fred Hutch HPC
 # infrastructure (Sprocket or PROOF).
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
 
 workflow leukemia_test {

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
 
 struct RefGenome {
     String name

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 workflow sra_cellranger_example {
   # Download a small GEX reference for Cell Ranger

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC variant of the ww-sra-cellranger pipeline testrun. Dispatches via

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/hpc-testruns/modules/ww-cellranger/ww-cellranger.wdl" as cellranger_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellranger/ww-cellranger.wdl" as cellranger_tasks
 
 workflow sra_cellranger {
   meta {


### PR DESCRIPTION
## Type of Change

- Other: switching import URL's back to `main` after a recent PR
- Bug fix: upping Sprocket version in HPC test run sbatch, slipped through the cracks on the previous PR 🤦 

## Description

No functional change, just switching import URL's back to the `main` branch.
See GitHub Action test runs below just in case.