### PR TITLE
Adding initial draft of module manifest json's

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -151,7 +151,7 @@ For modules where CI execution is impractical (GPU-only tools, license-gated too
 - Specify exact image versions (avoid `latest` tags)
 - Document image dependencies in the README
 
-**Module manifest (`module.json`) — experimental:**
+**Module manifest (`module.json`), experimental:**
 
 You may notice `module.json` files in a handful of modules (currently `ww-bwa`, `ww-gatk`) and pipelines (`ww-bwa-gatk`). These are an early experiment with the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), which standardizes module metadata (name, version, license, upstream tool provenance, and dependency declarations). The format has been informally validated against Sprocket's `wdl-modules` crate by collaborators at St. Jude.
 
@@ -159,7 +159,7 @@ A few things to know:
 
 - **Contributors are not required to add `module.json` files.** No executor consumes them at runtime yet, and the upstream spec is still unmerged. We're keeping a small set of examples around so the library is ready when tooling support arrives.
 - **The schema is a moving target.** Field names and constraints may change before the spec is finalized.
-- **If you do add one**, license strings must use current [SPDX identifiers](https://spdx.org/licenses/) (e.g. `GPL-3.0-only`, not `GPL-3.0`) — the parser rejects deprecated forms.
+- **If you do add one**, license strings must use current [SPDX identifiers](https://spdx.org/licenses/) (e.g. `GPL-3.0-only`, not `GPL-3.0`). The parser rejects deprecated forms.
 
 ## Pipeline Development Guidelines
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -151,6 +151,15 @@ For modules where CI execution is impractical (GPU-only tools, license-gated too
 - Specify exact image versions (avoid `latest` tags)
 - Document image dependencies in the README
 
+**Module manifest (`module.json`) — experimental:**
+
+You may notice `module.json` files in a handful of modules (currently `ww-bwa`, `ww-gatk`) and pipelines (`ww-bwa-gatk`). These are an early experiment with the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), which standardizes module metadata (name, version, license, upstream tool provenance, and dependency declarations). The format has been informally validated against Sprocket's `wdl-modules` crate by collaborators at St. Jude.
+
+A few things to know:
+
+- **Contributors are not required to add `module.json` files.** No executor consumes them at runtime yet, and the upstream spec is still unmerged. We're keeping a small set of examples around so the library is ready when tooling support arrives.
+- **The schema is a moving target.** Field names and constraints may change before the spec is finalized.
+- **If you do add one**, license strings must use current [SPDX identifiers](https://spdx.org/licenses/) (e.g. `GPL-3.0-only`, not `GPL-3.0`) — the parser rejects deprecated forms.
 
 ## Pipeline Development Guidelines
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -51,7 +51,7 @@ modules/module-name/
 
 ### **Optional: `module.json` (Experimental)**
 
-In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), a small set of modules (currently `ww-bwa` and `ww-gatk`) ship a `module.json` declaring metadata like license, version, and upstream tool provenance. These manifests are informational only (no executor reads them at runtime today) and are not required for new modules. See the [contributing guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for details if you'd like to add one.
+In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), a small set of modules (currently `ww-bwa` and `ww-gatk`) ship a `module.json` declaring metadata like license, version, and upstream tool provenance. These manifests are informational only (no executor reads them at runtime today) and are not required for new modules. You may choose to ignore these. See the [contributing guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for details if you'd like to add one.
 
 ## Available Modules
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -51,7 +51,7 @@ modules/module-name/
 
 ### **Optional: `module.json` (Experimental)**
 
-In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), a small set of modules (currently `ww-bwa` and `ww-gatk`) ship a `module.json` declaring metadata like license, version, and upstream tool provenance. These manifests are informational only — no executor reads them at runtime today — and are not required for new modules. See the [contributing guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for details if you'd like to add one.
+In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), a small set of modules (currently `ww-bwa` and `ww-gatk`) ship a `module.json` declaring metadata like license, version, and upstream tool provenance. These manifests are informational only (no executor reads them at runtime today) and are not required for new modules. See the [contributing guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for details if you'd like to add one.
 
 ## Available Modules
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -39,6 +39,7 @@ modules/module-name/
 ├── module-name.wdl         # Main WDL file with task definitions
 ├── testrun.wdl             # Zero-configuration test workflow used in CI
 ├── testrun_hpc.wdl         # Optional HPC-only test workflow (see below)
+├── module.json             # Optional, experimental module manifest (see below)
 └── README.md               # Module-specific documentation
 ```
 
@@ -47,6 +48,10 @@ modules/module-name/
 - **WDL File**: Contains all task definitions for the module, each with `meta` and `parameter_meta` blocks for documentation. Tasks optionally include [EDAM ontology](https://www.ebi.ac.uk/ols4/ontologies/edam) tags and file input/output descriptors. See the [Contributing Guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for details.
 - **Test Workflow**: At least one of `testrun.wdl` (used in CI) or `testrun_hpc.wdl` (used in monthly HPC test runs). Most modules ship just `testrun.wdl`; modules whose tools require GPUs, an HPC environment module, or more memory than GitHub Actions provides may add a `testrun_hpc.wdl`, and modules that cannot run in CI at all may ship only `testrun_hpc.wdl` (e.g. `ww-esmfold`). See the [contributing guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for the full table of file combinations.
 - **README**: Module-specific documentation with usage examples
+
+### **Optional: `module.json` (Experimental)**
+
+In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), a small set of modules (currently `ww-bwa` and `ww-gatk`) ship a `module.json` declaring metadata like license, version, and upstream tool provenance. These manifests are informational only — no executor reads them at runtime today — and are not required for new modules. See the [contributing guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for details if you'd like to add one.
 
 ## Available Modules
 

--- a/modules/ww-bwa/module.json
+++ b/modules/ww-bwa/module.json
@@ -1,0 +1,27 @@
+{
+  "name": "ww-bwa",
+  "version": "0.2.0",
+  "license": "MIT",
+  "authors": ["Emma Bishop <ebishop@fredhutch.org>"],
+  "description": "WILDS WDL for sequence alignment using BWA-MEM",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-bwa.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "bwa",
+      "version": "0.7.17",
+      "license": "GPL-3.0",
+      "homepage": "https://github.com/lh3/bwa",
+      "doi": "10.1093/bioinformatics/btp324"
+    },
+    {
+      "name": "samtools",
+      "version": "1.11",
+      "license": "MIT",
+      "homepage": "https://www.htslib.org/",
+      "doi": "10.1093/gigascience/giab008"
+    }
+  ]
+}

--- a/modules/ww-bwa/module.json
+++ b/modules/ww-bwa/module.json
@@ -12,7 +12,7 @@
     {
       "name": "bwa",
       "version": "0.7.17",
-      "license": "GPL-3.0",
+      "license": "GPL-3.0-only",
       "homepage": "https://github.com/lh3/bwa",
       "doi": "10.1093/bioinformatics/btp324"
     },

--- a/modules/ww-gatk/module.json
+++ b/modules/ww-gatk/module.json
@@ -1,0 +1,37 @@
+{
+  "name": "ww-gatk",
+  "version": "0.2.0",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL for variant calling and BAM preprocessing using GATK4",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-gatk.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "gatk",
+      "version": "4.6.1.0",
+      "license": "Apache-2.0",
+      "homepage": "https://gatk.broadinstitute.org/",
+      "doi": "10.1101/gr.107524.110"
+    },
+    {
+      "name": "samtools",
+      "version": "1.20",
+      "license": "MIT",
+      "homepage": "https://www.htslib.org/",
+      "doi": "10.1093/gigascience/giab008"
+    },
+    {
+      "name": "htslib",
+      "version": "1.20",
+      "license": "MIT",
+      "homepage": "https://www.htslib.org/",
+      "doi": "10.1093/gigascience/giab007"
+    }
+  ]
+}

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -44,6 +44,7 @@ pipelines/pipeline-name/
 ├── testrun.wdl          # Zero-configuration test workflow used in CI
 ├── testrun_hpc.wdl      # Zero-configuration test workflow used in HPC (optional, see below)
 ├── inputs.json          # Example inputs for the complete pipeline
+├── module.json          # Optional, experimental module manifest (see below)
 └── README.md            # Pipeline-specific documentation
 ```
 
@@ -55,6 +56,7 @@ Pipelines follow the same `testrun.wdl` / `testrun_hpc.wdl` split as modules: mo
 - **Options JSON**: Workflow execution configuration for different WDL engines
 - **Additional Input Files**: Alternative inputs for different use cases
 - **Platform Configurations**: Platform-specific execution configs in subdirectories (e.g., `.cirro/` for Cirro platform integration)
+- **`module.json` (Experimental)**: In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), a small set of pipelines (currently `ww-bwa-gatk`) ship a `module.json` declaring metadata like license, version, and module dependencies. These manifests are informational only — no executor reads them at runtime today — and are not required for new pipelines. See the [contributing guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for details.
 
 ## Available Pipelines
 

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -56,7 +56,7 @@ Pipelines follow the same `testrun.wdl` / `testrun_hpc.wdl` split as modules: mo
 - **Options JSON**: Workflow execution configuration for different WDL engines
 - **Additional Input Files**: Alternative inputs for different use cases
 - **Platform Configurations**: Platform-specific execution configs in subdirectories (e.g., `.cirro/` for Cirro platform integration)
-- **`module.json` (Experimental)**: In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), a small set of pipelines (currently `ww-bwa-gatk`) ship a `module.json` declaring metadata like license, version, and module dependencies. These manifests are informational only — no executor reads them at runtime today — and are not required for new pipelines. See the [contributing guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for details.
+- **`module.json` (Experimental)**: In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), a small set of pipelines (currently `ww-bwa-gatk`) ship a `module.json` declaring metadata like license, version, and module dependencies. These manifests are informational only (no executor reads them at runtime today) and are not required for new pipelines. See the [contributing guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for details.
 
 ## Available Pipelines
 

--- a/pipelines/ww-bwa-gatk/module.json
+++ b/pipelines/ww-bwa-gatk/module.json
@@ -11,12 +11,12 @@
   "dependencies": {
     "ww_bwa": {
       "git": "https://github.com/getwilds/wilds-wdl-library",
-      "branch": "main",
+      "branch": "add-test-manifest-json",
       "path": "modules/ww-bwa"
     },
     "ww_gatk": {
       "git": "https://github.com/getwilds/wilds-wdl-library",
-      "branch": "main",
+      "branch": "add-test-manifest-json",
       "path": "modules/ww-gatk"
     }
   }

--- a/pipelines/ww-bwa-gatk/module.json
+++ b/pipelines/ww-bwa-gatk/module.json
@@ -11,12 +11,12 @@
   "dependencies": {
     "ww_bwa": {
       "git": "https://github.com/getwilds/wilds-wdl-library",
-      "branch": "add-test-manifest-json",
+      "branch": "main",
       "path": "modules/ww-bwa"
     },
     "ww_gatk": {
       "git": "https://github.com/getwilds/wilds-wdl-library",
-      "branch": "add-test-manifest-json",
+      "branch": "main",
       "path": "modules/ww-gatk"
     }
   }

--- a/pipelines/ww-bwa-gatk/module.json
+++ b/pipelines/ww-bwa-gatk/module.json
@@ -1,0 +1,23 @@
+{
+  "name": "ww-bwa-gatk",
+  "version": "0.2.0",
+  "license": "MIT",
+  "authors": ["Emma Bishop <ebishop@fredhutch.org>"],
+  "description": "WILDS WDL pipeline aligning sequencing reads with BWA-MEM and performing GATK preprocessing (mark duplicates + base recalibration)",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-bwa-gatk.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_bwa": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-bwa"
+    },
+    "ww_gatk": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-gatk"
+    }
+  }
+}


### PR DESCRIPTION
## Type of Change

- Documentation update (forward-looking metadata; no executor consumes these files yet)

## Description

Adds an initial draft of `module.json` manifest files for two modules (`ww-bwa`, `ww-gatk`) and one pipeline (`ww-bwa-gatk`), based on the proposed WDL v1.4 module manifest spec from [openwdl/wdl#765](https://github.com/openwdl/wdl/pull/765) and its [schema](https://github.com/openwdl/wdl/blob/bc24901ae562ffc551075bdeb128018ccf6ea9d1/modules/schemas/module.schema.json). Also adds short explanatory blurbs to `CONTRIBUTING.md`, `modules/README.md`, and `pipelines/README.md` so collaborators who notice the new files understand what they are and that they're not yet required.

This is intentionally scoped as a small experiment to feel out the pattern before any library-wide rollout — the spec is still unmerged upstream and no current executor (Sprocket, miniWDL, Cromwell) reads `module.json`. Goals of the experiment:

- Verify that nearly all fields the schema requires (`name`, `version`, `license`, `authors`, `description`, `tools`) can be populated from information already present in our `meta` blocks, READMEs, and pinned Docker tags.
- Stress-test the `tools` array on a multi-tool image (`ww-gatk` covers GATK 4.6.1.0, samtools 1.20, and htslib 1.20).
- Exercise the `dependencies` block in a real pipeline (`ww-bwa-gatk` declares `ww-bwa` and `ww-gatk`).

A few decisions worth flagging for reviewers:

- **Versioning:** All three manifests are tagged `0.2.0` to match the current library release. Individual modules aren't independently versioned today; lockstep with the library is the simplest placeholder pending a broader discussion of per-module semver.
- **Module self-containment:** Module manifests (`ww-bwa`, `ww-gatk`) declare no `dependencies` because the `ww-<tool>.wdl` source files themselves never import other modules — only `testrun.wdl` and pipelines compose. Testrun-only deps (e.g. `ww-testdata`) are deliberately omitted from the module manifest as a test-tooling concern, not a consumer concern.
- **Pipeline `dependencies` use `branch: main`:** This matches our current import-URL convention but is not reproducible per the spec's intent (which prefers `version` or `tag`). Captured as a known limitation for now.
- **Pipeline `tools` array omitted:** The pipeline composes modules that already declare their own upstream tools; the pipeline itself introduces none.
- **SPDX strictness:** License strings must use current SPDX identifiers (e.g. `GPL-3.0-only`, not `GPL-3.0`). Documented in CONTRIBUTING.md so future contributors don't hit the same bump.

## Testing

**How did you test these changes?**

These are static JSON metadata files — no executor consumes them yet. Validation was done in two layers:

1. **Hand check against the [draft schema](https://github.com/openwdl/wdl/blob/bc24901ae562ffc551075bdeb128018ccf6ea9d1/modules/schemas/module.schema.json):** all three required fields (`name`, `version`, `license`) are present, the `version` strings match the schema's semver pattern, dependency selectors satisfy the `oneOf` mutual-exclusion constraints, and dependency keys match `^[A-Za-z][A-Za-z0-9_]*$`.

2. **Parsed with Sprocket's `wdl-modules` crate** (the new module-manifest infrastructure from [Sprocket v0.25.0](https://github.com/stjude-rust-labs/sprocket/releases/tag/v0.25.0)). A small throwaway Rust binary calling `wdl_modules::Manifest::parse(bytes)` confirmed all three manifests parse cleanly. This caught a real bug: an initial draft used `"license": "GPL-3.0"` (a deprecated SPDX identifier) and the parser rejected it; fixed to `"GPL-3.0-only"`. The validation tool and a walkthrough are checked in under `notes/wdl-modules-check/` and `notes/ModuleManifestValidationHowTo.md` (for reference only — not wired into CI).

3. **Independent confirmation from St. Jude:** a collaborator at St. Jude (the team behind Sprocket and `wdl-modules`) tried our manifests against their own tooling and reported them as well-formed.

No WDL files were modified, so existing CI lint and testrun behavior is unchanged.

**What workflow engine did you use?**

N/A for execution — no engine consumes `module.json` at runtime yet. Sprocket's `wdl-modules` v0.1.1 was used for static manifest validation only.

**Did the tests pass?**

Yes — all three manifests parse cleanly via `wdl-modules` after the SPDX fix. Existing CI (sprocket / miniWDL / Cromwell testruns on unchanged WDL) should remain green.

## Documentation

- [x] I updated the README (if applicable) — added experimental-manifest sections to `modules/README.md` and `pipelines/README.md`
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~ -- not applicable; no WDL changes
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~ -- not applicable

Also added a new "Module manifest (`module.json`), experimental" subsection to `.github/CONTRIBUTING.md` so contributors understand what the files are, that they're not required, and which SPDX gotcha to avoid if they add one.

## Additional Context

- The manifest spec is **draft and unmerged upstream**. The schema's `$id` still points to the `feat/modules` branch. Treat this PR as a proof-of-concept, not a commitment to the final field shape.
- If we decide to roll this out library-wide, two upstream questions are blockers: (1) per-module vs lockstep versioning, and (2) source-of-truth between `module.json`, `meta` blocks, and `.dockstore.yml`.