### PR TITLE
Adding concurrency limit to Cromwell CI/CD config

### DIFF
--- a/.github/configs/cromwell.conf
+++ b/.github/configs/cromwell.conf
@@ -11,3 +11,17 @@ docker {
     method = "local"
   }
 }
+
+# GHA ubuntu-latest runners have 16 GB RAM. Cromwell's local backend ignores
+# the `memory` runtime attribute and will fire every independent sibling call
+# at once, which OOM-kills the runner on memory-heavy tools like STAR
+# (three concurrent two-pass alignments). Cap concurrency to 2.
+backend {
+  providers {
+    Local {
+      config {
+        concurrent-job-limit = 2
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Type of Change

- Bug fix (CI infrastructure)

## Description

The `ww-star` Cromwell CI job has been failing consistently with `Process completed with exit code 143` ("The runner has received a shutdown signal"), while the miniwdl and Sprocket jobs for the same module pass. The runner is being OOM-killed: `testrun.wdl` has three independent sibling calls (`align_two_pass`, `align_single_end`, `align_no_splice`) that Cromwell's local backend fires concurrently. Cromwell's local backend also ignores the `memory` runtime attribute (`Unrecognized runtime attribute keys: memory` in the log), so three STAR two-pass alignments end up running in parallel on a 16 GB `ubuntu-latest` runner and exceed available memory.

This PR adds a `concurrent-job-limit = 2` setting to the `Local` backend in [`.github/configs/cromwell.conf`](.github/configs/cromwell.conf), which caps how many tasks Cromwell will dispatch at once. miniwdl and Sprocket already throttle on the declared `cpu` runtime attribute, which is why they weren't affected.

The change applies to every module's Cromwell CI run, not just `ww-star`, so any future memory-heavy modules with parallel siblings get the same protection.

## Testing

**How did you test these changes?**
Manually triggered a test run of `ww-star` on this branch via the GitHub Action.
https://github.com/getwilds/wilds-wdl-library/actions/runs/26143572781/job/76893967312

**What workflow engine did you use?**
Cromwell (v92) via GitHub Actions.

**Did the tests pass?**
Yes, Cromwell CI/CD now succeeds with ww-star using the max concurrency of 2.

## Documentation

- [x] ~~I updated the README (if applicable)~~ — N/A
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~ — N/A
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~ — N/A

## Additional Context

- Chose `concurrent-job-limit = 2` rather than `1` so that lightweight independent tasks (e.g., test data downloads) can still overlap. `2` is still below the 3-way STAR pileup that triggers the OOM.
- No WDL files were modified — the test workflow structure is unchanged.
- Other workflow engines (miniwdl, Sprocket) are unaffected; they already respect concurrency-relevant runtime attributes.