### PR TITLE
Adding initial draft of `ww-mosdepth` WILDS WDL module

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -495,6 +495,22 @@ tools:
       branches:
         - main
 
+  - name: ww-mosdepth
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-mosdepth/ww-mosdepth.wdl
+    readMePath: /modules/ww-mosdepth/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for fast sequencing coverage depth calculation using mosdepth
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-megahit
     subclass: WDL
     primaryDescriptorPath: /modules/ww-megahit/ww-megahit.wdl

--- a/modules/ww-mosdepth/README.md
+++ b/modules/ww-mosdepth/README.md
@@ -1,0 +1,97 @@
+# ww-mosdepth Module
+
+[![Project Status: Prototype – Useable, some support, open to feedback, unstable API.](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for calculating sequencing coverage depth using mosdepth.
+
+## Overview
+
+This module wraps `mosdepth`, a fast tool for calculating sequencing coverage depth from BAM or CRAM alignments at per-base, per-region, or per-window resolution. It provides a standardized way to generate coverage statistics and depth files.
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and follows the standard WILDS module structure:
+
+- **Main WDL file**: `ww-mosdepth.wdl` - Contains task definitions for the module
+- **Test workflow**: `testrun.wdl` - Demonstration workflow for testing and examples
+- **Documentation**: This README with usage examples and parameter descriptions
+
+## Available Tasks
+
+### `calculate_depth`
+
+Calculates sequencing coverage depth from BAM or CRAM alignments.
+
+**Inputs:**
+- `sample_name` (String): Name identifier for the sample
+- `input_bam` (File): Input BAM or CRAM file
+- `input_bam_index` (File): Index file for the input BAM/CRAM
+- `ref_fasta` (File, optional): Reference genome FASTA file (required for CRAM inputs)
+- `regions_bed` (File, optional): BED file specifying regions of interest
+- `window_size` (Int, default=100): Window size for windowed depth output (in bp)
+- `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
+- `memory_gb` (Int, default=4): Memory allocated for the task in GB
+
+**Outputs:**
+- `depth_per_base` (File): Per-base coverage depth in BED format
+- `depth_summary` (File): Summary of coverage depth statistics
+- `region_depth` (File): Coverage depth for specified regions or windows
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-mosdepth/ww-mosdepth.wdl" as mosdepth_tasks
+
+workflow my_coverage_analysis {
+  input {
+    File input_bam
+    File input_bai
+    File ref_fasta
+  }
+  
+  call mosdepth_tasks.calculate_depth {
+    input: {
+      sample_name: "sample_1",
+      input_bam: input_bam,
+      input_bam_index: input_bai,
+      ref_fasta: ref_fasta
+    }
+  }
+}
+```
+
+## Testing the Module
+
+The module includes a test workflow (`testrun.wdl`) that can be run independently:
+
+```bash
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl
+```
+
+## Docker Container
+
+This module uses the `getwilds/mosdepth:0.3.14` container image, which provides the `mosdepth` binary and necessary runtime dependencies.
+
+## Citation
+
+If you use mosdepth in your research, please cite the original authors:
+
+> Pedersen BS, Quinlan AR. Mosdepth: quick coverage depth calculation for genomes and exomes. Bioinformatics. 2018 Mar 1;34(5):867-868.
+> DOI: 10.1093/bioinformatics/btx699
+
+## Parameters and Resource Requirements
+
+### Default Resources
+- **CPU**: 2 cores
+- **Memory**: 4 GB
+
+### Resource Scaling
+- `cpu_cores`: Increase for larger BAM files or more chromosomes
+- `memory_gb`: Increase based on the size of the reference genome and the input BAM

--- a/modules/ww-mosdepth/README.md
+++ b/modules/ww-mosdepth/README.md
@@ -63,11 +63,21 @@ workflow my_coverage_analysis {
 }
 ```
 
+### Integration Examples
+
+This module pairs well with other WILDS modules:
+- **ww-testdata**: Automatic provisioning of test BAM and reference data
+- **ww-bwa** / **ww-bowtie2** / **ww-star**: For producing the aligned BAM/CRAM inputs
+- **ww-samtools**: For preprocessing (sorting, indexing, filtering) prior to depth calculation
+
 ## Testing the Module
 
 The module includes a test workflow (`testrun.wdl`) that can be run independently:
 
 ```bash
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+
 # Using miniWDL
 miniwdl run testrun.wdl
 
@@ -77,7 +87,9 @@ sprocket run testrun.wdl
 
 ## Docker Container
 
-This module uses the `getwilds/mosdepth:0.3.14` container image, which provides the `mosdepth` binary and necessary runtime dependencies.
+This module uses the `getwilds/mosdepth:0.3.14` container image, which includes:
+- The `mosdepth` binary (v0.3.14)
+- All necessary system dependencies for coverage depth calculation
 
 ## Citation
 
@@ -95,3 +107,32 @@ If you use mosdepth in your research, please cite the original authors:
 ### Resource Scaling
 - `cpu_cores`: Increase for larger BAM files or more chromosomes
 - `memory_gb`: Increase based on the size of the reference genome and the input BAM
+
+## Requirements
+
+- WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
+- Docker/Apptainer support
+- Sufficient computational resources (mosdepth is generally lightweight, but scales with BAM size)
+
+## Module Development
+
+This module is automatically tested as part of the WILDS WDL Library CI/CD pipeline using:
+- Multiple WDL executors (Cromwell, miniWDL, Sprocket)
+- Real sequencing data (chromosome 1 subset for efficiency)
+- Validation of expected output files
+
+For questions specific to this module or to contribute improvements, please see the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library).
+
+## Support
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+For questions specific to mosdepth usage or configuration, please refer to the [mosdepth repository](https://github.com/brentp/mosdepth).
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL module, please see our [contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/modules/ww-mosdepth/README.md
+++ b/modules/ww-mosdepth/README.md
@@ -36,7 +36,7 @@ Calculates sequencing coverage depth from BAM or CRAM alignments.
 **Outputs:**
 - `depth_per_base` (File): Per-base coverage depth in BED format
 - `depth_summary` (File): Summary of coverage depth statistics (plain text)
-- `region_depth` (File): Coverage depth per window or region (always produced)
+- `region_depth` (File, optional): Coverage depth per window or region (produced when `--by` is passed via `regions_bed` or `window_size`)
 
 ## Usage as a Module
 

--- a/modules/ww-mosdepth/README.md
+++ b/modules/ww-mosdepth/README.md
@@ -35,8 +35,8 @@ Calculates sequencing coverage depth from BAM or CRAM alignments.
 
 **Outputs:**
 - `depth_per_base` (File): Per-base coverage depth in BED format
-- `depth_summary` (File): Summary of coverage depth statistics
-- `region_depth` (File): Coverage depth for specified regions or windows
+- `depth_summary` (File): Summary of coverage depth statistics (plain text)
+- `region_depth` (File): Coverage depth per window or region (always produced)
 
 ## Usage as a Module
 
@@ -53,12 +53,11 @@ workflow my_coverage_analysis {
   }
   
   call mosdepth_tasks.calculate_depth {
-    input: {
-      sample_name: "sample_1",
-      input_bam: input_bam,
-      input_bam_index: input_bai,
-      ref_fasta: ref_fasta
-    }
+    input:
+      sample_name = "sample_1",
+      input_bam = input_bam,
+      input_bam_index = input_bai,
+      ref_fasta = ref_fasta
   }
 }
 ```

--- a/modules/ww-mosdepth/testrun.wdl
+++ b/modules/ww-mosdepth/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "ww-mosdepth.wdl" as ww_mosdepth
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-mosdepth/modules/ww-mosdepth/ww-mosdepth.wdl" as ww_mosdepth
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-mosdepth/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 struct MosdepthSample {
     String name

--- a/modules/ww-mosdepth/testrun.wdl
+++ b/modules/ww-mosdepth/testrun.wdl
@@ -1,0 +1,48 @@
+version 1.0
+
+import "ww-mosdepth.wdl" as ww_mosdepth
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+
+struct MosdepthSample {
+    String name
+    File bam
+    File bai
+}
+
+workflow mosdepth_example {
+  # Auto-download reference and BAM data
+  call ww_testdata.download_ref_data {
+    input:
+      chromo = "chr1",
+      version = "hg38"
+  }
+  
+  call ww_testdata.download_bam_data {
+    input:
+      filename = "test_sample.bam"
+  }
+
+  Array[MosdepthSample] final_samples = [
+    {
+      "name": "demo_sample_1",
+      "bam": download_bam_data.bam,
+      "bai": download_bam_data.bai
+    }
+  ]
+
+  scatter (sample in final_samples) {
+    call ww_mosdepth.calculate_depth {
+        input:
+          sample_name = sample.name,
+          input_bam = sample.bam,
+          input_bam_index = sample.bai,
+          ref_fasta = download_ref_data.fasta,
+          cpu_cores = 1,
+          memory_gb = 4
+    }
+  }
+
+  output {
+    Array[File] depth_files = calculate_depth.depth_per_base
+  }
+}

--- a/modules/ww-mosdepth/testrun.wdl
+++ b/modules/ww-mosdepth/testrun.wdl
@@ -25,6 +25,6 @@ workflow mosdepth_example {
   output {
     File depth_per_base = calculate_depth.depth_per_base
     File depth_summary = calculate_depth.depth_summary
-    File region_depth = calculate_depth.region_depth
+    File? region_depth = calculate_depth.region_depth
   }
 }

--- a/modules/ww-mosdepth/testrun.wdl
+++ b/modules/ww-mosdepth/testrun.wdl
@@ -1,48 +1,30 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-mosdepth/modules/ww-mosdepth/ww-mosdepth.wdl" as ww_mosdepth
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-mosdepth/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-
-struct MosdepthSample {
-    String name
-    File bam
-    File bai
-}
+import "./ww-mosdepth.wdl" as ww_mosdepth
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow mosdepth_example {
-  # Auto-download reference and BAM data
   call ww_testdata.download_ref_data {
     input:
       chromo = "chr1",
       version = "hg38"
   }
-  
-  call ww_testdata.download_bam_data {
+
+  call ww_testdata.download_bam_data
+
+  call ww_mosdepth.calculate_depth {
     input:
-      filename = "test_sample.bam"
-  }
-
-  Array[MosdepthSample] final_samples = [
-    {
-      "name": "demo_sample_1",
-      "bam": download_bam_data.bam,
-      "bai": download_bam_data.bai
-    }
-  ]
-
-  scatter (sample in final_samples) {
-    call ww_mosdepth.calculate_depth {
-        input:
-          sample_name = sample.name,
-          input_bam = sample.bam,
-          input_bam_index = sample.bai,
-          ref_fasta = download_ref_data.fasta,
-          cpu_cores = 1,
-          memory_gb = 4
-    }
+      sample_name = "demo_sample_1",
+      input_bam = download_bam_data.bam,
+      input_bam_index = download_bam_data.bai,
+      ref_fasta = download_ref_data.fasta,
+      cpu_cores = 1,
+      memory_gb = 4
   }
 
   output {
-    Array[File] depth_files = calculate_depth.depth_per_base
+    File depth_per_base = calculate_depth.depth_per_base
+    File depth_summary = calculate_depth.depth_summary
+    File region_depth = calculate_depth.region_depth
   }
 }

--- a/modules/ww-mosdepth/ww-mosdepth.wdl
+++ b/modules/ww-mosdepth/ww-mosdepth.wdl
@@ -75,7 +75,7 @@ task calculate_depth {
   output {
     File depth_per_base = "~{sample_name}.per-base.bed.gz"
     File depth_summary = "~{sample_name}.mosdepth.gz"
-    File region_depth = if (defined(regions_bed)) then "~{sample_name}.regions.bed.gz" else "~{sample_name}.regions.bed.gz"
+    File region_depth = "~{sample_name}.regions.bed.gz"
   }
 
   runtime {

--- a/modules/ww-mosdepth/ww-mosdepth.wdl
+++ b/modules/ww-mosdepth/ww-mosdepth.wdl
@@ -8,8 +8,8 @@ version 1.0
 
 task calculate_depth {
   meta {
-    author: "opencode"
-    email: "opencode@example.com"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Calculates sequencing coverage depth from BAM or CRAM alignments."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-mosdepth/ww-mosdepth.wdl"
     outputs: {

--- a/modules/ww-mosdepth/ww-mosdepth.wdl
+++ b/modules/ww-mosdepth/ww-mosdepth.wdl
@@ -1,0 +1,86 @@
+## WILDS WDL Mosdepth Module
+## Fast BAM/CRAM depth calculation.
+## Based on mosdepth by Brent Pedersen.
+
+version 1.0
+
+#### TASK DEFINITIONS ####
+
+task calculate_depth {
+  meta {
+    author: "opencode"
+    email: "opencode@example.com"
+    description: "Calculates sequencing coverage depth from BAM or CRAM alignments."
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-mosdepth/ww-mosdepth.wdl"
+    outputs: {
+        depth_per_base: "Per-base coverage depth in BED format",
+        depth_summary: "Summary of coverage depth statistics",
+        region_depth: "Coverage depth for specified regions (if provided)"
+    }
+    topic: "any"
+    species: "human,eukaryote,prokaryote,virus"
+    operation: "data_parsing"
+    input_sample_required: "input_bam:bam:bam"
+    input_sample_optional: "none"
+    input_reference_required: "none"
+    input_reference_optional: "ref_fasta:fasta:fasta"
+    output_sample: "depth_per_base:text_data:bed"
+    output_reference: "none"
+  }
+
+  parameter_meta {
+    sample_name: "Name identifier for the sample"
+    input_bam: "Input BAM or CRAM file"
+    input_bam_index: "Index file for the input BAM/CRAM"
+    ref_fasta: "Reference genome FASTA file (required for CRAM inputs)"
+    regions_bed: "Optional BED file specifying regions of interest"
+    window_size: "Window size for windowed depth output (default: 100bp)"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    String sample_name
+    File input_bam
+    File input_bam_index
+    File? ref_fasta
+    File? regions_bed
+    Int window_size = 100
+    Int cpu_cores = 2
+    Int memory_gb = 4
+  }
+
+  command <<<
+    set -eo pipefail
+
+    # Construct mosdepth command
+    CMD="mosdepth"
+    
+    if [ -n "~{ref_fasta}" ]; then
+      CMD="$CMD --fasta ~{ref_fasta}"
+    fi
+    
+    if [ -n "~{regions_bed}" ]; then
+      CMD="$CMD --by ~{regions_bed}"
+    else
+      CMD="$CMD --by ~{window_size}"
+    fi
+
+    CMD="$CMD --threads ~{cpu_cores} ~{sample_name} ~{input_bam}"
+    
+    # Execution
+    eval $CMD
+  >>>
+
+  output {
+    File depth_per_base = "~{sample_name}.per-base.bed.gz"
+    File depth_summary = "~{sample_name}.mosdepth.gz"
+    File region_depth = if (defined(regions_bed)) then "~{sample_name}.regions.bed.gz" else "~{sample_name}.regions.bed.gz"
+  }
+
+  runtime {
+    docker: "getwilds/mosdepth:0.3.14"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/modules/ww-mosdepth/ww-mosdepth.wdl
+++ b/modules/ww-mosdepth/ww-mosdepth.wdl
@@ -20,11 +20,11 @@ task calculate_depth {
     topic: "any"
     species: "human,eukaryote,prokaryote,virus"
     operation: "data_parsing"
-    input_sample_required: "input_bam:bam:bam"
-    input_sample_optional: "none"
+    input_sample_required: "input_bam:nucleic_acid_sequence_alignment:bam,input_bam_index:data_index:bai"
+    input_sample_optional: "regions_bed:annotation_track:bed"
     input_reference_required: "none"
-    input_reference_optional: "ref_fasta:fasta:fasta"
-    output_sample: "depth_per_base:text_data:bed"
+    input_reference_optional: "ref_fasta:dna_sequence:fasta"
+    output_sample: "depth_per_base:annotation_track:bed,depth_summary:text_data:textual_format,region_depth:annotation_track:bed"
     output_reference: "none"
   }
 

--- a/modules/ww-mosdepth/ww-mosdepth.wdl
+++ b/modules/ww-mosdepth/ww-mosdepth.wdl
@@ -15,7 +15,7 @@ task calculate_depth {
     outputs: {
         depth_per_base: "Per-base coverage depth in gzipped BED format",
         depth_summary: "Summary of coverage depth statistics (plain text)",
-        region_depth: "Coverage depth per window or region (always produced)"
+        region_depth: "Coverage depth per window or region (produced when --by is passed)"
     }
     topic: "any"
     species: "human,eukaryote,prokaryote,virus"
@@ -64,7 +64,7 @@ task calculate_depth {
   output {
     File depth_per_base = "~{sample_name}.per-base.bed.gz"
     File depth_summary = "~{sample_name}.mosdepth.summary.txt"
-    File region_depth = "~{sample_name}.regions.bed.gz"
+    File? region_depth = "~{sample_name}.regions.bed.gz"
   }
 
   runtime {

--- a/modules/ww-mosdepth/ww-mosdepth.wdl
+++ b/modules/ww-mosdepth/ww-mosdepth.wdl
@@ -13,9 +13,9 @@ task calculate_depth {
     description: "Calculates sequencing coverage depth from BAM or CRAM alignments."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-mosdepth/ww-mosdepth.wdl"
     outputs: {
-        depth_per_base: "Per-base coverage depth in BED format",
-        depth_summary: "Summary of coverage depth statistics",
-        region_depth: "Coverage depth for specified regions (if provided)"
+        depth_per_base: "Per-base coverage depth in gzipped BED format",
+        depth_summary: "Summary of coverage depth statistics (plain text)",
+        region_depth: "Coverage depth per window or region (always produced)"
     }
     topic: "any"
     species: "human,eukaryote,prokaryote,virus"
@@ -53,28 +53,17 @@ task calculate_depth {
   command <<<
     set -eo pipefail
 
-    # Construct mosdepth command
-    CMD="mosdepth"
-    
-    if [ -n "~{ref_fasta}" ]; then
-      CMD="$CMD --fasta ~{ref_fasta}"
-    fi
-    
-    if [ -n "~{regions_bed}" ]; then
-      CMD="$CMD --by ~{regions_bed}"
-    else
-      CMD="$CMD --by ~{window_size}"
-    fi
-
-    CMD="$CMD --threads ~{cpu_cores} ~{sample_name} ~{input_bam}"
-    
-    # Execution
-    eval $CMD
+    mosdepth \
+      ~{if defined(ref_fasta) then "--fasta " + ref_fasta else ""} \
+      ~{if defined(regions_bed) then "--by " + regions_bed else "--by " + window_size} \
+      --threads ~{cpu_cores} \
+      ~{sample_name} \
+      ~{input_bam}
   >>>
 
   output {
     File depth_per_base = "~{sample_name}.per-base.bed.gz"
-    File depth_summary = "~{sample_name}.mosdepth.gz"
+    File depth_summary = "~{sample_name}.mosdepth.summary.txt"
     File region_depth = "~{sample_name}.regions.bed.gz"
   }
 


### PR DESCRIPTION
## Type of Change

- New module

## Description

Adds `ww-mosdepth`, a WILDS WDL module wrapping [mosdepth](https://github.com/brentp/mosdepth) (v0.3.14) for fast sequencing coverage depth calculation from BAM or CRAM alignments.

The module provides a single task, `calculate_depth`, which supports:
- Per-base depth output (always produced)
- Windowed or region-based depth output via `--by` (optional `File?` output)
- Optional FASTA reference for CRAM inputs
- Configurable CPU and memory resources

## Testing

**How did you test these changes?**
Ran `testrun.wdl` using the `ww-testdata` module for input data. Verified all three outputs (`depth_per_base`, `depth_summary`, `region_depth`) were produced correctly.

**What workflow engine did you use?**
Sprocket, miniwdl, Cromwell (CI)

**Did the tests pass?**
Yes.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs-preview` to check documentation rendering (if applicable)