### PR TITLE
Adding WILDS WDL agent scaffolding

### DIFF
--- a/.agents/skills/add-testdata/SKILL.md
+++ b/.agents/skills/add-testdata/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: add-testdata
+description: Add a new test data download task to the ww-testdata module for use in module/pipeline testruns
+argument-hint: <task-name>
+allowed-tools: Bash, Edit, Read, Write, Glob, Grep, WebSearch, WebFetch
+---
+
+# Add a New Test Data Task to ww-testdata
+
+Add a new task called `$ARGUMENTS` to `modules/ww-testdata/ww-testdata.wdl`.
+
+## Steps
+
+### 1. Understand the Request
+
+Clarify with the user if not obvious:
+- What data needs to be downloaded or generated?
+- Where is the source (public URL, S3 bucket, GitHub repo, generated synthetically)?
+- What output files should the task produce?
+- Which module or pipeline will use this test data?
+
+### 2. Study Existing Patterns
+
+Read `modules/ww-testdata/ww-testdata.wdl` to understand the existing task patterns. Key conventions:
+
+**Docker images used for test data tasks:**
+- `getwilds/samtools:1.11` — reference genome prep, BAM/CRAM handling, general file downloads via curl/wget
+- `getwilds/awscli:2.27.49` — AWS S3 downloads (no-sign-request), general downloads
+- `getwilds/bcftools:1.19` — VCF filtering, region extraction, normalization
+- `getwilds/deseq2:1.40.2` — R/Bioconductor data generation
+- `getwilds/r-utils:0.1.0` — general R scripts
+
+**Common data sources:**
+- UCSC (hgdownload.soe.ucsc.edu) — reference genomes
+- GATK test data bucket (s3://gatk-test-data) — FASTQ, BAM
+- Public GitHub repos — tool-specific test data
+- 1000 Genomes FTP — population VCFs
+- NCBI FTP — dbSNP
+- UniProt — protein sequences
+- Google Cloud Storage — GATK best practices
+
+**Optimization strategies (keep test data small!):**
+- Subsample BAM files (5-10% with `samtools view -s`)
+- Filter to specific regions (`samtools faidx`, `bcftools view -r`)
+- Use small chromosomes or chromosome subsets
+- Download only what's needed (specific columns, specific samples)
+
+### 3. Write the New Task
+
+Add the task to `modules/ww-testdata/ww-testdata.wdl` following this template:
+
+```wdl
+task $ARGUMENTS {
+  meta {
+    author: "WILDS Team"
+    email: "wilds@fredhutch.org"
+    description: "Description of what this test data task provides"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
+    outputs: {
+      output_name: "Description of each output file"
+    }
+  }
+
+  parameter_meta {
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+  }
+
+  input {
+    # Add task-specific inputs with defaults where possible
+    Int cpu_cores = 1
+    Int memory_gb = 4
+  }
+
+  command <<<
+    set -eo pipefail
+
+    # Download or generate test data
+    # Keep files small for CI testing!
+  >>>
+
+  output {
+    # Define typed outputs
+  }
+
+  runtime {
+    docker: "getwilds/<appropriate-image>:<version>"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}
+```
+
+### 4. Update the testrun.wdl
+
+Read `modules/ww-testdata/testrun.wdl` and add a call to the new task. The testdata testrun calls ALL tasks to validate they work. Add:
+- A call to the new task
+- Include its outputs in the `validate_outputs` task if one exists
+
+### 5. Update the README
+
+Read `modules/ww-testdata/README.md` and add documentation for the new task, including:
+- Task name and description
+- Inputs (with defaults)
+- Outputs (with types and descriptions)
+- Data source
+
+### 6. Lint
+
+```bash
+make lint NAME=ww-testdata
+```
+
+Fix any issues and re-run until clean.
+
+### 7. Summary
+
+Report:
+- Task name and what it provides
+- Data source and approximate size
+- Which Docker image was used
+- Which module(s)/pipeline(s) can now use this test data

--- a/.agents/skills/add-testdata/SKILL.md
+++ b/.agents/skills/add-testdata/SKILL.md
@@ -2,7 +2,6 @@
 name: add-testdata
 description: Add a new test data download task to the ww-testdata module for use in module/pipeline testruns
 argument-hint: <task-name>
-allowed-tools: Bash, Edit, Read, Write, Glob, Grep, WebSearch, WebFetch
 ---
 
 # Add a New Test Data Task to ww-testdata

--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: create-module
+description: Create a new WILDS WDL module for a bioinformatics tool following project conventions
+argument-hint: <tool-name>
+allowed-tools: Bash, Edit, Read, Write, Glob, Grep, WebSearch, WebFetch
+---
+
+# Create a New WILDS WDL Module
+
+Create a new module called `ww-$ARGUMENTS` in `modules/ww-$ARGUMENTS/`.
+
+## Steps
+
+### 1. Research the Tool
+
+Before writing any code, research `$ARGUMENTS` to understand:
+- What it does and its primary use cases in bioinformatics
+- Its command-line interface and key subcommands
+- What Docker image exists at `getwilds/$ARGUMENTS` (check Docker Hub or the [wilds-docker-library](https://github.com/getwilds/wilds-docker-library)) and which version tag to pin
+- What inputs/outputs are typical
+
+If no `getwilds/` Docker image exists, flag this to the user — one will need to be created first.
+
+If the task would benefit greatly from having an additional tool in the Docker image (e.g., `samtools` for BAM conversion after alignment), stop and let the user know. They can add it to the image in the [wilds-docker-library](https://github.com/getwilds/wilds-docker-library) repo before proceeding.
+
+### 2. Study the Template
+
+Read the canonical template files to match their exact format:
+- `modules/ww-template/ww-template.wdl`
+- `modules/ww-template/testrun.wdl`
+- `modules/ww-template/README.md`
+
+Also review `modules/ww-testdata/ww-testdata.wdl` to see what test data is available (FASTQ, BAM, CRAM, VCF, reference genome, etc.) and pick appropriate test data for this tool.
+
+### 3. Create the Module Files
+
+Create three files in `modules/ww-$ARGUMENTS/`:
+
+#### `ww-$ARGUMENTS.wdl`
+- Start with `version 1.0`
+- Add a header comment block describing the module
+- Define task(s) with the tool's core functionality
+- Every task MUST have:
+  - `meta` block with: author, email, description, url, outputs
+  - `parameter_meta` block describing every input
+  - `input` block with typed parameters; include `cpu_cores` (Int, default sensible) and `memory_gb` (Int, default sensible)
+  - `command <<<` block starting with `set -eo pipefail`, using `~{var}` interpolation
+  - `output` block with typed outputs
+  - `runtime` block with `docker: "getwilds/$ARGUMENTS:<version>"` (pinned, never `latest`), `cpu: cpu_cores`, `memory: "~{memory_gb} GB"`
+
+#### `testrun.wdl`
+- `version 1.0`
+- Import the module using a **relative file path**: `import "ww-$ARGUMENTS.wdl" as ww_$ARGUMENTS_UNDERSCORE`
+- Import testdata using a **relative file path**: `import "../ww-testdata/ww-testdata.wdl" as ww_testdata`
+- **IMPORTANT**: Use relative imports so the module can be linted and tested locally before being committed. The CI/CD pipeline or the user will update these to GitHub raw URLs when ready.
+- Workflow name: `$ARGUMENTS_example` (with hyphens converted to underscores)
+- Must run with zero configuration (no input files needed)
+- Use appropriate `ww_testdata` tasks to provision test data
+- Scatter over samples when applicable
+- Define a struct if grouping inputs makes sense
+
+#### `README.md`
+- Follow the exact format of `modules/ww-template/README.md`
+- Include: badges, overview, module structure, available tasks (with inputs/outputs), usage examples, testing instructions, Docker container info, citations, parameters/resources
+
+### 4. Lint the Module
+
+Run linting and fix any issues. The Makefile requires three tools to be in PATH:
+- **sprocket**: `/Users/tfirman/.cargo/bin/sprocket`
+- **uv** (used to run miniwdl): `/opt/homebrew/bin/uv`
+- **java** (used for WOMtool): `/usr/bin/java`
+
+Always include all three in PATH when running make targets:
+
+```bash
+PATH="/Users/tfirman/.cargo/bin:/opt/homebrew/bin:/opt/miniconda3/bin:$PATH" make lint NAME=ww-$ARGUMENTS
+```
+
+Fix any lint errors and re-run until clean.
+
+### 5. Test Run (if possible)
+
+Attempt a test run:
+```bash
+PATH="/Users/tfirman/.cargo/bin:/opt/homebrew/bin:/opt/miniconda3/bin:$PATH" make run_sprocket NAME=ww-$ARGUMENTS
+```
+
+If the test run fails due to missing test data or Docker images, note what's needed for the user.
+
+### 6. Important: Do NOT Commit
+
+Do NOT create any git commits or push to GitHub. The user will handle all git operations themselves.
+
+### 7. Summary
+
+Report to the user:
+- What files were created
+- What Docker image and version was used
+- What test data tasks are used
+- Any issues that need follow-up (missing Docker image, missing test data in ww-testdata, lint warnings, etc.)

--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -42,6 +42,7 @@ Create three files in `modules/ww-$ARGUMENTS/`:
 - Define task(s) with the tool's core functionality
 - Every task MUST have:
   - `meta` block with: author, email, description, url, outputs
+    - Use `author: "WILDS Team"` and `email: "wilds@fredhutch.org"` as placeholders — the actual contributor will replace these in review
   - `parameter_meta` block describing every input
   - `input` block with typed parameters; include `cpu_cores` (Int, default sensible) and `memory_gb` (Int, default sensible)
   - `command <<<` block starting with `set -eo pipefail`, using `~{var}` interpolation

--- a/.agents/skills/create-pipeline/SKILL.md
+++ b/.agents/skills/create-pipeline/SKILL.md
@@ -53,6 +53,8 @@ Create four files in `pipelines/ww-$0/`:
   ```
 - Define structs for grouped inputs (samples, references)
 - Workflow name: use the pipeline name with hyphens converted to underscores (e.g., `bwa_gatk`)
+- Workflow MUST have a `meta` block with: author, email, description, url, outputs (same shape as task `meta` blocks in modules)
+  - Use `author: "WILDS Team"` and `email: "wilds@fredhutch.org"` as placeholders — the actual contributor will replace these in review
 - Wire module task outputs to downstream task inputs
 - Include `cpu_cores` and `memory_gb` as workflow-level inputs with sensible defaults
 - Collect final outputs at workflow level

--- a/.agents/skills/create-pipeline/SKILL.md
+++ b/.agents/skills/create-pipeline/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: create-pipeline
+description: Create a new WILDS WDL pipeline that combines existing modules into a workflow
+argument-hint: <pipeline-name> <module1> <module2> [...]
+allowed-tools: Bash, Edit, Read, Write, Glob, Grep, WebSearch, WebFetch
+---
+
+# Create a New WILDS WDL Pipeline
+
+Create a new pipeline called `ww-$0` in `pipelines/ww-$0/` that combines the specified modules.
+
+The remaining arguments (`$1`, `$2`, etc.) are the module names to combine. If no modules are specified, ask the user which modules to include.
+
+## Steps
+
+### 1. Verify Modules Exist
+
+Check that each specified module exists under `modules/`. List available modules if any are missing:
+```
+modules/ww-<name>/ww-<name>.wdl
+```
+
+Read each module's WDL file to understand its tasks, inputs, and outputs. This is critical for wiring them together correctly.
+
+### 2. Study Existing Pipelines
+
+Read example pipelines to match the exact conventions. Study at least two of these:
+- `pipelines/ww-sra-star/` (Basic: 2 modules)
+- `pipelines/ww-star-deseq2/` (Intermediate: 4 modules)
+- `pipelines/ww-bwa-gatk/` (Advanced: multi-step DNA-seq)
+
+Pick the example closest in complexity to what you're building.
+
+### 3. Design the Pipeline
+
+Before writing code, plan:
+- **Data flow:** How outputs from one module feed as inputs to the next
+- **Scatter strategy:** What to scatter over (samples? chromosomes?) and what runs once (index building, reference prep)
+- **Structs:** Group related inputs (e.g., `SampleInfo`, `RefGenome`) — follow existing struct patterns
+- **Complexity level:** Basic (2-3 modules), Intermediate (4-6), or Advanced (10+)
+
+Present the design to the user for confirmation before proceeding.
+
+### 4. Create Pipeline Files
+
+Create four files in `pipelines/ww-$0/`:
+
+#### `ww-$0.wdl`
+- `version 1.0`
+- Import each module using GitHub raw URLs:
+  ```wdl
+  import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-<name>/ww-<name>.wdl" as <alias>_tasks
+  ```
+- Define structs for grouped inputs (samples, references)
+- Workflow name: use the pipeline name with hyphens converted to underscores (e.g., `bwa_gatk`)
+- Wire module task outputs to downstream task inputs
+- Include `cpu_cores` and `memory_gb` as workflow-level inputs with sensible defaults
+- Collect final outputs at workflow level
+
+#### `testrun.wdl`
+- `version 1.0`
+- Import the pipeline WDL and `ww-testdata`
+- Workflow name: `{pipeline_name}_example` (underscored)
+- Must run with zero configuration
+- Use `ww-testdata` tasks for all test data — check what's available:
+  - `download_ref_data` — reference genome, GTF, BED, index, dict
+  - `download_fastq_data` — paired-end FASTQ
+  - `download_bam_data` / `download_cram_data` — alignment files
+  - `download_dbsnp_vcf` / `download_known_indels_vcf` / `download_gnomad_vcf` — variant databases
+  - `download_test_transcriptome` — RNA transcriptome
+  - `generate_pasilla_counts` — DESeq2 count data
+  - `download_diamond_data` — protein sequence data
+  - Various GLIMPSE2, ShapeMapper, CellRanger, ichorCNA tasks
+- Use reduced resources for testing (fewer CPUs, less memory)
+- Subsample data where possible (`max_reads`, region filtering)
+- Construct structs from downloaded test data
+
+#### `inputs.json`
+- Use workflow name as prefix: `"pipeline_name.input_name"`
+- Include placeholder paths: `"/path/to/file.ext"`
+- Show struct format for complex inputs (arrays of structs)
+- Include all configurable parameters with reasonable defaults
+- Serve as a user template — make it clear what needs to be customized
+
+#### `README.md`
+- Follow existing pipeline README format (see `pipelines/ww-sra-star/README.md` or `pipelines/ww-star-deseq2/README.md`)
+- Include: badges, overview, complexity level, pipeline structure, module dependencies, usage, input parameters, output files, testing section, citations
+
+### 5. Lint the Pipeline
+
+```bash
+make lint NAME=ww-$0
+```
+
+Fix any issues and re-run until clean.
+
+### 6. Test Run (if possible)
+
+```bash
+make run_sprocket NAME=ww-$0
+```
+
+### 7. Summary
+
+Report:
+- Pipeline complexity level and modules used
+- Data flow diagram (ASCII)
+- Files created
+- Any issues needing follow-up (missing test data, Docker images, etc.)

--- a/.agents/skills/lint-module/SKILL.md
+++ b/.agents/skills/lint-module/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: lint-module
+description: Run WDL linting on a WILDS module or pipeline and fix any issues found
+argument-hint: <ww-name>
+allowed-tools: Bash(make *), Read, Edit, Glob, Grep
+---
+
+# Lint a WILDS WDL Module or Pipeline
+
+Run all available linting checks on `$ARGUMENTS` and fix any issues.
+
+## Steps
+
+### 1. Determine Module or Pipeline
+
+Check if `$ARGUMENTS` exists in `modules/` or `pipelines/`:
+- Module: `modules/$ARGUMENTS/$ARGUMENTS.wdl`
+- Pipeline: `pipelines/$ARGUMENTS/$ARGUMENTS.wdl`
+
+### 2. Run Linting
+
+```bash
+make lint NAME=$ARGUMENTS
+```
+
+This runs sprocket, miniwdl, and WOMtool linters.
+
+If make targets aren't available, run sprocket directly:
+```bash
+make lint_sprocket NAME=$ARGUMENTS
+```
+
+### 3. Fix Issues
+
+For each lint error:
+- Read the relevant WDL file
+- Fix the issue following project conventions (see CLAUDE.md)
+- Re-run linting to confirm the fix
+
+**Known Sprocket exceptions** (these are OK and won't cause failures):
+- TodoComment
+- ContainerUri
+- TrailingComma
+- CommentWhitespace
+- UnusedInput
+
+### 4. Report Results
+
+Summarize what was found and fixed. If there are unfixable issues, explain why and suggest next steps.

--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: pr-description
+description: Draft a pull request description using the project's PR template
+argument-hint: [optional branch or description context]
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# Draft a Pull Request Description
+
+Generate a PR description following the project's PR template at `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Steps
+
+### 1. Gather Context
+
+- Read `.github/PULL_REQUEST_TEMPLATE.md` to get the template format
+- Run `git log --oneline main..HEAD` to see all commits on the current branch
+- Run `git diff --stat main..HEAD` to understand what files changed
+- Optionally read changed files to understand the nature of the changes
+
+### 2. Draft the PR Description
+
+Fill in the PR template sections based on the changes:
+
+- **Type of Change**: Infer from the changes (new module, new pipeline, bug fix, etc.)
+- **Description**: Summarize what was added/changed and why, with links to relevant tools/docs where appropriate
+- **Related Issue**: Leave as a placeholder unless context is provided
+- **Testing**: Describe how the changes were tested based on what you can infer from the conversation or branch history (e.g., sprocket lint, testrun results)
+- **Documentation**: Check the boxes based on whether READMEs and parameter descriptions exist in the changed files
+- **Additional Context**: Note anything reviewers should know (e.g., Docker image changes, new dependencies)
+
+### 3. Output
+
+Present the draft PR description inside a single markdown code block (```markdown ... ```) so the user can easily copy the raw markdown directly into GitHub. Do NOT render it as formatted text outside a code block. Do NOT create any git commits or push to GitHub.

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: run-tests
+description: Run the testrun.wdl for a WILDS module or pipeline using sprocket or miniwdl
+argument-hint: <ww-name> [executor]
+allowed-tools: Bash(make *), Read, Glob, Grep
+---
+
+# Run Tests for a WILDS Module or Pipeline
+
+Execute the `testrun.wdl` for `$0` and report results.
+
+## Steps
+
+### 1. Locate the Test Workflow
+
+Find `testrun.wdl` in either:
+- `modules/$0/testrun.wdl`
+- `pipelines/$0/testrun.wdl`
+
+### 2. Run the Test
+
+If a second argument (`$1`) is provided, use that executor. Otherwise default to sprocket.
+
+**Sprocket:**
+```bash
+make run_sprocket NAME=$0
+```
+
+**miniWDL:**
+```bash
+make run_miniwdl NAME=$0
+```
+
+### 3. Report Results
+
+- If the test passes, report success with a brief summary of outputs
+- If the test fails, analyze the error output, suggest fixes, and offer to apply them

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -514,6 +514,17 @@ After meeting the requirements above, submit a PR to merge your forked repo into
 
 We occasionally use large language models (primarily [Claude](https://www.anthropic.com/claude)) to assist with prototyping modules and pipelines, and contributors are welcome to do the same. However, all AI-generated code must go through the same testing, linting, and human review process as any other contribution. Please ensure you review and understand any AI-generated code before submitting it in a PR.
 
+To make AI assistance more consistent with project conventions, the repository ships an [`AGENTS.md`](../AGENTS.md) project-context file (following the vendor-neutral [agents.md](https://agents.md/) convention) and a set of reusable task recipes under [`.agents/skills/`](../.agents/skills/):
+
+- `create-module` — scaffold a new `ww-toolname` module
+- `create-pipeline` — assemble existing modules into a new pipeline
+- `add-testdata` — add a test-data download task to `ww-testdata`
+- `run-tests` — run `testrun.wdl` via Sprocket or miniwdl
+- `lint-module` — run linting and fix issues
+- `pr-description` — draft a PR description from the current branch
+
+Tools that follow the AGENTS.md convention (OpenCode, Claude Code, and others) discover these files automatically. Use of these tools is optional — they are provided as a convenience and do not replace the testing and review requirements above.
+
 ### Review Criteria
 
 Your PR will be evaluated on:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -516,12 +516,12 @@ We occasionally use large language models (primarily [Claude](https://www.anthro
 
 To make AI assistance more consistent with project conventions, the repository ships an [`AGENTS.md`](../AGENTS.md) project-context file (following the vendor-neutral [agents.md](https://agents.md/) convention) and a set of reusable task recipes under [`.agents/skills/`](../.agents/skills/):
 
+- `add-testdata` — add a test-data download task to `ww-testdata`
 - `create-module` — scaffold a new `ww-toolname` module
 - `create-pipeline` — assemble existing modules into a new pipeline
-- `add-testdata` — add a test-data download task to `ww-testdata`
-- `run-tests` — run `testrun.wdl` via Sprocket or miniwdl
 - `lint-module` — run linting and fix issues
 - `pr-description` — draft a PR description from the current branch
+- `run-tests` — run `testrun.wdl` via Sprocket or miniwdl
 
 Tools that follow the AGENTS.md convention (OpenCode, Claude Code, and others) discover these files automatically. Use of these tools is optional — they are provided as a convenience and do not replace the testing and review requirements above.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,5 @@
 # AGENTS.md - WILDS WDL Library
 
-This file provides project context for AI coding agents. It follows the [AGENTS.md](https://agents.md/) convention and is read by any agent tool that supports it (OpenCode, Claude Code, Aider, Cursor, Cline, and others). The conventions documented here are vendor-neutral — bring whichever tool and model your team approves.
 
 ## Project Overview
 Centralized bioinformatics WDL library with two tiers: **modules** (tool-specific task collections) and **pipelines** (workflows combining modules). All WDL uses version 1.0.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# AGENTS.md - WILDS WDL Library
+
+This file provides project context for AI coding agents. It follows the [AGENTS.md](https://agents.md/) convention and is read by any agent tool that supports it (OpenCode, Claude Code, Aider, Cursor, Cline, and others). The conventions documented here are vendor-neutral — bring whichever tool and model your team approves.
+
+## Project Overview
+Centralized bioinformatics WDL library with two tiers: **modules** (tool-specific task collections) and **pipelines** (workflows combining modules). All WDL uses version 1.0.
+
+## Repo Structure
+```
+modules/ww-toolname/
+  ww-toolname.wdl          # Task definitions
+  testrun.wdl              # Zero-config test workflow (required)
+  README.md
+pipelines/ww-pipeline-name/
+  ww-pipeline-name.wdl     # Workflow importing modules
+  testrun.wdl
+  inputs.json              # Example inputs with placeholder paths
+  README.md
+```
+
+## Module Conventions
+- Use `ww-template` as the canonical example
+- Every task needs `meta` (author, email, description, url, outputs) and `parameter_meta` blocks
+- Command blocks: start with `set -eo pipefail`, use `<<<...>>>` heredoc syntax
+- Docker images: always from `getwilds/` with exact version pins (never `latest`)
+- Resource params: `cpu_cores` and `memory_gb` with sensible defaults
+- Imports use GitHub raw URLs: `https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-*/ww-*.wdl`
+- Modules are self-contained: `ww-<toolname>.wdl` files never import other modules. Cross-module composition happens only in `testrun.wdl` (for test fixtures) and in pipelines. If a task needs another tool's output, add it to the existing module rather than introducing a cross-module import in the source WDL.
+
+## Test Workflows (testrun.wdl)
+- Must run with zero configuration (no input files needed)
+- Import the module under test + `ww-testdata` for auto-provisioned test data
+- Workflow name: `{toolname}_example` (e.g., `star_example`)
+- Scatter over samples when applicable
+- Some modules also provide a `testrun_hpc.wdl` variant for tools that require HPC-specific resources (GPUs, large memory)
+
+## Pipeline Conventions
+- Combine existing modules; prefer existing modules over new task definitions
+- Document complexity level: Basic (2-3 modules), Intermediate (4-6), Advanced (10+)
+- Include `inputs.json` with placeholder paths as user template
+- Use WDL structs for grouping complex inputs
+
+## Linting & Testing
+```bash
+make lint NAME=ww-toolname          # All linting (Sprocket + miniwdl + WOMtool + Cirro)
+make lint_sprocket NAME=ww-toolname # Sprocket only
+make run NAME=ww-toolname           # Run testrun.wdl on all engines
+make run_sprocket NAME=ww-toolname  # Run testrun.wdl with Sprocket
+make run_miniwdl NAME=ww-toolname   # Run testrun.wdl with miniwdl
+make run_cromwell NAME=ww-toolname  # Run testrun.wdl with Cromwell
+```
+Sprocket exceptions (from sprocket.toml): TodoComment, ContainerUri, UnusedInput
+
+## Common Development Pitfalls
+- Import URLs must point to the correct branch during development; switch to `main` before merging
+- Docker image version conflicts (especially with complex tools like ColabFold) - always pin versions
+- Test data changes go in the `ww-testdata` module, not individual modules
+- All modules/pipelines must pass CI on three executors: Cromwell, miniWDL, and Sprocket
+
+## Dockstore Registration
+- All modules and pipelines must be registered in `.dockstore.yml`
+- Modules go under `tools:`, pipelines under `workflows:`
+- Include author info (name, email, role, affiliation, orcid), description, topic, and tags
+- Keep entries alphabetically ordered within their section
+- Author details should match `CITATION.cff` where applicable
+
+## PR Process
+- Request reviews from @emjbishop or @tefirman
+- Fill out PR template (type, description, testing, documentation checklist)
+- CI runs linting + multi-executor test runs automatically
+
+## Agent Skills
+
+Reusable task-specific instructions live in [.agents/skills/](.agents/skills/). Each `SKILL.md` is a self-contained recipe an agent can follow:
+
+- `create-module` — scaffold a new `ww-toolname` module
+- `create-pipeline` — assemble existing modules into a new pipeline
+- `add-testdata` — add a test-data download task to `ww-testdata`
+- `run-tests` — run `testrun.wdl` via sprocket or miniwdl
+- `lint-module` — run linting and fix issues
+- `pr-description` — draft a PR description from the current branch
+
+OpenCode discovers these automatically. Other tools may need a pointer or a config entry — see your tool's docs for how it picks up `SKILL.md` files.
+
+## Model Capability Notes
+
+The skills above vary in how much model capability they need:
+
+- **Smaller models handle well:** `lint-module`, `run-tests`, `pr-description`, `add-testdata`.
+- **Larger / frontier models recommended for:** `create-module` and `create-pipeline` — these reason across many files and make 10+ tool calls. Pipeline creation has been demonstrated with smaller local models in early experiments; module creation remains harder.
+
+When in doubt, start with a smaller model and escalate if it stalls. For data-sensitive work, local models via Ollama (or similar) are a good fit for the lighter skills and keep the codebase off third-party servers entirely.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,5 @@
 # AGENTS.md - WILDS WDL Library
 
-
 ## Project Overview
 Centralized bioinformatics WDL library with two tiers: **modules** (tool-specific task collections) and **pipelines** (workflows combining modules). All WDL uses version 1.0.
 
@@ -78,14 +77,3 @@ Reusable task-specific instructions live in [.agents/skills/](.agents/skills/). 
 - `run-tests` — run `testrun.wdl` via sprocket or miniwdl
 - `lint-module` — run linting and fix issues
 - `pr-description` — draft a PR description from the current branch
-
-OpenCode discovers these automatically. Other tools may need a pointer or a config entry — see your tool's docs for how it picks up `SKILL.md` files.
-
-## Model Capability Notes
-
-The skills above vary in how much model capability they need:
-
-- **Smaller models handle well:** `lint-module`, `run-tests`, `pr-description`, `add-testdata`.
-- **Larger / frontier models recommended for:** `create-module` and `create-pipeline` — these reason across many files and make 10+ tool calls. Pipeline creation has been demonstrated with smaller local models in early experiments; module creation remains harder.
-
-When in doubt, start with a smaller model and escalate if it stalls. For data-sensitive work, local models via Ollama (or similar) are a good fit for the lighter skills and keep the codebase off third-party servers entirely.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Fred Hutch researchers can use [PROOF](https://sciwiki.fredhutch.org/datademos/p
 
 Large language models (primarily [Claude](https://www.anthropic.com/claude)) have been used to assist with prototyping new modules and pipelines in this repository, including initial drafts of task scaffolding, command structures, and test workflows. All AI-generated code is reviewed, validated, and modified as necessary by human researchers through linting tools, multi-executor test runs (Cromwell, miniWDL, Sprocket), and peer code review. No architectural or scientific decisions are made by AI tools.
 
+To support contributors who use AI coding assistants, the repository ships an [`AGENTS.md`](AGENTS.md) project-context file (following the vendor-neutral [agents.md](https://agents.md/) convention) and a set of reusable task recipes under [`.agents/skills/`](.agents/skills/) for common operations like scaffolding a new module, adding test data, and running linting. These are picked up automatically by tools that support the convention (OpenCode, Claude Code, and others). Use of these tools is optional, and the human-review requirement above applies to any AI-assisted contribution regardless of which tool was used.
+
 ## Contributing
 
 We welcome contributions at all levels:

--- a/docs-README.md
+++ b/docs-README.md
@@ -134,6 +134,8 @@ All tasks use versioned, tested Docker images from the [WILDS Docker Library](ht
 
 Large language models (primarily [Claude](https://www.anthropic.com/claude)) have been used to assist with prototyping new modules and pipelines in this repository, including initial drafts of task scaffolding, command structures, and test workflows. All AI-generated code is reviewed, validated, and modified as necessary by human researchers through linting tools, multi-executor test runs (Cromwell, miniWDL, Sprocket), and peer code review. No architectural or scientific decisions are made by AI tools.
 
+To support contributors who use AI coding assistants, the repository ships an [`AGENTS.md`](https://github.com/getwilds/wilds-wdl-library/blob/main/AGENTS.md) project-context file (following the vendor-neutral [agents.md](https://agents.md/) convention) and a set of reusable task recipes under [`.agents/skills/`](https://github.com/getwilds/wilds-wdl-library/tree/main/.agents/skills) for common operations like scaffolding a new module, adding test data, and running linting. These are picked up automatically by tools that support the convention (OpenCode, Claude Code, and others). Use of these tools is optional, and the human-review requirement above applies to any AI-assisted contribution regardless of which tool was used.
+
 ---
 
 ## Getting Help

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["AGENTS.md"]
+}


### PR DESCRIPTION
## Type of Change

- Documentation update
- Other: agent tooling scaffolding (AGENTS.md + reusable `SKILL.md` recipes)

## Description

Introduces vendor-neutral AI coding agent context and reusable task recipes to the repo, following the [AGENTS.md](https://agents.md/) convention so any agent tool (Perplexity, OpenCode, Claude Code, etc.) can pick them up.

Adds:

- `AGENTS.md`: project overview, repo structure, module/pipeline conventions, linting/testing commands, and dockstore/PR process notes.
- `opencode.json`: minimal OpenCode config that points the tool at `AGENTS.md`.
- `.agents/skills/`: six self-contained `SKILL.md` recipes:
  - `create-module`: scaffold a new `ww-toolname` module
  - `create-pipeline`: assemble existing modules into a new pipeline
  - `add-testdata`: add a test-data download task to `ww-testdata`
  - `run-tests`: run `testrun.wdl` via Sprocket or miniwdl
  - `lint-module`: run linting and fix issues
  - `pr-description`: draft a PR description from the current branch

Also updates existing documentation to reference the new files:

- `README.md` and `docs-README.md` — extended the "AI Disclosure" section with a pointer to `AGENTS.md` and `.agents/skills/`, noting that use of these tools is optional and the existing human-review requirement still applies.
- `.github/CONTRIBUTING.md` — expanded the "AI-Assisted Development" subsection to enumerate the six skills and explain how AGENTS.md-aware tools discover them.

No module or pipeline code is changed by this PR.

## Testing

**How did you test these changes?**
Documentation-only / agent-config changes, no WDL behavior is affected, so no testrun was required. The skill recipes themselves were exercised during prototype development of previous modules and pipelines.

## Documentation

- [x] I updated the README (if applicable)
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~ -- N/A
- [ ] I ran `make docs-preview` to check documentation rendering (if applicable)

## Additional Context

- Skills live under `.agents/skills/` rather than a tool-specific path (e.g. `.claude/skills/`) so any AGENTS.md-aware tool can discover them. OpenCode picks them up automatically; other tools may need a config pointer.
- The "Model Capability Notes" section flags that `create-module` and `create-pipeline` are the most demanding skills and recommends frontier models for those, while the lighter skills (`lint-module`, `run-tests`, `pr-description`, `add-testdata`) work well with smaller/local models — useful for users wanting to keep data off third-party servers.
