### PR TITLE
Confirming v8 functionality and disabling output BAMs

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -13,7 +13,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural variant annotation using AnnotSV
     enableAutoDois: true
@@ -29,7 +29,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for variant annotation using Annovar
     enableAutoDois: true
@@ -45,7 +45,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for downloading files from S3 using AWS SSO authentication
     enableAutoDois: true
@@ -61,7 +61,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for variant calling and VCF manipulation using bcftools
     enableAutoDois: true
@@ -77,7 +77,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for converting GTF annotation files to BED12 format using bedparse
     enableAutoDois: true
@@ -93,7 +93,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for BAM coverage analysis using BEDTools
     enableAutoDois: true
@@ -109,7 +109,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for building Bowtie index files and aligning reads
     enableAutoDois: true
@@ -125,7 +125,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for building Bowtie 2 index files and aligning reads
     enableAutoDois: true
@@ -141,7 +141,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for building BWA index files and aligning reads
     enableAutoDois: true
@@ -157,7 +157,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for single-cell gene expression analysis using Cell Ranger
     enableAutoDois: true
@@ -173,7 +173,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for germline variant calling using Clair3 deep learning models
     enableAutoDois: true
@@ -189,7 +189,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for copy number variant detection using CNVkit
     enableAutoDois: true
@@ -205,7 +205,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for protein structure prediction using ColabFold/AlphaFold2
     enableAutoDois: true
@@ -221,7 +221,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for generating consensus variant calls from multiple variant callers
     enableAutoDois: true
@@ -237,7 +237,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for generating normalized coverage tracks using deepTools
     enableAutoDois: true
@@ -253,7 +253,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for germline variant calling using DeepVariant
     enableAutoDois: true
@@ -269,7 +269,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural variant calling using Delly
     enableAutoDois: true
@@ -285,12 +285,12 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Elaine Glenny
         email: eglenny@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0002-1024-4290
     topic: WDL module for differential expression analysis using DESeq2
     enableAutoDois: true
@@ -306,7 +306,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for sequence alignment using DIAMOND
     enableAutoDois: true
@@ -322,7 +322,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for downloading sequencing data from the European Nucleotide Archive
     enableAutoDois: true
@@ -338,7 +338,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for protein 3D structure prediction from amino acid sequences using ESMFold
     enableAutoDois: true
@@ -354,7 +354,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for FASTQ quality filtering and adapter trimming using fastp
     enableAutoDois: true
@@ -370,7 +370,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for FASTQ quality control analysis using FastQC
     enableAutoDois: true
@@ -386,12 +386,12 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for variant calling and genome preprocessing using GATK
     enableAutoDois: true
@@ -407,7 +407,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for downloading files from the Genomic Data Commons
     enableAutoDois: true
@@ -423,7 +423,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for GFF/GTF annotation file conversion and normalization using gffread
     enableAutoDois: true
@@ -439,7 +439,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for genotype imputation using GLIMPSE2
     enableAutoDois: true
@@ -455,7 +455,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for tumor fraction estimation using ichorCNA
     enableAutoDois: true
@@ -471,7 +471,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for translating alternative splicing events into protein sequences using JCAST
     enableAutoDois: true
@@ -487,7 +487,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural variant calling using Manta
     enableAutoDois: true
@@ -503,7 +503,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for de novo metagenome assembly using MEGAHIT
     enableAutoDois: true
@@ -519,7 +519,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for aggregating QC reports using MultiQC
     enableAutoDois: true
@@ -535,7 +535,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for differential alternative splicing analysis using rMATS
     enableAutoDois: true
@@ -551,7 +551,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA-seq quality control using RSeQC
     enableAutoDois: true
@@ -567,7 +567,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA-seq quantification using Salmon
     enableAutoDois: true
@@ -583,12 +583,12 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for processing genomic files with Samtools
     enableAutoDois: true
@@ -604,7 +604,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for single-cell RNA-seq QC and clustering using Seurat
     enableAutoDois: true
@@ -620,7 +620,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA structure probing analysis using ShapeMapper
     enableAutoDois: true
@@ -636,7 +636,7 @@ tools:
       - name: Caroline Nondin
         email: cnondin@fredhutch.org
         role: Research Assistant
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0009-0955-5954
     topic: WDL module for calculating sunrise/sunset times and sun time differences for the SJL model
     enableAutoDois: true
@@ -652,7 +652,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural variant calling using Smoove
     enableAutoDois: true
@@ -668,7 +668,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for sequence sketching and comparison using sourmash
     enableAutoDois: true
@@ -684,7 +684,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for de novo metagenomic assembly using metaSPAdes
     enableAutoDois: true
@@ -700,7 +700,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for downloading sequencing data from the Sequence Read Archive
     enableAutoDois: true
@@ -716,7 +716,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA-seq alignment using STAR two-pass methodology
     enableAutoDois: true
@@ -732,7 +732,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural ensemble generation using STARLING
     enableAutoDois: true
@@ -748,7 +748,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for germline variant calling using Strelka
     enableAutoDois: true
@@ -764,17 +764,17 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Chris Lo
         email: clo2@fredhutch.org
         role: Data Science Trainer
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
     topic: WDL module for downloading and provisioning test data used across WILDS WDL module and pipeline test runs
     enableAutoDois: true
     filters:
@@ -789,7 +789,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for adapter and quality trimming using Trim Galore
     enableAutoDois: true
@@ -805,7 +805,7 @@ tools:
       - name: Chris Lo
         email: clo2@fredhutch.org
         role: Data Science Trainer
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
     topic: WDL module for running TritonNP analysis
     enableAutoDois: true
     filters:
@@ -820,7 +820,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for UMI-aware read deduplication using umi_tools dedup
     enableAutoDois: true
@@ -836,7 +836,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for somatic variant calling using VarScan
     enableAutoDois: true
@@ -852,7 +852,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA secondary structure prediction using the ViennaRNA package
     enableAutoDois: true
@@ -875,7 +875,7 @@ workflows:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL workflow to align sequencing data using BWA and perform QC steps with GATK
     enableAutoDois: true
@@ -893,7 +893,7 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL workflow to download raw sequencing data from ENA and align using STAR two-pass methodology
     enableAutoDois: true
@@ -911,12 +911,12 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
     topic: Convert paired FASTQ files to unmapped CRAM format using WILDS WDL modules
     enableAutoDois: true
@@ -934,17 +934,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Louisa Goss
         email: lgoss2@fredhutch.org
         role: Research Associate
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0005-2936-2405
     topic: WDL workflow for genotype imputation from low-coverage WGS data using GLIMPSE2
     enableAutoDois: true
@@ -962,17 +962,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Caroline Nondin
         email: cnondin@fredhutch.org
         role: Research Assistant
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0009-0955-5954
     topic: WDL pipeline to calculate sunrise/sunset times and sun time differences across geographic tiles
     enableAutoDois: true
@@ -990,17 +990,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Sitapriya Moorthi
         email: smoorthi@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0001-6372-5170
     topic: Consensus variant calling workflow for human panel/PCR-based targeted DNA sequencing for leukemia
     enableAutoDois: true
@@ -1018,7 +1018,7 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     description: "Paired-end PRO-seq pipeline with UMI deduplication and spike-in normalization, adapted from JAJ256/PROseq_alignment.sh"
     topic: proseq
@@ -1037,17 +1037,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Elaine Glenny
         email: eglenny@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0002-1024-4290
     topic: Comprehensive RNA-seq pipeline covering read QC, adapter trimming, alignment, post-alignment QC, differential expression, and aggregated reporting
     enableAutoDois: true
@@ -1065,17 +1065,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Sitapriya Moorthi
         email: smoorthi@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0001-6372-5170
       - name: Siobhan O'Brien
         email: sobrien2@fredhutch.org
         role: Post-Doctoral Research Fellow
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4958-1080
     topic: WDL workflow to analyze saturation mutagenesis data using BWA alignment and GATK
     enableAutoDois: true
@@ -1093,7 +1093,7 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL pipeline for alternative splicing proteomics with STAR alignment, rMATS splicing, and JCAST translation
     enableAutoDois: true
@@ -1111,22 +1111,22 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Alice Berger
         email: aberger@fredhutch.org
         role: Associate Professor
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0002-6538-2658
       - name: Janet Young
         email: jyoung@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0001-8220-8427
     topic: WDL workflow to download raw sequencing data from SRA and quantify using Salmon quasi-mapping
     enableAutoDois: true
@@ -1144,17 +1144,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Hrishi Venkatesh
         email: hvenkate@fredhutch.org
         role: Post-Doctoral Research Fellow
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0002-2938-3856
     description: "WDL workflow to download single-cell RNA-seq data from SRA and process using Cell Ranger count"
     topic: single-cell
@@ -1173,17 +1173,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Alice Berger
         email: aberger@fredhutch.org
         role: Associate Professor
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0002-6538-2658
       - name: Janet Young
         email: jyoung@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0001-8220-8427
     topic: WDL workflow to download raw sequencing data from SRA and align using STAR two-pass methodology
     enableAutoDois: true
@@ -1201,17 +1201,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Ethan Bouvet
         email: ebouvet@fredhutch.org
         role: Research Technician
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0006-6552-2522
     topic: WDL workflow for RNA-seq alignment via STAR and DESeq2 differential expression analysis
     enableAutoDois: true
@@ -1229,7 +1229,7 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutchinson Cancer Center
+        affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
     topic: Batch ensemble generation pipeline splitting a protein FASTA into chunks for parallel STARLING processing
     enableAutoDois: true

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -13,7 +13,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural variant annotation using AnnotSV
     enableAutoDois: true
@@ -29,7 +29,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for variant annotation using Annovar
     enableAutoDois: true
@@ -45,7 +45,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for downloading files from S3 using AWS SSO authentication
     enableAutoDois: true
@@ -61,7 +61,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for variant calling and VCF manipulation using bcftools
     enableAutoDois: true
@@ -77,7 +77,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for converting GTF annotation files to BED12 format using bedparse
     enableAutoDois: true
@@ -93,7 +93,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for BAM coverage analysis using BEDTools
     enableAutoDois: true
@@ -109,7 +109,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for building Bowtie index files and aligning reads
     enableAutoDois: true
@@ -125,7 +125,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for building Bowtie 2 index files and aligning reads
     enableAutoDois: true
@@ -141,7 +141,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for building BWA index files and aligning reads
     enableAutoDois: true
@@ -157,7 +157,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for single-cell gene expression analysis using Cell Ranger
     enableAutoDois: true
@@ -173,7 +173,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for germline variant calling using Clair3 deep learning models
     enableAutoDois: true
@@ -189,7 +189,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for copy number variant detection using CNVkit
     enableAutoDois: true
@@ -205,7 +205,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for protein structure prediction using ColabFold/AlphaFold2
     enableAutoDois: true
@@ -221,7 +221,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for generating consensus variant calls from multiple variant callers
     enableAutoDois: true
@@ -237,7 +237,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for generating normalized coverage tracks using deepTools
     enableAutoDois: true
@@ -253,7 +253,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for germline variant calling using DeepVariant
     enableAutoDois: true
@@ -269,7 +269,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural variant calling using Delly
     enableAutoDois: true
@@ -285,12 +285,12 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Elaine Glenny
         email: eglenny@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0002-1024-4290
     topic: WDL module for differential expression analysis using DESeq2
     enableAutoDois: true
@@ -306,7 +306,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for sequence alignment using DIAMOND
     enableAutoDois: true
@@ -322,7 +322,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for downloading sequencing data from the European Nucleotide Archive
     enableAutoDois: true
@@ -338,7 +338,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for protein 3D structure prediction from amino acid sequences using ESMFold
     enableAutoDois: true
@@ -354,7 +354,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for FASTQ quality filtering and adapter trimming using fastp
     enableAutoDois: true
@@ -370,7 +370,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for FASTQ quality control analysis using FastQC
     enableAutoDois: true
@@ -386,12 +386,12 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for variant calling and genome preprocessing using GATK
     enableAutoDois: true
@@ -407,7 +407,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for downloading files from the Genomic Data Commons
     enableAutoDois: true
@@ -423,7 +423,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for GFF/GTF annotation file conversion and normalization using gffread
     enableAutoDois: true
@@ -439,7 +439,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for genotype imputation using GLIMPSE2
     enableAutoDois: true
@@ -455,7 +455,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for tumor fraction estimation using ichorCNA
     enableAutoDois: true
@@ -471,7 +471,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for translating alternative splicing events into protein sequences using JCAST
     enableAutoDois: true
@@ -487,7 +487,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural variant calling using Manta
     enableAutoDois: true
@@ -503,7 +503,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for de novo metagenome assembly using MEGAHIT
     enableAutoDois: true
@@ -519,7 +519,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for aggregating QC reports using MultiQC
     enableAutoDois: true
@@ -535,7 +535,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for differential alternative splicing analysis using rMATS
     enableAutoDois: true
@@ -551,7 +551,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA-seq quality control using RSeQC
     enableAutoDois: true
@@ -567,7 +567,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA-seq quantification using Salmon
     enableAutoDois: true
@@ -583,12 +583,12 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for processing genomic files with Samtools
     enableAutoDois: true
@@ -604,7 +604,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA structure probing analysis using ShapeMapper
     enableAutoDois: true
@@ -620,7 +620,7 @@ tools:
       - name: Caroline Nondin
         email: cnondin@fredhutch.org
         role: Research Assistant
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0009-0955-5954
     topic: WDL module for calculating sunrise/sunset times and sun time differences for the SJL model
     enableAutoDois: true
@@ -636,7 +636,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural variant calling using Smoove
     enableAutoDois: true
@@ -652,7 +652,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for sequence sketching and comparison using sourmash
     enableAutoDois: true
@@ -668,7 +668,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for de novo metagenomic assembly using metaSPAdes
     enableAutoDois: true
@@ -684,7 +684,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for downloading sequencing data from the Sequence Read Archive
     enableAutoDois: true
@@ -700,7 +700,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA-seq alignment using STAR two-pass methodology
     enableAutoDois: true
@@ -716,7 +716,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for structural ensemble generation using STARLING
     enableAutoDois: true
@@ -732,7 +732,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for germline variant calling using Strelka
     enableAutoDois: true
@@ -748,17 +748,17 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Chris Lo
         email: clo2@fredhutch.org
         role: Data Science Trainer
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
     topic: WDL module for downloading and provisioning test data used across WILDS WDL module and pipeline test runs
     enableAutoDois: true
     filters:
@@ -773,7 +773,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for adapter and quality trimming using Trim Galore
     enableAutoDois: true
@@ -789,7 +789,7 @@ tools:
       - name: Chris Lo
         email: clo2@fredhutch.org
         role: Data Science Trainer
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
     topic: WDL module for running TritonNP analysis
     enableAutoDois: true
     filters:
@@ -804,7 +804,7 @@ tools:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL module for somatic variant calling using VarScan
     enableAutoDois: true
@@ -820,7 +820,7 @@ tools:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL module for RNA secondary structure prediction using the ViennaRNA package
     enableAutoDois: true
@@ -843,7 +843,7 @@ workflows:
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: WDL workflow to align sequencing data using BWA and perform QC steps with GATK
     enableAutoDois: true
@@ -861,7 +861,7 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL workflow to download raw sequencing data from ENA and align using STAR two-pass methodology
     enableAutoDois: true
@@ -879,12 +879,12 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
     topic: Convert paired FASTQ files to unmapped CRAM format using WILDS WDL modules
     enableAutoDois: true
@@ -902,17 +902,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Louisa Goss
         email: lgoss2@fredhutch.org
         role: Research Associate
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0005-2936-2405
     topic: WDL workflow for genotype imputation from low-coverage WGS data using GLIMPSE2
     enableAutoDois: true
@@ -930,17 +930,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Caroline Nondin
         email: cnondin@fredhutch.org
         role: Research Assistant
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0009-0955-5954
     topic: WDL pipeline to calculate sunrise/sunset times and sun time differences across geographic tiles
     enableAutoDois: true
@@ -958,17 +958,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Sitapriya Moorthi
         email: smoorthi@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0001-6372-5170
     topic: Consensus variant calling workflow for human panel/PCR-based targeted DNA sequencing for leukemia
     enableAutoDois: true
@@ -986,17 +986,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Elaine Glenny
         email: eglenny@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0002-1024-4290
     topic: Comprehensive RNA-seq pipeline covering read QC, adapter trimming, alignment, post-alignment QC, differential expression, and aggregated reporting
     enableAutoDois: true
@@ -1014,17 +1014,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Sitapriya Moorthi
         email: smoorthi@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0001-6372-5170
       - name: Siobhan O'Brien
         email: sobrien2@fredhutch.org
         role: Post-Doctoral Research Fellow
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4958-1080
     topic: WDL workflow to analyze saturation mutagenesis data using BWA alignment and GATK
     enableAutoDois: true
@@ -1042,7 +1042,7 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: WDL pipeline for alternative splicing proteomics with STAR alignment, rMATS splicing, and JCAST translation
     enableAutoDois: true
@@ -1060,22 +1060,22 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Alice Berger
         email: aberger@fredhutch.org
         role: Associate Professor
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0002-6538-2658
       - name: Janet Young
         email: jyoung@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0001-8220-8427
     topic: WDL workflow to download raw sequencing data from SRA and quantify using Salmon quasi-mapping
     enableAutoDois: true
@@ -1093,13 +1093,18 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
+      - name: Hrishi Venkatesh
+        email: hvenkate@fredhutch.org
+        role: Post-Doctoral Research Fellow
+        affiliation: Fred Hutchinson Cancer Center
+        orcid: 0000-0002-2938-3856
     description: "WDL workflow to download single-cell RNA-seq data from SRA and process using Cell Ranger count"
     topic: single-cell
     enableAutoDois: true
@@ -1123,17 +1128,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Alice Berger
         email: aberger@fredhutch.org
         role: Associate Professor
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0002-6538-2658
       - name: Janet Young
         email: jyoung@fredhutch.org
         role: Staff Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0001-8220-8427
     topic: WDL workflow to download raw sequencing data from SRA and align using STAR two-pass methodology
     enableAutoDois: true
@@ -1151,17 +1156,17 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
       - name: Emma Bishop
         email: ebishop@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0000-0003-4484-3336
       - name: Ethan Bouvet
         email: ebouvet@fredhutch.org
         role: Research Technician
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0006-6552-2522
     topic: WDL workflow for RNA-seq alignment via STAR and DESeq2 differential expression analysis
     enableAutoDois: true
@@ -1179,7 +1184,7 @@ workflows:
       - name: Taylor Firman
         email: tfirman@fredhutch.org
         role: Research Informatics Data Scientist
-        affiliation: Fred Hutch Cancer Center
+        affiliation: Fred Hutchinson Cancer Center
         orcid: 0009-0002-2052-1084
     topic: Batch ensemble generation pipeline splitting a protein FASTA into chunks for parallel STARLING processing
     enableAutoDois: true

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -596,6 +596,22 @@ tools:
       branches:
         - main
 
+  - name: ww-seurat
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-seurat/ww-seurat.wdl
+    readMePath: /modules/ww-seurat/README.md
+    authors:
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutchinson Cancer Center
+        orcid: 0000-0003-4484-3336
+    topic: WDL module for single-cell RNA-seq QC and clustering using Seurat
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-shapemapper
     subclass: WDL
     primaryDescriptorPath: /modules/ww-shapemapper/ww-shapemapper.wdl
@@ -796,6 +812,22 @@ tools:
       branches:
         - main
 
+  - name: ww-umi-tools
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-umi-tools/ww-umi-tools.wdl
+    readMePath: /modules/ww-umi-tools/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutchinson Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for UMI-aware read deduplication using umi_tools dedup
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-varscan
     subclass: WDL
     primaryDescriptorPath: /modules/ww-varscan/ww-varscan.wdl
@@ -976,6 +1008,25 @@ workflows:
       branches:
         - main
 
+  - name: ww-proseq
+    subclass: WDL
+    primaryDescriptorPath: /pipelines/ww-proseq/ww-proseq.wdl
+    readMePath: /pipelines/ww-proseq/README.md
+    testParameterFiles:
+      - /pipelines/ww-proseq/inputs.json
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutchinson Cancer Center
+        orcid: 0009-0002-2052-1084
+    description: "Paired-end PRO-seq pipeline with UMI deduplication and spike-in normalization, adapted from JAJ256/PROseq_alignment.sh"
+    topic: proseq
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-rnaseq
     subclass: WDL
     primaryDescriptorPath: /pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -1111,12 +1162,6 @@ workflows:
     filters:
       branches:
         - main
-      tags:
-        - genomics
-        - single-cell
-        - rna-seq
-        - cellranger
-        - sra
 
   - name: ww-sra-star
     subclass: WDL

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,58 +27,58 @@ keywords:
 authors:
   - family-names: Firman
     given-names: Taylor
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0009-0002-2052-1084"
   - family-names: Bishop
     given-names: Emma
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0000-0003-4484-3336"
   - family-names: Chamberlain
     given-names: Scott
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0000-0003-1444-9135"
   - family-names: Minot
     given-names: Sam
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0000-0003-1639-3905"
   - family-names: Lo
     given-names: Chris
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
   - family-names: Nondin
     given-names: Caroline
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0009-0009-0955-5954"
   - family-names: Goss
     given-names: Louisa
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0009-0005-2936-2405"
   - family-names: Berger
     given-names: Alice
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0000-0002-6538-2658"
   - family-names: Young
     given-names: Janet
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0000-0001-8220-8427"
   - family-names: Moorthi
     given-names: Sitapriya
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0000-0001-6372-5170"
   - family-names: O'Brien
     given-names: Siobhan
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0000-0003-4958-1080"
   - family-names: Glenny
     given-names: Elaine
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0000-0002-1024-4290"
   - family-names: Bouvet
     given-names: Ethan
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0009-0006-6552-2522"
   - family-names: Venkatesh
     given-names: Hrishi
-    affiliation: "Fred Hutchinson Cancer Center"
+    affiliation: "Fred Hutch Cancer Center"
     orcid: "https://orcid.org/0000-0002-2938-3856"
   - family-names: McClain
     given-names: Alexander

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,52 +27,59 @@ keywords:
 authors:
   - family-names: Firman
     given-names: Taylor
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0009-0002-2052-1084"
   - family-names: Bishop
     given-names: Emma
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0000-0003-4484-3336"
   - family-names: Chamberlain
     given-names: Scott
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0000-0003-1444-9135"
   - family-names: Minot
     given-names: Sam
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0000-0003-1639-3905"
   - family-names: Lo
     given-names: Chris
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
   - family-names: Nondin
     given-names: Caroline
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0009-0009-0955-5954"
   - family-names: Goss
     given-names: Louisa
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0009-0005-2936-2405"
   - family-names: Berger
     given-names: Alice
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0000-0002-6538-2658"
   - family-names: Young
     given-names: Janet
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0000-0001-8220-8427"
   - family-names: Moorthi
     given-names: Sitapriya
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0000-0001-6372-5170"
   - family-names: O'Brien
     given-names: Siobhan
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0000-0003-4958-1080"
   - family-names: Glenny
     given-names: Elaine
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0000-0002-1024-4290"
   - family-names: Bouvet
     given-names: Ethan
-    affiliation: "Fred Hutch Cancer Center"
+    affiliation: "Fred Hutchinson Cancer Center"
     orcid: "https://orcid.org/0009-0006-6552-2522"
+  - family-names: Venkatesh
+    given-names: Hrishi
+    affiliation: "Fred Hutchinson Cancer Center"
+    orcid: "https://orcid.org/0000-0002-2938-3856"
+  - family-names: McClain
+    given-names: Alexander
+    affiliation: "St. Jude Children's Research Hospital"

--- a/modules/ww-cellranger/README.md
+++ b/modules/ww-cellranger/README.md
@@ -38,6 +38,10 @@ When using either `run_count_hpc_cromwell` or `run_count_hpc_sprocket`, the same
 
 If your files don't follow this convention, you can use the `rename_fastqs` task from this module to rename them automatically.
 
+### Supported Cell Ranger Versions
+
+This module's `cellranger count` invocation is compatible with **Cell Ranger 8.x, 9.x, and 10.x**. The CLI for the flags used here (including the required `--create-bam`) has been stable across those releases. To use a specific version, override `docker_image` (for `run_count`) or `cellranger_module` (for the HPC variants) with your preferred release. **Cell Ranger 7.x and earlier are not supported** because they predate the `--create-bam` flag.
+
 ### Current Limitations
 
 **This module currently only accepts samples that are gene expression (GEX) only.** Feature barcoding data (e.g., antibody-derived tags, CRISPR guides) is not supported at this time.

--- a/modules/ww-cellranger/ww-cellranger.wdl
+++ b/modules/ww-cellranger/ww-cellranger.wdl
@@ -38,7 +38,7 @@ task run_count {
     expect_cells: "Optional: Expected number of recovered cells"
     chemistry: "Optional: Assay configuration (e.g. SC3Pv2)"
     skip_on_chemistry_failure: "When `true`, let task succeed with absent outputs if chemistry can't be auto detected."
-    docker_image: "Private Cell Ranger Docker image. No public image is provided because Cell Ranger is not redistributable; build your own from the WILDS Dockerfile recipe."
+    docker_image: "Private Cell Ranger Docker image. No public image is provided because Cell Ranger is not redistributable; build your own from the WILDS Dockerfile recipe. Compatible with Cell Ranger 8.x-10.x; v7 and earlier are not supported."
   }
 
   input {
@@ -204,7 +204,7 @@ task run_count_hpc_cromwell {
     expect_cells: "Optional: Expected number of recovered cells"
     chemistry: "Optional: Assay configuration (e.g. SC3Pv2)"
     skip_on_chemistry_failure: "When `true`, let task succeed with absent outputs if chemistry can't be auto detected."
-    cellranger_module: "HPC environment module to load for Cell Ranger (e.g. 'CellRanger/10.0.0')"
+    cellranger_module: "HPC environment module to load for Cell Ranger (e.g. 'CellRanger/10.0.0'). Compatible with Cell Ranger 8.x-10.x; v7 and earlier are not supported."
   }
 
   input {
@@ -376,7 +376,7 @@ task run_count_hpc_sprocket {
     expect_cells: "Optional: Expected number of recovered cells"
     chemistry: "Optional: Assay configuration (e.g. SC3Pv2)"
     skip_on_chemistry_failure: "When `true`, let task succeed with absent outputs if chemistry can't be auto detected."
-    cellranger_module: "HPC environment module to load for Cell Ranger (e.g. 'CellRanger/10.0.0')"
+    cellranger_module: "HPC environment module to load for Cell Ranger (e.g. 'CellRanger/10.0.0'). Compatible with Cell Ranger 8.x-10.x; v7 and earlier are not supported."
   }
 
   input {

--- a/modules/ww-sra/README.md
+++ b/modules/ww-sra/README.md
@@ -10,6 +10,12 @@ This module provides reusable WDL tasks for downloading sequencing data from the
 
 The module uses `prefetch` + `fasterq-dump` for efficient, multi-threaded downloading of FASTQ files from SRA accessions, with optional NGC authentication for downloading controlled-access dbGaP data.
 
+## Data Governance
+
+When pulling controlled-access data from dbGaP via the `ngc_file` input, you are bound by the data use agreement attached to that study, which typically restricts where the downloaded FASTQs (and any data derived from them) may be stored. **Make sure to run any workflow that imports this module in a location approved for regulated data storage** and avoid persisting outputs to general-purpose or shared filesystems.
+
+**Fred Hutch users:** Use [PROOF Regulated](https://sciwiki.fredhutch.org/datademos/proof-regulated/) to submit workflows that use this module. PROOF Regulated stages analysis data under `/fh/regulated`, which is set up for compliance with dbGaP and similar data use agreements.
+
 ## Module Structure
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -10,9 +10,13 @@ This pipeline combines the `ww-sra` and `ww-cellranger` modules to download scRN
 
 The pipeline automatically handles FASTQ renaming to satisfy Cell Ranger's strict naming convention, so users only need to provide SRA accession IDs and a reference transcriptome.
 
-## Scope and Limitations
+## Scope and Data Governance
 
 This pipeline is scoped as an on-ramp for users who are new to computational workflows, but want Cell Ranger count outputs from SRA samples. To match that scope, BAM output is disabled: the pipeline hardcodes `create_bam = false` on all Cell Ranger calls and does not expose it as a workflow input. This avoids producing the largest Cell Ranger output for users whose downstream tooling (Seurat, Scanpy) reads directly from the `.h5` or matrix files, and avoids accidental persistence of BAMs derived from controlled-access dbGaP data, where redistribution restrictions typically prohibit sharing them.
+
+When pulling controlled-access data from dbGaP via the `ngc_file` input, you are bound by the data use agreement attached to that study, which typically restricts where derived data (FASTQs, count matrices, BAMs, etc.) may be stored. **Make sure to run this pipeline in a location approved for regulated data storage** and avoid persisting outputs to general-purpose or shared filesystems.
+
+**Fred Hutch users:** Use [PROOF Regulated](https://sciwiki.fredhutch.org/datademos/proof-regulated/) to submit this pipeline. PROOF Regulated stages analysis data under `/fh/regulated`, which is set up for compliance with dbGaP and similar data use agreements.
 
 ## Pipeline Structure
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -10,6 +10,10 @@ This pipeline combines the `ww-sra` and `ww-cellranger` modules to download scRN
 
 The pipeline automatically handles FASTQ renaming to satisfy Cell Ranger's strict naming convention, so users only need to provide SRA accession IDs and a reference transcriptome.
 
+## Scope and Limitations
+
+This pipeline is scoped as an on-ramp for users who are new to computational workflows, but want Cell Ranger count outputs from SRA samples. To match that scope, BAM output is disabled: the pipeline hardcodes `create_bam = false` on all Cell Ranger calls and does not expose it as a workflow input. This avoids producing the largest Cell Ranger output for users whose downstream tooling (Seurat, Scanpy) reads directly from the `.h5` or matrix files, and avoids accidental persistence of BAMs derived from controlled-access dbGaP data, where redistribution restrictions typically prohibit sharing them.
+
 ## Pipeline Structure
 
 This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and demonstrates:
@@ -107,7 +111,6 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `memory_gb` | Memory allocation in GB | Int | No | 64 |
 | `max_reads` | Maximum reads to download per sample (for testing) | Int | No | all reads |
 | `ngc_file` | NGC repository key file for controlled-access dbGaP data | File | No | - |
-| `create_bam` | Whether Cell Ranger should generate a BAM file | Boolean | No | true |
 | `expect_cells` | Expected number of recovered cells per sample | Int | No | - |
 | `chemistry` | Assay configuration (e.g., SC3Pv2, SC3Pv3) | String | No | auto-detect |
 | `skip_on_chemistry_failure` | If true, samples Cell Ranger can't auto-detect a chemistry for are skipped instead of failing the workflow. See the module [README](../../modules/ww-cellranger/README.md#graceful-chemistry-detection-skip). | Boolean | No | `false` |

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -194,6 +194,8 @@ For questions, bugs, and/or feature requests, reach out to the Fred Hutch Office
 
 ## Contributing
 
+Special thanks to [Hrishi Venkatesh](https://github.com/hvenkat94) for extensive testing of this pipeline on HPC infrastructure and for identifying important edge cases that have shaped its current scope and design. Thank you for your contributions!
+
 If you would like to contribute to this WILDS WDL pipeline, please see our [contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
 
 ## License

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -18,7 +18,6 @@ workflow sra_cellranger_example {
     ncpu = 2,
     memory_gb = 6,
     max_reads = 1000000,
-    create_bam = false,
     skip_on_chemistry_failure = true
   }
 

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -19,7 +19,6 @@ workflow sra_cellranger_example {
     ncpu = 2,
     memory_gb = 6,
     max_reads = 1000000,
-    create_bam = false,
     skip_on_chemistry_failure = true,
     execution_mode = "hpc_sprocket"
   }

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -26,7 +26,6 @@ workflow sra_cellranger {
     memory_gb: "memory allocation in GB for Cell Ranger tasks"
     max_reads: "Optional maximum number of reads to download from SRA (for testing/downsampling). If not specified, downloads all reads."
     ngc_file: "Optional NGC repository key file for downloading controlled-access dbGaP data."
-    create_bam: "Whether Cell Ranger should generate a BAM file (default: true)"
     expect_cells: "Optional expected number of recovered cells per sample"
     chemistry: "Optional assay configuration for Cell Ranger (e.g. SC3Pv2, SC3Pv3)"
     skip_on_chemistry_failure: "When `true`, let task succeed with absent outputs if chemistry can't be auto detected."
@@ -42,7 +41,6 @@ workflow sra_cellranger {
     Int memory_gb = 64
     Int? max_reads
     File? ngc_file
-    Boolean create_bam = true
     Int? expect_cells
     String? chemistry
     Boolean skip_on_chemistry_failure = false
@@ -80,7 +78,7 @@ workflow sra_cellranger {
           r2_fastqs = [rename_fastqs.r2_renamed],
           ref_gex = ref_gex,
           sample_id = id,
-          create_bam = create_bam,
+          create_bam = false,
           cpu_cores = ncpu,
           memory_gb = memory_gb,
           expect_cells = expect_cells,
@@ -96,7 +94,7 @@ workflow sra_cellranger {
           r2_fastqs = [rename_fastqs.r2_renamed],
           ref_gex = ref_gex,
           sample_id = id,
-          create_bam = create_bam,
+          create_bam = false,
           cpu_cores = ncpu,
           memory_gb = memory_gb,
           expect_cells = expect_cells,
@@ -112,7 +110,7 @@ workflow sra_cellranger {
           r2_fastqs = [rename_fastqs.r2_renamed],
           ref_gex = ref_gex,
           sample_id = id,
-          create_bam = create_bam,
+          create_bam = false,
           cpu_cores = ncpu,
           memory_gb = memory_gb,
           expect_cells = expect_cells,

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -5,8 +5,16 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 
 workflow sra_cellranger {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Hrishi Venkatesh",
+            email: "hvenkate@fredhutch.org"
+        }
+    ]
     description: "WDL workflow to download single-cell RNA-seq data from SRA and process using Cell Ranger count"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
     outputs: {

--- a/pipelines/ww-sra-salmon/README.md
+++ b/pipelines/ww-sra-salmon/README.md
@@ -10,6 +10,12 @@ This pipeline showcases how to combine WILDS WDL modules to create a complete RN
 
 This pipeline serves as both a functional workflow and a demonstration of modular WDL design patterns within the WILDS ecosystem.
 
+## Data Governance
+
+When pulling controlled-access data from dbGaP via the `ngc_file` input, you are bound by the data use agreement attached to that study, which typically restricts where derived data (FASTQs, transcript quantifications, etc.) may be stored. **Make sure to run this pipeline in a location approved for regulated data storage** and avoid persisting outputs to general-purpose or shared filesystems.
+
+**Fred Hutch users:** Use [PROOF Regulated](https://sciwiki.fredhutch.org/datademos/proof-regulated/) to submit this pipeline. PROOF Regulated stages analysis data under `/fh/regulated`, which is set up for compliance with dbGaP and similar data use agreements.
+
 ## Pipeline Structure
 
 This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and demonstrates:

--- a/pipelines/ww-sra-star/README.md
+++ b/pipelines/ww-sra-star/README.md
@@ -10,6 +10,12 @@ This pipeline showcases how to combine WILDS WDL modules to create a complete RN
 
 This pipeline serves as both a functional workflow and a demonstration of modular WDL design patterns within the WILDS ecosystem.
 
+## Data Governance
+
+When pulling controlled-access data from dbGaP via the `ngc_file` input, you are bound by the data use agreement attached to that study, which typically restricts where derived data (FASTQs, alignments, BAMs, etc.) may be stored. **Make sure to run this pipeline in a location approved for regulated data storage** and avoid persisting outputs to general-purpose or shared filesystems.
+
+**Fred Hutch users:** Use [PROOF Regulated](https://sciwiki.fredhutch.org/datademos/proof-regulated/) to submit this pipeline. PROOF Regulated stages analysis data under `/fh/regulated`, which is set up for compliance with dbGaP and similar data use agreements.
+
 ## Pipeline Structure
 
 This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and demonstrates:


### PR DESCRIPTION
## Type of Change

- Bug fix (`ww-sra-cellranger`: removes `create_bam` input, hardcodes `create_bam = false`)
- Documentation update (Cell Ranger version-compatibility note in `ww-cellranger`; new Data Governance sections in `ww-sra`, `ww-sra-cellranger`, `ww-sra-star`, and `ww-sra-salmon`; new co-author acknowledgement)
- Other: Dockstore registration backfill for three previously unlisted modules/pipelines (`ww-seurat`, `ww-umi-tools`, `ww-proseq`)

## Description

This branch bundles four related-but-distinct improvements:

1. **`ww-sra-cellranger` no longer produces BAMs.** Removes the `create_bam` workflow input and hardcodes `create_bam = false` on all three dispatch branches (`run_count`, `run_count_hpc_cromwell`, `run_count_hpc_sprocket`). Pipeline is scoped as a WDL on-ramp for getting Cell Ranger count outputs from SRA samples; exposing `create_bam` at the pipeline level cut against that scope in two ways: (a) users pulling dbGaP data via `ngc_file` are typically bound by redistribution restrictions that prohibit sharing BAMs, and (b) BAMs are the largest Cell Ranger output and typical downstream single-cell tooling (Seurat, Scanpy) reads from the `.h5` or matrix files. The pipeline README's prior "Scope and Limitations" section has been renamed to **Scope and Data Governance** and the regulated-data guidance has been folded into it.

2. **Data governance documentation for the SRA-pulling family.** Added new **Data Governance** sections to the `ww-sra-star` and `ww-sra-salmon` pipeline READMEs and to the `ww-sra` module README, telling users that dbGaP-derived data must be stored in a location approved for regulated data and pointing Fred Hutch users at PROOF Regulated (`/fh/regulated`). The other two SRA-pulling pipelines are not changing their default behavior — their whole purpose is to produce aligned or quantified data, so removing those outputs would defeat the pipeline. The governance message is therefore a documentation-only reminder rather than a behavior change.

3. **Documenting Cell Ranger version compatibility in `ww-cellranger`.** A collaborator asked about running the module against Cell Ranger v8 rather than v10. Verified via 10x's release notes that v8.x, v9.x, and v10.x all share the `cellranger count` CLI used by this module (the required `--create-bam` flag landed in v8.0). Added a **Supported Cell Ranger Versions** section to the module README and short compatibility notes to the `docker_image` / `cellranger_module` `parameter_meta` entries. v7.x and earlier are explicitly not supported (they predate `--create-bam`). Confirmed end-to-end with a v8 environment-module test run on Fred Hutch HPC via Sprocket.

4. **Recognizing Hrishi Venkatesh as a `ww-sra-cellranger` co-author.** Adds Hrishi to the pipeline's WDL `meta` block (multi-author list), the `.dockstore.yml` authors list for the `ww-sra-cellranger` entry, and the top-level `CITATION.cff`. New **Contributing** section in the pipeline README acknowledges his testing work on HPC and his role in shaping the pipeline's scope and design.

5. **Dockstore registration backfill.** Audit revealed three real modules/pipelines were not registered in `.dockstore.yml`: `ww-seurat` (single-cell QC and clustering via Seurat), `ww-umi-tools` (UMI-aware dedup via `umi_tools dedup`), and `ww-proseq` (paired-end PRO-seq pipeline). Added entries for all three, mirroring the structure of similar existing entries and pulling author info from each WDL `meta` block.

## Related Issue

Closes #358.

## Testing

**How did you test these changes?**
- `make lint_sprocket NAME=ww-sra-cellranger` after the `create_bam` removal — clean.
- Confirmed `.dockstore.yml` still parses as YAML after each insertion; entry counts went from 50 tools / 14 workflows to 52 tools / 15 workflows as expected.
- Ran `testrun_hpc.wdl` end-to-end on Fred Hutch HPC via Sprocket against a Cell Ranger v8 environment module to validate the version-compatibility claim (this also exercises the `create_bam = false` change through the full HPC dispatch path).

**What workflow engine did you use?**
Cromwell (on Fred Hutch HPC for the v8 test run); sprocket lint locally. Full Cromwell + miniWDL + Sprocket coverage will be exercised by CI on push.

**Did the tests pass?**
Yes. The v8 HPC `testrun_hpc.wdl` produced clean Cell Ranger outputs (results tarball, web summary, metrics CSV) end-to-end.

## Documentation

- [x] I updated the README (if applicable): `ww-cellranger`, `ww-sra-cellranger`, `ww-sra`, `ww-sra-star`, `ww-sra-salmon`
- [x] I added/updated parameter descriptions in the WDL (if applicable): version-compatibility notes on `ww-cellranger` count tasks; removed `create_bam` parameter_meta from `ww-sra-cellranger`
- [x] I ran `make docs-preview` to check documentation rendering (if applicable)