### PR TITLE
Accept Run Selector txt file as input for `ww-sra-cellranger`

### DIFF
--- a/modules/ww-cellranger/testrun.wdl
+++ b/modules/ww-cellranger/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellranger/ww-cellranger.wdl" as ww_cellranger
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/run-selector-input/modules/ww-cellranger/ww-cellranger.wdl" as ww_cellranger
 
 workflow cellranger_example {
 

--- a/modules/ww-cellranger/ww-cellranger.wdl
+++ b/modules/ww-cellranger/ww-cellranger.wdl
@@ -153,10 +153,13 @@ task run_count {
     # Create tarball of output directory
     tar -czf "~{sample_id}_outs.tar.gz" "~{sample_id}/outs"
 
-    # Move output files to working directory for outputting
-    mv "~{sample_id}/outs/web_summary.html" .
-    mv "~{sample_id}/outs/metrics_summary.csv" .
-    mv "~{sample_id}/outs/filtered_feature_bc_matrix.h5" .
+    # Move output files to working directory for outputting, prefixing
+    # each with the sample ID so basenames stay unique when a downstream
+    # workflow flattens multiple samples into one directory (e.g.
+    # Cromwell's final_workflow_outputs_dir).
+    mv "~{sample_id}/outs/web_summary.html" "~{sample_id}_web_summary.html"
+    mv "~{sample_id}/outs/metrics_summary.csv" "~{sample_id}_metrics_summary.csv"
+    mv "~{sample_id}/outs/filtered_feature_bc_matrix.h5" "~{sample_id}_filtered_feature_bc_matrix.h5"
 
     # Clean up Cell Ranger output directory for housekeeping
     # (and to avoid Sprocket symlink validation errors)
@@ -166,9 +169,9 @@ task run_count {
   output {
     File chemistry_status = "chemistry_status.txt"
     File? results_tar = "~{sample_id}_outs.tar.gz"
-    File? web_summary = "web_summary.html"
-    File? metrics_summary = "metrics_summary.csv"
-    File? filtered_h5 = "filtered_feature_bc_matrix.h5"
+    File? web_summary = "~{sample_id}_web_summary.html"
+    File? metrics_summary = "~{sample_id}_metrics_summary.csv"
+    File? filtered_h5 = "~{sample_id}_filtered_feature_bc_matrix.h5"
   }
 
   runtime {
@@ -323,10 +326,13 @@ task run_count_hpc_cromwell {
     # Create tarball of output directory
     tar -czf "~{sample_id}_outs.tar.gz" "~{sample_id}/outs"
 
-    # Move output files to working directory for outputting
-    mv "~{sample_id}/outs/web_summary.html" .
-    mv "~{sample_id}/outs/metrics_summary.csv" .
-    mv "~{sample_id}/outs/filtered_feature_bc_matrix.h5" .
+    # Move output files to working directory for outputting, prefixing
+    # each with the sample ID so basenames stay unique when a downstream
+    # workflow flattens multiple samples into one directory (e.g.
+    # Cromwell's final_workflow_outputs_dir).
+    mv "~{sample_id}/outs/web_summary.html" "~{sample_id}_web_summary.html"
+    mv "~{sample_id}/outs/metrics_summary.csv" "~{sample_id}_metrics_summary.csv"
+    mv "~{sample_id}/outs/filtered_feature_bc_matrix.h5" "~{sample_id}_filtered_feature_bc_matrix.h5"
 
     # Clean up Cell Ranger output directory for housekeeping
     # (and to avoid Sprocket symlink validation errors)
@@ -336,9 +342,9 @@ task run_count_hpc_cromwell {
   output {
     File chemistry_status = "chemistry_status.txt"
     File? results_tar = "~{sample_id}_outs.tar.gz"
-    File? web_summary = "web_summary.html"
-    File? metrics_summary = "metrics_summary.csv"
-    File? filtered_h5 = "filtered_feature_bc_matrix.h5"
+    File? web_summary = "~{sample_id}_web_summary.html"
+    File? metrics_summary = "~{sample_id}_metrics_summary.csv"
+    File? filtered_h5 = "~{sample_id}_filtered_feature_bc_matrix.h5"
   }
 
   # No docker/container runtime key: Cromwell's HPC backend runs this
@@ -497,10 +503,13 @@ task run_count_hpc_sprocket {
     # Create tarball of output directory
     tar -czf "~{sample_id}_outs.tar.gz" "~{sample_id}/outs"
 
-    # Move output files to working directory for outputting
-    mv "~{sample_id}/outs/web_summary.html" .
-    mv "~{sample_id}/outs/metrics_summary.csv" .
-    mv "~{sample_id}/outs/filtered_feature_bc_matrix.h5" .
+    # Move output files to working directory for outputting, prefixing
+    # each with the sample ID so basenames stay unique when a downstream
+    # workflow flattens multiple samples into one directory (e.g.
+    # Cromwell's final_workflow_outputs_dir).
+    mv "~{sample_id}/outs/web_summary.html" "~{sample_id}_web_summary.html"
+    mv "~{sample_id}/outs/metrics_summary.csv" "~{sample_id}_metrics_summary.csv"
+    mv "~{sample_id}/outs/filtered_feature_bc_matrix.h5" "~{sample_id}_filtered_feature_bc_matrix.h5"
 
     # Clean up Cell Ranger output directory for housekeeping
     # (and to avoid Sprocket symlink validation errors)
@@ -510,9 +519,9 @@ task run_count_hpc_sprocket {
   output {
     File chemistry_status = "chemistry_status.txt"
     File? results_tar = "~{sample_id}_outs.tar.gz"
-    File? web_summary = "web_summary.html"
-    File? metrics_summary = "metrics_summary.csv"
-    File? filtered_h5 = "filtered_feature_bc_matrix.h5"
+    File? web_summary = "~{sample_id}_web_summary.html"
+    File? metrics_summary = "~{sample_id}_metrics_summary.csv"
+    File? filtered_h5 = "~{sample_id}_filtered_feature_bc_matrix.h5"
   }
 
   # Minimal Lua-having container so the host's bind-mounted Lmod can

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -98,7 +98,7 @@ SRR1039508
 SRR13777504
 ```
 
-One accession per line, with no header row, commas, or quotes: exactly like the file the **Accession List** button exports (under **Select** > **Download** > **Accession List**).
+One accession per line, with no header row, commas, or quotes: exactly what the **Accession List** button exports (scroll to the **Select** table > find the **Download** column > click the **Accession List** button).
 
 **Curate your list in Run Selector before running.** This is a manual step, and an important one. Many SRA studies group multiple assay types under a single project: it is common to find single-cell RNA-seq, multiome RNA and ATAC, bulk RNA-seq, and whole-exome runs all under one accession. The SRA metadata does not reliably flag which runs are single-cell. `library_strategy` is `RNA-Seq` for both single-cell and bulk transcriptomic runs, and the only single-cell signal is often a submitter-specific naming convention in the free-text `library_name` field. There is no automated rule that picks the correct Cell Ranger inputs across studies, so the pipeline does not attempt one. Use Run Selector's filters and the per-run library names to select only the runs you intend to feed to Cell Ranger, then export that subset as your accession list.
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -100,9 +100,7 @@ SRR13777504
 
 One accession per line, with no header row, commas, or quotes: exactly what the **Accession List** button exports (scroll to the **Select** table > find the **Download** column > click the **Accession List** button).
 
-**Curate your list in Run Selector before running.** This is a manual step, and an important one. Many SRA studies group multiple assay types under a single project: it is common to find single-cell RNA-seq, multiome RNA and ATAC, bulk RNA-seq, and whole-exome runs all under one accession. The SRA metadata does not reliably flag which runs are single-cell. `library_strategy` is `RNA-Seq` for both single-cell and bulk transcriptomic runs, and the only single-cell signal is often a submitter-specific naming convention in the free-text `library_name` field. There is no automated rule that picks the correct Cell Ranger inputs across studies, so the pipeline does not attempt one. Use Run Selector's filters and the per-run library names to select only the runs you intend to feed to Cell Ranger, then export that subset as your accession list.
-
-If a non-single-cell run does slip through, `skip_on_chemistry_failure` is the safety net rather than a substitute for curation. See [Mixed single-cell / non-single-cell input](#mixed-single-cell--non-single-cell-input) below.
+**Curate your list in Run Selector before running.** Many SRA studies group multiple assay types under a single project: it is common to find single-cell RNA-seq, multiome RNA and ATAC, bulk RNA-seq, and whole-exome runs all under one accession. Use Run Selector's filters to select only the runs you intend to feed to Cell Ranger, then export that subset as your accession list. If a non-single-cell run does slip through, `skip_on_chemistry_failure` is the safety net rather than a substitute for curation. See [Mixed single-cell / non-single-cell input](#mixed-single-cell--non-single-cell-input) below.
 
 ### Running the Pipeline
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -98,7 +98,7 @@ SRR1039508
 SRR13777504
 ```
 
-One accession per line, with no header row, commas, or quotes: exactly what the **Accession List** button exports. (Be careful not to grab the adjacent **Metadata** button instead, which downloads a multi-column CSV rather than a bare accession list.)
+One accession per line, with no header row, commas, or quotes: exactly like the file the **Accession List** button exports (under **Select** > **Download** > **Accession List**).
 
 **Curate your list in Run Selector before running.** This is a manual step, and an important one. Many SRA studies group multiple assay types under a single project: it is common to find single-cell RNA-seq, multiome RNA and ATAC, bulk RNA-seq, and whole-exome runs all under one accession. The SRA metadata does not reliably flag which runs are single-cell. `library_strategy` is `RNA-Seq` for both single-cell and bulk transcriptomic runs, and the only single-cell signal is often a submitter-specific naming convention in the free-text `library_name` field. There is no automated rule that picks the correct Cell Ranger inputs across studies, so the pipeline does not attempt one. Use Run Selector's filters and the per-run library names to select only the runs you intend to feed to Cell Ranger, then export that subset as your accession list.
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -125,7 +125,7 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 
 | Parameter | Description | Type | Required? | Default |
 |-----------|-------------|------|-----------|---------|
-| `sra_id_file` | Text file of SRA accession IDs, one per line (e.g. the "Accession List" export from [SRA Run Selector](https://www.ncbi.nlm.nih.gov/Traces/study/)). See [Selecting Samples with SRA Run Selector](#selecting-samples-with-sra-run-selector) for details. | File | One of `sra_id_file` / `sra_id_list` | - |
+| `sra_id_file` | Text file of SRA accession IDs, one per line | File | One of `sra_id_file` / `sra_id_list` | - |
 | `sra_id_list` | List of SRA accession IDs to download. Alternative to `sra_id_file`. | Array[String] | One of `sra_id_file` / `sra_id_list` | - |
 | `ref_gex` | Cell Ranger GEX reference transcriptome tarball | File | Yes | - |
 | `ncpu` | Number of CPU cores | Int | No | 8 |

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -90,7 +90,15 @@ Create an inputs JSON file with your SRA accessions and Cell Ranger reference. P
 
 ### Selecting Samples with SRA Run Selector
 
-`sra_id_file` is the one-accession-per-line text file produced by the **Accession List** button in NCBI's [SRA Run Selector](https://www.ncbi.nlm.nih.gov/Traces/study/). For any study with more than a handful of samples, this is the recommended way to provide inputs.
+`sra_id_file` is the one-accession-per-line text file produced by the **Accession List** button in NCBI's [SRA Run Selector](https://www.ncbi.nlm.nih.gov/Traces/study/). For any study with more than a handful of samples, this is the recommended way to provide inputs. It should look like this:
+
+```
+SRR7722937
+SRR1039508
+SRR13777504
+```
+
+One accession per line, with no header row, commas, or quotes: exactly what the **Accession List** button exports. (Be careful not to grab the adjacent **Metadata** button instead, which downloads a multi-column CSV rather than a bare accession list.)
 
 **Curate your list in Run Selector before running.** This is a manual step, and an important one. Many SRA studies group multiple assay types under a single project: it is common to find single-cell RNA-seq, multiome RNA and ATAC, bulk RNA-seq, and whole-exome runs all under one accession. The SRA metadata does not reliably flag which runs are single-cell. `library_strategy` is `RNA-Seq` for both single-cell and bulk transcriptomic runs, and the only single-cell signal is often a submitter-specific naming convention in the free-text `library_name` field. There is no automated rule that picks the correct Cell Ranger inputs across studies, so the pipeline does not attempt one. Use Run Selector's filters and the per-run library names to select only the runs you intend to feed to Cell Ranger, then export that subset as your accession list.
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -70,11 +70,11 @@ Unused inputs are ignored — e.g., `docker_image` has no effect when `execution
 
 ### Input Configuration
 
-Create an inputs JSON file with your SRA accessions and Cell Ranger reference:
+Create an inputs JSON file with your SRA accessions and Cell Ranger reference. Provide the samples either as a text file of accessions (`sra_id_file`, shown below) or as an inline array (`sra_id_list`):
 
 ```json
 {
-  "sra_cellranger.sra_id_list": ["SRR12345678"],
+  "sra_cellranger.sra_id_file": "/path/to/SRR_Acc_List.txt",
   "sra_cellranger.ref_gex": "/path/to/cellranger/reference.tar.gz",
   "sra_cellranger.ncpu": 8,
   "sra_cellranger.memory_gb": 64,
@@ -87,6 +87,14 @@ Create an inputs JSON file with your SRA accessions and Cell Ranger reference:
 > **Note:** This template sets `execution_mode: "hpc_cromwell"` so it works out of the box for Fred Hutch users on PROOF (where Cell Ranger is provided as the `CellRanger/10.0.0` environment module under Cromwell). The WDL default is `"docker"` — if you are running on a container-based backend, change it to `"docker"` and override `docker_image` to point at your private Cell Ranger image. If you are submitting to Sprocket-on-HPC instead of Cromwell-on-HPC, change it to `"hpc_sprocket"`. See [Cell Ranger Software Environment](#cell-ranger-software-environment) above for details.
 >
 > The `ngc_file` parameter is optional. Include it when downloading controlled-access dbGaP data.
+
+### Selecting Samples with SRA Run Selector
+
+`sra_id_file` is the one-accession-per-line text file produced by the **Accession List** button in NCBI's [SRA Run Selector](https://www.ncbi.nlm.nih.gov/Traces/study/). For any study with more than a handful of samples, this is the recommended way to provide inputs.
+
+**Curate your list in Run Selector before running.** This is a manual step, and an important one. Many SRA studies group multiple assay types under a single project: it is common to find single-cell RNA-seq, multiome RNA and ATAC, bulk RNA-seq, and whole-exome runs all under one accession. The SRA metadata does not reliably flag which runs are single-cell. `library_strategy` is `RNA-Seq` for both single-cell and bulk transcriptomic runs, and the only single-cell signal is often a submitter-specific naming convention in the free-text `library_name` field. There is no automated rule that picks the correct Cell Ranger inputs across studies, so the pipeline does not attempt one. Use Run Selector's filters and the per-run library names to select only the runs you intend to feed to Cell Ranger, then export that subset as your accession list.
+
+If a non-single-cell run does slip through, `skip_on_chemistry_failure` is the safety net rather than a substitute for curation. See [Mixed single-cell / non-single-cell input](#mixed-single-cell--non-single-cell-input) below.
 
 ### Running the Pipeline
 
@@ -109,7 +117,8 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 
 | Parameter | Description | Type | Required? | Default |
 |-----------|-------------|------|-----------|---------|
-| `sra_id_list` | List of SRA accession IDs to download | Array[String] | Yes | - |
+| `sra_id_file` | Text file of SRA accession IDs, one per line (e.g. the "Accession List" export from [SRA Run Selector](https://www.ncbi.nlm.nih.gov/Traces/study/)). See [Selecting Samples with SRA Run Selector](#selecting-samples-with-sra-run-selector) for details. | File | One of `sra_id_file` / `sra_id_list` | - |
+| `sra_id_list` | List of SRA accession IDs to download. Alternative to `sra_id_file`. | Array[String] | One of `sra_id_file` / `sra_id_list` | - |
 | `ref_gex` | Cell Ranger GEX reference transcriptome tarball | File | Yes | - |
 | `ncpu` | Number of CPU cores | Int | No | 8 |
 | `memory_gb` | Memory allocation in GB | Int | No | 64 |

--- a/pipelines/ww-sra-cellranger/inputs.json
+++ b/pipelines/ww-sra-cellranger/inputs.json
@@ -1,5 +1,5 @@
 {
-  "sra_cellranger.sra_id_list": ["SRR12345678", "SRR12345679"],
+  "sra_cellranger.sra_id_file": "/path/to/SRR_Acc_List.txt",
   "sra_cellranger.ref_gex": "/path/to/cellranger/reference.tar.gz",
   "sra_cellranger.ncpu": 8,
   "sra_cellranger.memory_gb": 64,

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/run-selector-input/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 workflow sra_cellranger_example {
   # Download a small GEX reference for Cell Ranger

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellranger/ww-cellranger.wdl" as cellranger_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/run-selector-input/modules/ww-cellranger/ww-cellranger.wdl" as cellranger_tasks
 
 workflow sra_cellranger {
   meta {

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -28,7 +28,8 @@ workflow sra_cellranger {
   }
 
   parameter_meta {
-    sra_id_list: "list of SRA sample ID's to be pulled down and processed with Cell Ranger"
+    sra_id_list: "Array of SRA sample ID's to be pulled down and processed with Cell Ranger. Provide this or `sra_id_file` (the file takes precedence when both are given)."
+    sra_id_file: "Optional text file of SRA sample ID's, one per line, as an alternative to `sra_id_list`. This is the format produced by the 'Accession List' button in NCBI's SRA Run Selector."
     ref_gex: "GEX reference transcriptome tarball for Cell Ranger"
     ncpu: "number of CPUs to use for SRA download and Cell Ranger processing"
     memory_gb: "memory allocation in GB for Cell Ranger tasks"
@@ -43,7 +44,8 @@ workflow sra_cellranger {
   }
 
   input {
-    Array[String] sra_id_list
+    Array[String]? sra_id_list
+    File? sra_id_file
     File ref_gex
     Int ncpu = 8
     Int memory_gb = 64
@@ -57,7 +59,15 @@ workflow sra_cellranger {
     String cellranger_module = "CellRanger/10.0.0"
   }
 
-  scatter (id in sra_id_list) {
+  # Resolve the sample list from whichever input was provided. A
+  # Run-Selector-style text file (one accession per line) takes
+  # precedence over the inline array; supplying neither fails loudly
+  # via select_first.
+  Array[String] sra_ids = if defined(sra_id_file)
+    then read_lines(select_first([sra_id_file]))
+    else select_first([sra_id_list])
+
+  scatter (id in sra_ids) {
     # Download FASTQ files from SRA
     call sra_tasks.fastqdump { input:
         sra_id = id,
@@ -154,7 +164,7 @@ workflow sra_cellranger {
   # Partition sample_ids into "ran" vs "skipped" based on each
   # chemistry_status file's contents.
   call summarize_chemistry_status { input:
-      sample_ids = sra_id_list,
+      sample_ids = sra_ids,
       chemistry_status_files = chemistry_status_file
   }
 


### PR DESCRIPTION
## Type of Change

- New feature (optional `sra_id_file` input for an existing pipeline)
- Bug fix (output filename collision in `ww-cellranger`)

## Description

Two related changes to the `ww-sra-cellranger` stack.

**1. Optional `sra_id_file` input (feature).** A plain-text file of SRA run accessions (one per line) as an alternative to the inline `sra_id_list` array, matching the **Accession List** export from NCBI's [SRA Run Selector](https://www.ncbi.nlm.nih.gov/Traces/study/) so curated lists drop in with no reformatting.

- `ww-sra-cellranger.wdl`: added `File? sra_id_file`, made `sra_id_list` optional, and resolve both into one `sra_ids` list via `read_lines` (file takes precedence; neither fails loudly via `select_first`). Added `parameter_meta` for both.
- `inputs.json` + `README.md`: template now demonstrates `sra_id_file`; new Run Selector subsection plus updated Input Parameters table.

Complements, not replaces, the `skip_on_chemistry_failure` graceful-fail behavior (#357), which remains the safety net for a mis-picked accession.

**2. Sample-prefixed Cell Ranger output basenames (bug fix).** A collaborator running on a real dbGaP dataset with Cromwell's `final_workflow_outputs_dir` hit collisions on web summaries and filtered `.h5`s: three of the four `ww-cellranger` count outputs used static basenames that clobber each other once outputs are flattened into one directory. Prefixed `web_summary`, `metrics_summary`, and `filtered_h5` with `~{sample_id}` (matching the existing `results_tar` convention) across all three count task variants. Fixed at the module; the pipeline needs no changes since it references outputs by variable name.

## Related Issue

Fixes #362

## Testing

**How did you test these changes?**
Sprocket lint on the pipeline (`make lint_sprocket NAME=ww-sra-cellranger`) plus a PROOF testrun of the `sra_id_file` path with the two existing test accessions (`SRR7722937` single-cell, `SRR1039508` bulk), confirming the single-cell/skipped partition is unchanged. The collision was reproduced and confirmed fixed by a collaborator's full dbGaP run with `final_workflow_outputs_dir` set.

**What workflow engine did you use?**
Sprocket for linting, PROOF/Cromwell for test runs, all three for the GitHub Action test runs below.

**Did the tests pass?**
Still in progress...

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)