### PR TITLE
Add TSV samplesheet and prebuilt index inputs to `ww-proseq`

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1066,6 +1066,7 @@ workflows:
         email: rwang4@fredhutch.org
         role: Postdoctoral Research Fellow
         affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0008-5342-3433
     description: "Paired-end PRO-seq pipeline with UMI deduplication and spike-in normalization, adapted from JAJ256/PROseq_alignment.sh"
     topic: proseq
     enableAutoDois: true

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1020,6 +1020,10 @@ workflows:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
+      - name: Ruihong Wang
+        email: rwang4@fredhutch.org
+        role: Postdoctoral Research Fellow
+        affiliation: Fred Hutch Cancer Center
     description: "Paired-end PRO-seq pipeline with UMI deduplication and spike-in normalization, adapted from JAJ256/PROseq_alignment.sh"
     topic: proseq
     enableAutoDois: true

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -83,3 +83,7 @@ authors:
   - family-names: McClain
     given-names: Alexander
     affiliation: "St. Jude Children's Research Hospital"
+  - family-names: Wang
+    given-names: Ruihong
+    affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0009-0008-5342-3433"

--- a/modules/ww-bowtie/README.md
+++ b/modules/ww-bowtie/README.md
@@ -51,6 +51,20 @@ Aligns short reads to a reference genome using Bowtie.
 - `sorted_bam` (File): Sorted Bowtie alignment output BAM file
 - `sorted_bai` (File): Index file for the sorted Bowtie alignment BAM file
 
+## Building Your Own Index Tarball
+
+`bowtie_build` packages the Bowtie index files inside a subdirectory named after `index_prefix` (default `bowtie_index`) before compressing, and `bowtie_align` expects that same subdirectory when it extracts the tarball. If you already have Bowtie index files, e.g. built outside this module, you can package them for `bowtie_align` yourself by replicating that layout:
+
+```bash
+mkdir bowtie_index
+mv my_index.*.ebwt bowtie_index/
+tar -czf bowtie_index.tar.gz bowtie_index/
+```
+
+The directory name inside the tarball must match whatever `index_prefix` you pass to `bowtie_align` (default `bowtie_index`).
+
+In most cases, it's easier to just run `bowtie_build` on your reference FASTA and pass its `bowtie_index_tar` output straight into `bowtie_align`, rather than assembling the tarball by hand.
+
 ## Usage as a Module
 
 ### Importing into Your Workflow

--- a/modules/ww-bowtie2/README.md
+++ b/modules/ww-bowtie2/README.md
@@ -59,6 +59,20 @@ Aligns reads to a reference using Bowtie 2, optionally filtering the output usin
 - `unaligned_r1` (File?, optional): FASTQ of R1 reads that failed to align concordantly. Only produced when `capture_unaligned` is true and `mates` is set (paired-end input).
 - `unaligned_r2` (File?, optional): FASTQ of R2 reads that failed to align concordantly. Only produced when `capture_unaligned` is true and `mates` is set (paired-end input).
 
+## Building Your Own Index Tarball
+
+`bowtie2_build` packages the Bowtie 2 index files inside a subdirectory named after `index_prefix` (default `bowtie2_index`) before compressing, and `bowtie2_align` expects that same subdirectory when it extracts the tarball. If you already have Bowtie 2 index files, e.g. built outside this module, you can package them for `bowtie2_align` yourself by replicating that layout:
+
+```bash
+mkdir bowtie2_index
+mv my_index.*.bt2 bowtie2_index/
+tar -czf bowtie2_index.tar.gz bowtie2_index/
+```
+
+The directory name inside the tarball must match whatever `index_prefix` you pass to `bowtie2_align` (default `bowtie2_index`).
+
+In most cases, it's easier to just run `bowtie2_build` on your reference FASTA and pass its `bowtie2_index_tar` output straight into `bowtie2_align`, rather than assembling the tarball by hand.
+
 ## Usage as a Module
 
 ### Importing into Your Workflow

--- a/pipelines/ww-proseq/README.md
+++ b/pipelines/ww-proseq/README.md
@@ -54,11 +54,7 @@ Spike-in alignments are kept (filtered to spike-in contigs only) so downstream a
 Three things to configure:
 
 1. **Samples** — a `samples.tsv` sample sheet (recommended) or an array of `ProseqSample` structs (see [Specifying Samples](#specifying-samples))
-2. **References** — a `ProseqReferences` struct containing:
-   - `experimental_fasta` — the experimental organism's genome (e.g., dm6 for Drosophila S2 cells)
-   - `spikein_merged_fasta` — experimental + spike-in genomes concatenated, with a distinguishing prefix on spike-in contig names
-   - `rdna_fasta` — the rDNA reference for rRNA depletion (typically the host's 45S precursor)
-   - `spikein_chrom_prefix` — the prefix used on spike-in contig names in the merged FASTA
+2. **References** — a `ProseqReferences` struct. For each of the three references (experimental, spike-in-merged, rDNA), provide either a FASTA to index or a prebuilt bowtie2 index tarball (see [`ProseqReferences` struct](#proseqreferences-structure))
 3. **Pipeline parameters** — UMI config, MAPQ threshold, resource allocation
 
 See [`inputs.json`](inputs.json) for a template.
@@ -101,7 +97,7 @@ java -jar cromwell.jar run ww-proseq.wdl --inputs inputs.json
 |-----------|------|---------|-------------|
 | `samples_tsv` | `File` | required* | Tab-separated sample sheet with header `name`, `r1`, `r2` (see [Specifying Samples](#specifying-samples)). Recommended for sequencing-core output |
 | `samples` | `Array[ProseqSample]` | required* | Per-sample name + R1 + R2 (see [`ProseqSample` struct](#proseqsample-structure) below) |
-| `references` | `ProseqReferences` | required | Three FASTAs + spike-in chromosome prefix (see [`ProseqReferences` struct](#proseqreferences-structure) below) |
+| `references` | `ProseqReferences` | required | Per reference, a FASTA to index or a prebuilt bowtie2 tarball, plus the spike-in chromosome prefix (see [`ProseqReferences` struct](#proseqreferences-structure) below) |
 | `umi_loc` | `String` | `"per_read"` | fastp UMI location. `per_read` for qPRO-seq (UMIs on both ends), `read1` / `read2` for one-sided UMIs, `""` to disable |
 | `umi_len` | `Int` | `6` | UMI length in basepairs |
 | `mapq_threshold` | `Int` | `10` | Minimum MAPQ for retained alignments |
@@ -160,17 +156,28 @@ struct ProseqSample {
 
 ```wdl
 struct ProseqReferences {
-    File experimental_fasta
-    File spikein_merged_fasta
-    File rdna_fasta
+    File? experimental_fasta
+    File? spikein_merged_fasta
+    File? rdna_fasta
+    File? experimental_index_tar
+    File? spikein_index_tar
+    File? rdna_index_tar
     String spikein_chrom_prefix
+    String? experimental_index_prefix
+    String? spikein_index_prefix
+    String? rdna_index_prefix
 }
 ```
 
-- `experimental_fasta` — experimental organism's genome FASTA
-- `spikein_merged_fasta` — experimental + spike-in genomes concatenated, with a prefix on spike-in contigs
-- `rdna_fasta` — rRNA reference for rRNA depletion (typically the host's 45S precursor)
-- `spikein_chrom_prefix` — prefix used on spike-in contig names in the merged FASTA
+For each of the three references, provide **either** the FASTA (the pipeline builds the bowtie2 index) **or** a prebuilt index tarball (the build is skipped, saving time on repeat runs). The choices are independent, so you can mix built and prebuilt references.
+
+Providing the FASTAs is recommended: the pipeline builds each index from scratch with a known prefix and layout, which avoids the version and naming mismatches a prebuilt tarball can introduce. Reach for the tarball inputs when build time is a real concern and you already have indices in hand.
+
+- `experimental_fasta`/`experimental_index_tar`: experimental organism's genome (e.g., dm6 for Drosophila S2 cells)
+- `spikein_merged_fasta`/`spikein_index_tar`: experimental + spike-in genomes concatenated, with a prefix on spike-in contigs
+- `rdna_fasta`/`rdna_index_tar`: rRNA reference for rRNA depletion (typically the host's 45S precursor)
+- `spikein_chrom_prefix`: prefix used on spike-in contig names in the merged FASTA
+- `experimental_index_prefix`/`spikein_index_prefix`/`rdna_index_prefix`: optional. The name prefix of the index files inside each tarball, defaulting to `experimental`, `spikein`, and `rdna`. A tarball must contain a `bowtie2_index/` directory holding files named `<prefix>.*`, exactly as produced by `ww-bowtie2.bowtie2_build`. Set these only if your prebuilt tarball uses different names.
 
 ## Output Files
 

--- a/pipelines/ww-proseq/README.md
+++ b/pipelines/ww-proseq/README.md
@@ -53,7 +53,7 @@ Spike-in alignments are kept (filtered to spike-in contigs only) so downstream a
 
 Three things to configure:
 
-1. **Samples** — array of `ProseqSample` structs (`name`, `r1`, `r2`)
+1. **Samples** — a `samples.tsv` sample sheet (recommended) or an array of `ProseqSample` structs (see [Specifying Samples](#specifying-samples))
 2. **References** — a `ProseqReferences` struct containing:
    - `experimental_fasta` — the experimental organism's genome (e.g., dm6 for Drosophila S2 cells)
    - `spikein_merged_fasta` — experimental + spike-in genomes concatenated, with a distinguishing prefix on spike-in contig names
@@ -99,13 +99,52 @@ java -jar cromwell.jar run ww-proseq.wdl --inputs inputs.json
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `samples` | `Array[ProseqSample]` | required | Per-sample name + R1 + R2 (see [`ProseqSample` struct](#proseqsample-structure) below) |
+| `samples_tsv` | `File` | required* | Tab-separated sample sheet with header `name`, `r1`, `r2` (see [Specifying Samples](#specifying-samples)). Recommended for sequencing-core output |
+| `samples` | `Array[ProseqSample]` | required* | Per-sample name + R1 + R2 (see [`ProseqSample` struct](#proseqsample-structure) below) |
 | `references` | `ProseqReferences` | required | Three FASTAs + spike-in chromosome prefix (see [`ProseqReferences` struct](#proseqreferences-structure) below) |
 | `umi_loc` | `String` | `"per_read"` | fastp UMI location. `per_read` for qPRO-seq (UMIs on both ends), `read1` / `read2` for one-sided UMIs, `""` to disable |
 | `umi_len` | `Int` | `6` | UMI length in basepairs |
 | `mapq_threshold` | `Int` | `10` | Minimum MAPQ for retained alignments |
 | `align_cpu` | `Int` | `4` | CPU cores per bowtie2 alignment task |
 | `align_memory_gb` | `Int` | `8` | Memory per bowtie2 alignment task |
+
+*Provide either `samples_tsv` or `samples`, not both.
+
+### Specifying Samples
+
+Samples can be supplied two ways. Provide exactly one of the two.
+
+#### Option 1: TSV File (Recommended)
+
+Create a tab-separated file (`samples.tsv`) with a header row and one row per sample:
+
+```tsv
+name	r1	r2
+sample1	/path/to/sample1_R1.fastq.gz	/path/to/sample1_R2.fastq.gz
+sample2	/path/to/sample2_R1.fastq.gz	/path/to/sample2_R2.fastq.gz
+```
+
+Then reference it in your inputs JSON:
+
+```json
+{
+  "proseq.samples_tsv": "/path/to/samples.tsv"
+}
+```
+
+An example `samples.tsv` template is included in this directory.
+
+#### Option 2: `samples` Struct Array
+
+Provide the samples directly as an array of `ProseqSample` structs in the inputs JSON (see the [`ProseqSample` struct](#proseqsample-structure) below). This is the form the `testrun.wdl` test workflow uses, since constructing a TSV within WDL itself is awkward.
+
+```json
+{
+  "proseq.samples": [
+    { "name": "sample1", "r1": "/path/to/sample1_R1.fastq.gz", "r2": "/path/to/sample1_R2.fastq.gz" }
+  ]
+}
+```
 
 ### `ProseqSample` Structure
 
@@ -135,7 +174,7 @@ struct ProseqReferences {
 
 ## Output Files
 
-Per sample (arrays scattered over `samples`):
+Per sample (arrays scattered over the input samples):
 - `fastp_r1_trimmed`, `fastp_r2_trimmed` — UMI-extracted, adapter-trimmed FASTQs
 - `fastp_html`, `fastp_json` — fastp reports
 - `experimental_bam_dedup`, `experimental_bai_dedup` — deduplicated experimental BAM

--- a/pipelines/ww-proseq/README.md
+++ b/pipelines/ww-proseq/README.md
@@ -177,7 +177,7 @@ Providing the FASTAs is recommended: the pipeline builds each index from scratch
 - `spikein_merged_fasta`/`spikein_index_tar`: experimental + spike-in genomes concatenated, with a prefix on spike-in contigs
 - `rdna_fasta`/`rdna_index_tar`: rRNA reference for rRNA depletion (typically the host's 45S precursor)
 - `spikein_chrom_prefix`: prefix used on spike-in contig names in the merged FASTA
-- `experimental_index_prefix`/`spikein_index_prefix`/`rdna_index_prefix`: optional. The name prefix of the index files inside each tarball, defaulting to `experimental`, `spikein`, and `rdna`. A tarball must contain a `bowtie2_index/` directory holding files named `<prefix>.*`, exactly as produced by `ww-bowtie2.bowtie2_build`. Set these only if your prebuilt tarball uses different names.
+- `experimental_index_prefix`/`spikein_index_prefix`/`rdna_index_prefix`: optional. The name prefix of the index files inside each tarball, defaulting to `experimental`, `spikein`, and `rdna`. A tarball must contain a `bowtie2_index/` directory holding files named `<prefix>.*`, exactly as produced by `ww-bowtie2.bowtie2_build`. Set these only if your prebuilt tarball uses different names. See [ww-bowtie2's README](../../modules/ww-bowtie2/README.md#building-your-own-index-tarball) for instructions on assembling a compatible tarball by hand.
 
 ## Output Files
 

--- a/pipelines/ww-proseq/README.md
+++ b/pipelines/ww-proseq/README.md
@@ -240,6 +240,10 @@ If you use this pipeline, please cite the original PRO-seq method:
 
 For the qPRO-seq variant this pipeline implements and the reference shell pipeline it adapts, see [JAJ256/PROseq_alignment.sh](https://github.com/JAJ256/PROseq_alignment.sh) and follow the citation guidance there. Underlying tools (fastp, bowtie2, samtools, UMI-tools, deepTools, MultiQC) should be cited per their own homepages.
 
+## Acknowledgments
+
+This pipeline was developed in collaboration with Ruihong Wang through the [WILDS WDL Development Program](https://sciwiki.fredhutch.org/datascience/wilds_workflow_dev/). Thank you for the initial motivation and testing!
+
 ## Support
 
 - Open an issue in the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library/issues)

--- a/pipelines/ww-proseq/README.md
+++ b/pipelines/ww-proseq/README.md
@@ -242,7 +242,7 @@ For the qPRO-seq variant this pipeline implements and the reference shell pipeli
 
 ## Acknowledgments
 
-This pipeline was developed in collaboration with Ruihong Wang through the [WILDS WDL Development Program](https://sciwiki.fredhutch.org/datascience/wilds_workflow_dev/). Thank you for the initial motivation and testing!
+This pipeline was developed in collaboration with [Ruihong Wang](https://github.com/redd-wang) through the [WILDS WDL Development Program](https://sciwiki.fredhutch.org/datascience/wilds_workflow_dev/). Thank you for the initial motivation and testing!
 
 ## Support
 

--- a/pipelines/ww-proseq/inputs.json
+++ b/pipelines/ww-proseq/inputs.json
@@ -1,16 +1,5 @@
 {
-  "proseq.samples": [
-    {
-      "name": "sample1",
-      "r1": "/path/to/sample1_R1.fastq.gz",
-      "r2": "/path/to/sample1_R2.fastq.gz"
-    },
-    {
-      "name": "sample2",
-      "r1": "/path/to/sample2_R1.fastq.gz",
-      "r2": "/path/to/sample2_R2.fastq.gz"
-    }
-  ],
+  "proseq.samples_tsv": "/path/to/samples.tsv",
   "proseq.references": {
     "experimental_fasta": "/path/to/dm6.fa",
     "spikein_merged_fasta": "/path/to/dm6_hg38_merged.fa",

--- a/pipelines/ww-proseq/samples.tsv
+++ b/pipelines/ww-proseq/samples.tsv
@@ -1,0 +1,3 @@
+name	r1	r2
+sample1	/path/to/sample1_R1.fastq.gz	/path/to/sample1_R2.fastq.gz
+sample2	/path/to/sample2_R1.fastq.gz	/path/to/sample2_R2.fastq.gz

--- a/pipelines/ww-proseq/testrun.wdl
+++ b/pipelines/ww-proseq/testrun.wdl
@@ -58,17 +58,17 @@ workflow proseq_example {
   # rDNA reference for rRNA depletion.
   call ww_testdata.download_rrna_reference { }
 
-  ProseqReferences references = {
-      "experimental_fasta": download_dm6.fasta,
-      "spikein_merged_fasta": build_merged.merged_fasta,
-      "rdna_fasta": download_rrna_reference.fasta,
-      "spikein_chrom_prefix": "hg38"
+  ProseqReferences references = object {
+      experimental_fasta: download_dm6.fasta,
+      spikein_merged_fasta: build_merged.merged_fasta,
+      rdna_fasta: download_rrna_reference.fasta,
+      spikein_chrom_prefix: "hg38"
   }
 
-  ProseqSample sample1 = {
-      "name": "proseq_demo",
-      "r1": proseq_rep1.r1_end,
-      "r2": proseq_rep1.r2_end
+  ProseqSample sample1 = object {
+      name: "proseq_demo",
+      r1: proseq_rep1.r1_end,
+      r2: proseq_rep1.r2_end
   }
 
   call proseq_workflow.proseq { input:

--- a/pipelines/ww-proseq/testrun.wdl
+++ b/pipelines/ww-proseq/testrun.wdl
@@ -11,10 +11,16 @@ struct ProseqSample {
 }
 
 struct ProseqReferences {
-    File experimental_fasta
-    File spikein_merged_fasta
-    File rdna_fasta
+    File? experimental_fasta
+    File? spikein_merged_fasta
+    File? rdna_fasta
+    File? experimental_index_tar
+    File? spikein_index_tar
+    File? rdna_index_tar
     String spikein_chrom_prefix
+    String? experimental_index_prefix
+    String? spikein_index_prefix
+    String? rdna_index_prefix
 }
 
 workflow proseq_example {

--- a/pipelines/ww-proseq/testrun.wdl
+++ b/pipelines/ww-proseq/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-proseq/ww-proseq.wdl" as proseq_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/proseq-input-change/pipelines/ww-proseq/ww-proseq.wdl" as proseq_workflow
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
 

--- a/pipelines/ww-proseq/ww-proseq.wdl
+++ b/pipelines/ww-proseq/ww-proseq.wdl
@@ -14,10 +14,16 @@ struct ProseqSample {
 }
 
 struct ProseqReferences {
-    File experimental_fasta
-    File spikein_merged_fasta
-    File rdna_fasta
+    File? experimental_fasta
+    File? spikein_merged_fasta
+    File? rdna_fasta
+    File? experimental_index_tar
+    File? spikein_index_tar
+    File? rdna_index_tar
     String spikein_chrom_prefix
+    String? experimental_index_prefix
+    String? spikein_index_prefix
+    String? rdna_index_prefix
 }
 
 workflow proseq {
@@ -51,7 +57,7 @@ workflow proseq {
   parameter_meta {
     samples_tsv: "Tab-separated file with columns: name, r1, r2 (header row required). Easy to generate from sequencing-core output with command-line tools. Alternative to providing the samples struct array."
     samples: "List of paired-end PRO-seq samples (name + R1 + R2). Alternative to samples_tsv; provide exactly one of the two."
-    references: "PRO-seq reference set: experimental genome FASTA, spike-in-merged FASTA, rDNA FASTA, and the chromosome-name prefix used to flag spike-in contigs in the merged reference"
+    references: "PRO-seq reference set. For each reference, provide a FASTA to index or a prebuilt bowtie2 tarball to skip the build. Also holds the spike-in contig prefix and per-index name prefixes."
     umi_loc: "fastp UMI location. 'per_read', 'read1', 'read2', or '' to disable UMI extraction (default: 'per_read')."
     umi_len: "UMI length in basepairs (default: 6)"
     mapq_threshold: "Minimum MAPQ score for retained alignments"
@@ -91,25 +97,41 @@ workflow proseq {
     then select_first([tsv_sample])
     else select_first([samples])
 
-  # Build the three bowtie2 indices once, in parallel, before the per-sample scatter.
-  call bowtie2_tasks.bowtie2_build as build_experimental { input:
-      reference_fasta = references.experimental_fasta,
-      index_prefix = "experimental",
-      cpu_cores = align_cpu,
-      memory_gb = align_memory_gb
+  # Index name prefixes default to the reference type when not specified.
+  String experimental_prefix = select_first([references.experimental_index_prefix, "experimental"])
+  String spikein_prefix = select_first([references.spikein_index_prefix, "spikein"])
+  String rdna_prefix = select_first([references.rdna_index_prefix, "rdna"])
+
+  # Build each bowtie2 index only when a prebuilt tarball wasn't supplied.
+  if (!defined(references.experimental_index_tar)) {
+    call bowtie2_tasks.bowtie2_build as build_experimental { input:
+        reference_fasta = select_first([references.experimental_fasta]),
+        index_prefix = experimental_prefix,
+        cpu_cores = align_cpu,
+        memory_gb = align_memory_gb
+    }
   }
-  call bowtie2_tasks.bowtie2_build as build_spikein { input:
-      reference_fasta = references.spikein_merged_fasta,
-      index_prefix = "spikein",
-      cpu_cores = align_cpu,
-      memory_gb = align_memory_gb
+  if (!defined(references.spikein_index_tar)) {
+    call bowtie2_tasks.bowtie2_build as build_spikein { input:
+        reference_fasta = select_first([references.spikein_merged_fasta]),
+        index_prefix = spikein_prefix,
+        cpu_cores = align_cpu,
+        memory_gb = align_memory_gb
+    }
   }
-  call bowtie2_tasks.bowtie2_build as build_rdna { input:
-      reference_fasta = references.rdna_fasta,
-      index_prefix = "rdna",
-      cpu_cores = align_cpu,
-      memory_gb = align_memory_gb
+  if (!defined(references.rdna_index_tar)) {
+    call bowtie2_tasks.bowtie2_build as build_rdna { input:
+        reference_fasta = select_first([references.rdna_fasta]),
+        index_prefix = rdna_prefix,
+        cpu_cores = align_cpu,
+        memory_gb = align_memory_gb
+    }
   }
+
+  # Use the prebuilt tarball when given, otherwise the one just built.
+  File experimental_index_tar = select_first([references.experimental_index_tar, build_experimental.bowtie2_index_tar])
+  File spikein_index_tar = select_first([references.spikein_index_tar, build_spikein.bowtie2_index_tar])
+  File rdna_index_tar = select_first([references.rdna_index_tar, build_rdna.bowtie2_index_tar])
 
   scatter (sample in all_samples) {
     # Step 1 — UMI-aware adapter trimming. fastp moves the UMI from the read sequence
@@ -125,8 +147,8 @@ workflow proseq {
     # Step 2 — rRNA depletion. Align to the rDNA reference; reads that *fail* to align
     # are passed to subsequent alignment steps. The mapped BAM is discarded.
     call bowtie2_tasks.bowtie2_align as deplete_rrna { input:
-        bowtie2_index_tar = build_rdna.bowtie2_index_tar,
-        index_prefix = "rdna",
+        bowtie2_index_tar = rdna_index_tar,
+        index_prefix = rdna_prefix,
         reads = fastp_paired.r1_trimmed,
         mates = fastp_paired.r2_trimmed,
         name = sample.name + ".rrna",
@@ -140,8 +162,8 @@ workflow proseq {
     # experimental+spike-in reference, then keeps only proper pairs above the MAPQ
     # threshold. Concordance flags match the original PROseq_alignment.sh script.
     call bowtie2_tasks.bowtie2_align as align_spikein { input:
-        bowtie2_index_tar = build_spikein.bowtie2_index_tar,
-        index_prefix = "spikein",
+        bowtie2_index_tar = spikein_index_tar,
+        index_prefix = spikein_prefix,
         reads = select_first([deplete_rrna.unaligned_r1]),
         mates = select_first([deplete_rrna.unaligned_r2]),
         name = sample.name + ".spikein_unfiltered",
@@ -163,8 +185,8 @@ workflow proseq {
 
     # Step 4 — Experimental genome alignment with proper-pair + MAPQ filter.
     call bowtie2_tasks.bowtie2_align as align_experimental { input:
-        bowtie2_index_tar = build_experimental.bowtie2_index_tar,
-        index_prefix = "experimental",
+        bowtie2_index_tar = experimental_index_tar,
+        index_prefix = experimental_prefix,
         reads = select_first([deplete_rrna.unaligned_r1]),
         mates = select_first([deplete_rrna.unaligned_r2]),
         name = sample.name + ".experimental",

--- a/pipelines/ww-proseq/ww-proseq.wdl
+++ b/pipelines/ww-proseq/ww-proseq.wdl
@@ -49,7 +49,8 @@ workflow proseq {
   }
 
   parameter_meta {
-    samples: "List of paired-end PRO-seq samples (name + R1 + R2)"
+    samples_tsv: "Tab-separated file with columns: name, r1, r2 (header row required). Easy to generate from sequencing-core output with command-line tools. Alternative to providing the samples struct array."
+    samples: "List of paired-end PRO-seq samples (name + R1 + R2). Alternative to samples_tsv; provide exactly one of the two."
     references: "PRO-seq reference set: experimental genome FASTA, spike-in-merged FASTA, rDNA FASTA, and the chromosome-name prefix used to flag spike-in contigs in the merged reference"
     umi_loc: "fastp UMI location. 'per_read', 'read1', 'read2', or '' to disable UMI extraction (default: 'per_read')."
     umi_len: "UMI length in basepairs (default: 6)"
@@ -59,7 +60,9 @@ workflow proseq {
   }
 
   input {
-    Array[ProseqSample] samples
+    # Provide samples either as a TSV file or as the samples struct array directly. Supply exactly one of the two.
+    File? samples_tsv
+    Array[ProseqSample]? samples
     ProseqReferences references
     String umi_loc = "per_read"
     Int umi_len = 6
@@ -67,6 +70,26 @@ workflow proseq {
     Int align_cpu = 4
     Int align_memory_gb = 8
   }
+
+  # Parse the samples TSV (header row: name, r1, r2) when provided.
+  Array[Array[String]] tsv_rows = if defined(samples_tsv) then read_tsv(select_first([samples_tsv])) else []
+
+  # Build structs from each TSV data row, skipping the header.
+  if (defined(samples_tsv)) {
+    scatter (row_idx in range(length(tsv_rows) - 1)) {
+      Int data_idx = row_idx + 1
+      ProseqSample tsv_sample = object {
+        name: tsv_rows[data_idx][0],
+        r1: tsv_rows[data_idx][1],
+        r2: tsv_rows[data_idx][2]
+      }
+    }
+  }
+
+  # Normalize both input methods into the single list the scatter consumes.
+  Array[ProseqSample] all_samples = if defined(samples_tsv)
+    then select_first([tsv_sample])
+    else select_first([samples])
 
   # Build the three bowtie2 indices once, in parallel, before the per-sample scatter.
   call bowtie2_tasks.bowtie2_build as build_experimental { input:
@@ -88,7 +111,7 @@ workflow proseq {
       memory_gb = align_memory_gb
   }
 
-  scatter (sample in samples) {
+  scatter (sample in all_samples) {
     # Step 1 — UMI-aware adapter trimming. fastp moves the UMI from the read sequence
     # into the read name (separated by ':'), the format umi_tools dedup consumes later.
     call fastp_tasks.fastp_paired { input:

--- a/pipelines/ww-proseq/ww-proseq.wdl
+++ b/pipelines/ww-proseq/ww-proseq.wdl
@@ -28,8 +28,16 @@ struct ProseqReferences {
 
 workflow proseq {
   meta {
-    author: "Taylor Firman"
-    email: "tfirman@fredhutch.org"
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        },
+        {
+            name: "Ruihong Wang",
+            email: "rwang4@fredhutch.org"
+        }
+    ]
     description: "Paired-end PRO-seq pipeline with UMI deduplication and spike-in normalization, adapted from JAJ256/PROseq_alignment.sh. Covers UMI-aware trimming, rRNA depletion + spike-in + experimental alignment, UMI dedup, strand-specific 3' bigWigs, and aggregated QC."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-proseq/ww-proseq.wdl"
     outputs: {


### PR DESCRIPTION
## Type of Change

- Pipeline enhancement (new input options for `ww-proseq`)
- Documentation update

## Description

Adds two input conveniences to `ww-proseq` based on collaborator feedback. No change to processing logic or outputs; existing inputs remain backward compatible.

**1. TSV sample sheet.** Samples can now be supplied via a `samples_tsv` (header `name`, `r1`, `r2`) instead of the `Array[ProseqSample]` struct array. It's easy to generate with command-line tools and paths are read straight from the TSV. Provide exactly one of `samples_tsv` or `samples`. Includes an example `samples.tsv` and a TSV-first `inputs.json`.

**2. Prebuilt bowtie2 indices.** For each reference (experimental, spike-in-merged, rDNA), users can now provide a prebuilt index tarball instead of a FASTA to skip that build step on repeat runs. Choices are independent (built and prebuilt can be mixed), with optional per-index name prefixes for non-default tarballs. README recommends FASTAs by default.

## Testing

**How did you test these changes?**
`womtool validate` and `sprocket check` pass on both `ww-proseq.wdl` and `testrun.wdl`. The TSV path was confirmed end-to-end in a live Sprocket run on Fred Hutch HPC.

**What workflow engine did you use?**
Sprocket (Fred Hutch HPC) + WOMtool for static validation. CI also runs Cromwell and miniWDL.

**Did the tests pass?**
Yes.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)