### PR TITLE
Relative Path Import Pilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 *-test.json
+*-test.tsv
 .DS_Store
 **/.DS_Store
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ Complete analysis workflows combining multiple modules.
 
 ## Quick Start
 
-### Running Pipelines Directly (No Clone Required)
+### Running Pipelines
 
-Thanks to GitHub URL imports, you can download and run any pipeline without cloning the entire repository:
+There are two equally supported ways to obtain and run a pipeline. Which one fits depends on how the pipeline imports its modules, so check the individual pipeline's README if you are unsure.
+
+**Option 1: Download a single file (no clone required)**
+
+Works for pipelines that import their modules using GitHub URLs, where your WDL executor fetches the dependencies automatically at runtime:
 
 ```bash
 # Download a pipeline and its example inputs
@@ -57,9 +61,9 @@ curl -O https://raw.githubusercontent.com/getwilds/wilds-wdl-library/main/pipeli
 sprocket run ww-sra-star.wdl @inputs.json
 ```
 
-### Using the Full Repository
+**Option 2: Clone the repository (or download a release bundle)**
 
-If you want to explore multiple components or contribute:
+Required for pipelines that import their modules using relative paths (currently being piloted in `ww-bwa-gatk`; see [issue #364](https://github.com/getwilds/wilds-wdl-library/issues/364)), since the surrounding `modules/` directory must be present on disk. This approach also keeps the whole workflow self-contained and inspectable, with nothing fetched at runtime, and is the right choice if you want to explore multiple components or contribute:
 
 ```bash
 # Clone the repository
@@ -71,8 +75,8 @@ cd modules/ww-star
 sprocket run testrun.wdl
 
 # Run a pipeline (modify inputs.json as necessary)
-cd ../../pipelines/ww-sra-star
-sprocket run ww-sra-star.wdl @inputs.json
+cd ../../pipelines/ww-bwa-gatk
+sprocket run ww-bwa-gatk.wdl @inputs.json
 ```
 
 ### Importing into Your Workflows
@@ -89,12 +93,14 @@ workflow my_analysis {
 }
 ```
 
-WILDS pipelines use GitHub URLs for imports, providing several advantages:
+The example above uses GitHub URL imports, which are convenient for plug-and-play usage:
 
 - **No local cloning required**: Use modules directly without downloading the repository
-- **Version control**: Pin to specific commits or tags for reproducibility
+- **Version control**: Pin to a specific commit or tag for reproducibility (prefer a commit SHA over `refs/heads/main`, which is a moving target)
 - **Easy updates**: Switch between versions by changing the URL
 - **Modular usage**: Import only the modules you need
+
+Alternatively, modules can be referenced with **relative path imports** (e.g. `import "../ww-star/ww-star.wdl"`), which keep the workflow self-contained with nothing fetched at runtime and make it runnable on executors that block remote imports (such as AWS HealthOmics), at the cost of needing the repository layout present on disk. Both styles are valid; see the [modules README](modules/README.md) and [issue #364](https://github.com/getwilds/wilds-wdl-library/issues/364) for the tradeoffs.
 
 ## Supported Executors
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -106,24 +106,50 @@ In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.c
 
 ### **Importing Tasks**
 
-Modules are designed to be imported into other workflows:
+Modules are designed to be imported into other workflows. There are two ways to reference a module, and the right choice depends on how you plan to run the workflow.
+
+**Option 1: GitHub URL imports**
 
 ```wdl
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as star_tasks
 
 workflow my_pipeline {
-  call star_tasks.build_star_index { 
-    input: reference_fasta = my_fasta 
+  call star_tasks.build_star_index {
+    input: reference_fasta = my_fasta
   }
 }
 ```
 
-We recommend using GitHub URLs when importing WILDS WDL modules for a few reasons:
+URL imports are convenient for plug-and-play usage:
 
 - **No local cloning required**: Use modules directly without downloading the repository
-- **Version control**: Pin to specific commits or tags for reproducibility
+- **Version control**: Pin to a specific commit or tag for reproducibility (prefer a commit SHA over `refs/heads/main`, which is a moving target)
 - **Easy updates**: Switch between versions by changing the URL
 - **Modular usage**: Import only the modules you need
+
+The tradeoff is that the imported code is fetched from the network at runtime with no integrity check, and some executors (for example, AWS HealthOmics) block remote imports for exactly this reason. See [issue #364](https://github.com/getwilds/wilds-wdl-library/issues/364) for the discussion.
+
+**Option 2: Relative path imports**
+
+```wdl
+import "../ww-star/ww-star.wdl" as star_tasks
+
+workflow my_pipeline {
+  call star_tasks.build_star_index {
+    input: reference_fasta = my_fasta
+  }
+}
+```
+
+Relative imports keep the entire workflow self-contained and inspectable, with nothing fetched at runtime:
+
+- **No runtime fetch**: Every line of code that runs travels with the workflow
+- **Executor compatibility**: Works on executors that block remote imports, such as AWS HealthOmics
+- **Supply-chain safety**: Removes the risk of pulling unverified code from a URL at execution time
+
+The tradeoff is that the surrounding repository layout (`modules/` alongside `pipelines/`) must be present on disk, so you need a clone of the library (or a release bundle) rather than a single downloaded file. Relative paths resolve against the importing file's own location, so the path depends on where the importing file sits relative to the module.
+
+> **Note:** Relative path imports are currently being piloted in the `ww-bwa-gatk` pipeline (see [issue #364](https://github.com/getwilds/wilds-wdl-library/issues/364)). The rest of the library still uses URL imports. Both approaches are valid; pick the one that matches your execution environment.
 
 ### **Running Test Workflows**
 

--- a/modules/ww-bwa/testrun.wdl
+++ b/modules/ww-bwa/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as ww_bwa
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bwa.wdl" as ww_bwa
 
 struct BwaSample {
     String name

--- a/modules/ww-gatk/testrun.wdl
+++ b/modules/ww-gatk/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as ww_gatk
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as ww_bwa
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-gatk.wdl" as ww_gatk
+import "../ww-bwa/ww-bwa.wdl" as ww_bwa
 
 struct GatkSample {
     String name

--- a/modules/ww-testdata/testrun.wdl
+++ b/modules/ww-testdata/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-testdata.wdl" as ww_testdata
 
 workflow testdata_example {
   # Pull down reference genome and index files for chr1

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -79,9 +79,13 @@ Pipelines follow the same `testrun.wdl` / `testrun_hpc.wdl` split as modules: mo
 
 ## Using Pipelines
 
-### **Running Directly (No Git Clone Required)**
+### **Obtaining a Pipeline**
 
-You can download and run any pipeline without cloning the entire repository:
+There are two equally supported ways to get a pipeline onto your system. Which one fits depends on how the pipeline imports its modules, so check the individual pipeline's README if you are unsure.
+
+**Option 1: Download a single file**
+
+Works for pipelines that import their modules using GitHub URLs, where your WDL executor fetches the dependencies automatically at runtime. No clone required:
 
 ```bash
 # Download a pipeline and its example inputs
@@ -94,7 +98,18 @@ curl -O https://raw.githubusercontent.com/getwilds/wilds-wdl-library/main/pipeli
 sprocket run ww-sra-star.wdl @inputs.json
 ```
 
-This works because all pipelines import modules using GitHub URLs, so your WDL executor fetches dependencies automatically.
+**Option 2: Clone the repository (or download a release bundle)**
+
+Required for pipelines that import their modules using **relative paths** (currently being piloted in `ww-bwa-gatk`; see [issue #364](https://github.com/getwilds/wilds-wdl-library/issues/364)), since the surrounding `modules/` directory must be present on disk. This approach also keeps the whole workflow self-contained and inspectable, with nothing fetched at runtime:
+
+```bash
+# Clone the library, then run from within the pipeline directory
+git clone https://github.com/getwilds/wilds-wdl-library.git
+cd wilds-wdl-library/pipelines/ww-bwa-gatk
+
+# Modify inputs.json as necessary for your data, then run via the command line or PROOF's point-and-click interface
+sprocket run ww-bwa-gatk.wdl @inputs.json
+```
 
 ### **Testing and Demonstration**
 

--- a/pipelines/ww-bwa-gatk/README.md
+++ b/pipelines/ww-bwa-gatk/README.md
@@ -34,13 +34,35 @@ This pipeline imports and uses:
 - **ww-bwa module**: For genome indexing and read alignment (`bwa_index`, `bwa_mem` tasks)
 - **ww-gatk module**: For marking duplicate reads and recalibrating base quality scores (`mark_duplicates`, `create_sequence_dictionary`, `base_recalibrator` tasks)
 
+## Module Imports
+
+This pipeline imports its modules using **relative paths** rather than remote URLs:
+
+```wdl
+import "../../modules/ww-bwa/ww-bwa.wdl" as bwa_tasks
+import "../../modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
+```
+
+Relative imports keep the entire workflow self-contained and inspectable: every line of code that runs travels with the pipeline, with no content fetched from the network at runtime. This makes the pipeline compatible with executors that block remote imports for security reasons (for example, AWS HealthOmics), and it removes the supply-chain risk of pulling unverified code from a URL at execution time. The tradeoff is that you need the surrounding repository layout (`modules/` alongside `pipelines/`) on disk, so clone the WILDS WDL Library (or use a release bundle) rather than downloading the single `ww-bwa-gatk.wdl` file.
+
+### Using remote URL imports instead
+
+If you would rather run the pipeline as a single file without cloning the repository, you can swap the relative imports for remote URL imports. Pin them to an immutable commit SHA (not a moving branch like `refs/heads/main`) so the code you reviewed is the code that runs:
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/4e501e6996af284c3444150e39bf7c5629394732/modules/ww-bwa/ww-bwa.wdl" as bwa_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/4e501e6996af284c3444150e39bf7c5629394732/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
+```
+
+Note that remote imports are fetched at runtime with no integrity check, and executors such as AWS HealthOmics will reject them.
+
 ## Usage
 
 ### Requirements
 
 - WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
 - Docker/Apptainer support
-- Internet access for module imports
+- A local clone of the WILDS WDL Library (or a release bundle), since this pipeline imports its modules via relative paths (see [Module Imports](#module-imports) below)
 - Sufficient compute resources for BWA-MEM alignment
 
 ### Input Configuration
@@ -137,7 +159,7 @@ For detailed information on configuring and using Cirro pipelines, see the [offi
 - **Memory**: 64GB recommended for human genome alignment (16 GB for testing purposes)
 - **CPUs**: 8+ cores recommended for efficient processing (8 cores for testing purposes)
 - **Storage**: Sufficient space for indexed reference genome and BAM files
-- **Network**: Stable internet connection for module imports
+- **Network**: Internet access to pull the Docker/Apptainer images used by each task
 
 ### Optimization Tips
 - Use call caching to save intermediate files if the pipeline crashes partway

--- a/pipelines/ww-bwa-gatk/testrun.wdl
+++ b/pipelines/ww-bwa-gatk/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl" as bwa_gatk_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bwa-gatk.wdl" as bwa_gatk_workflow
 
 struct BwaSample {
     String name

--- a/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl
+++ b/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as bwa_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
+import "../../modules/ww-bwa/ww-bwa.wdl" as bwa_tasks
+import "../../modules/ww-gatk/ww-gatk.wdl" as gatk_tasks
 
 struct BwaSample {
     String name


### PR DESCRIPTION
## Type of Change

- Documentation update
- Other: pilot conversion for switching from remote URL imports to relative path imports

## Description

This is a **draft/discussion** PR piloting relative path imports in a single pipeline (`ww-bwa-gatk`) and its constituent modules, as a first step toward addressing the supply-chain and AWS HealthOmics concerns raised in #364. It is intentionally scoped to one pipeline so we can validate the approach on CI and Fred Hutch HPC (PROOF) before deciding whether to expand it library-wide.

**WDL changes (URL imports to relative imports):**
- `pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl`: imports `ww-bwa` and `ww-gatk` via `../../modules/...`
- `pipelines/ww-bwa-gatk/testrun.wdl`: imports `ww-testdata` and the pipeline relatively
- `modules/ww-bwa/testrun.wdl`, `modules/ww-gatk/testrun.wdl`, `modules/ww-testdata/testrun.wdl`: the three modules used by this pipeline, converted so the whole dependency chain is relative

**Documentation changes (all framed as co-equal options, not flipping the recommendation yet):**
- `pipelines/ww-bwa-gatk/README.md`: new "Module Imports" section explaining relative imports and documenting a remote-URL alternative pinned to a commit SHA for plug-and-play users
- `modules/README.md`, `pipelines/README.md`, top-level `README.md`: present URL vs. relative imports as two equally supported options with their tradeoffs, and note the pilot is currently scoped to `ww-bwa-gatk`

**Why relative imports:** the workflow becomes fully self-contained and inspectable, with nothing fetched from the network at runtime. This removes the supply-chain risk of pulling unverified code from a URL and makes the workflow runnable on executors that block remote imports (e.g. AWS HealthOmics). The tradeoff is that the repo layout (`modules/` alongside `pipelines/`) must be present on disk.

## Related Issue

Related to #364

## Testing

**How did you test these changes?**
- Linted all five edited WDLs and ran the `ww-bwa-gatk` testrun locally with relative imports, completed successfully.
- Reproduced the **PROOF (Cromwell server-mode)** delivery path with Cromwell 92 locally, using a `workflowDependencies`-style imports zip and an isolated entrypoint (so imports could only resolve via the zip, not local disk). Key findings below.

**What workflow engine did you use?**
All three engines locally and for CI, PROOF (Cromwell server mode) for the zip path.

**Did the tests pass?**
Yes, with one important operational caveat for the PROOF path (see Additional Context):

- Cromwell's zip-imports resolver does **not** allow a submitted workflow's relative imports to escape the zip root with `../`. Submitting `ww-bwa-gatk.wdl` directly with a library zip therefore fails at import resolution.
- One potential fix is a thin **wrapper entrypoint** that imports the pipeline by its in-zip path, making the pipeline a *nested* import so its `../../modules/...` paths resolve correctly. Verified working in Cromwell 92 and on PROOF, although it's worth noting that the per-task details on the "Track Workflows" page are lost in that case...
- The imports zip must have `modules/` and `pipelines/` at its **root**. GitHub's "Download ZIP" wraps everything under a top-level `wilds-wdl-library-<ref>/` directory, but a correctly-rooted zip works.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [ ] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

**This is a draft pending discussion, not a finished change.** 

The logistics of switching to relative imports is pretty straightforward and the advantages are clear from a security standpoint. The only remaining question is how to ensure continued functionality on PROOF for Fred Hutch users:

The URL imports make it easy for users to simply download their script of interest and plug it right into PROOF, but with relative paths, users need a properly organized imports zip at that point:

- GitHub's source zip always nests everything under a top-level `wilds-wdl-library-<ref>/` folder, so users can't just upload it as `workflowDependencies`. Cromwell looks for `pipelines/...` at the zip root and finds the wrapper folder instead. Today that forces a manual unzip-and-re-zip step, which undercuts the "easy for intro users" goal.
- Cleanest fix is shipping a **correctly-rooted release bundle** (modules/ + pipelines/ at root) as a CI-published artifact. But the current quarterly release cadence would make changes slow to reach that bundle. Maybe we publish a rolling `main` bundle separately from tagged releases? Or increase release frequency?
- One other idea I was thinking of was to add direct integration with the WILDS WDL Library on the "Submit a Workflow" page of PROOF. For instance, instead of uploading your own WDL, users can just use a dropdown to pick from one of the existing pipelines and we'll take care of the WDL script exacts for them behind the scenes.

**Other open items for discussion:**
- Whether to adopt the wrapper-entrypoint pattern as the official PROOF delivery mechanism (and possibly generate wrappers automatically, e.g. a `make` target, rather than hand-writing one per pipeline).
- Whether/when to expand the relative-import conversion beyond `ww-bwa-gatk`. The doc blurbs are written to be honest about the pilot scope; all "piloted in `ww-bwa-gatk`" mentions are greppable and would need updating on rollout.