### PR TITLE
Moving Docker image from `runtime` to inputs

### DIFF
--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -44,10 +44,10 @@ Create three files in `modules/ww-$ARGUMENTS/`:
   - `meta` block with: author, email, description, url, outputs
     - Use `author: "WILDS Team"` and `email: "wilds@fredhutch.org"` as placeholders — the actual contributor will replace these in review
   - `parameter_meta` block describing every input
-  - `input` block with typed parameters; include `cpu_cores` (Int, default sensible) and `memory_gb` (Int, default sensible)
+  - `input` block with typed parameters; include `cpu_cores` (Int, default sensible), `memory_gb` (Int, default sensible), and `String docker_image = "getwilds/$ARGUMENTS:<version>"` (pinned, never `latest`)
   - `command <<<` block starting with `set -eo pipefail`, using `~{var}` interpolation
   - `output` block with typed outputs
-  - `runtime` block with `docker: "getwilds/$ARGUMENTS:<version>"` (pinned, never `latest`), `cpu: cpu_cores`, `memory: "~{memory_gb} GB"`
+  - `runtime` block with `docker: docker_image`, `cpu: cpu_cores`, `memory: "~{memory_gb} GB"`
 
 #### `testrun.wdl`
 - `version 1.0`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ pipelines/ww-pipeline-name/
 - Use `ww-template` as the canonical example
 - Every task needs `meta` (author, email, description, url, outputs) and `parameter_meta` blocks
 - Command blocks: start with `set -eo pipefail`, use `<<<...>>>` heredoc syntax
-- Docker images: always from `getwilds/` with exact version pins (never `latest`)
+- Docker images: always from `getwilds/` with exact version pins (never `latest`); declared as `String docker_image = "getwilds/tool:version"` in the `input` block and referenced via `docker: docker_image` in `runtime`
 - Resource params: `cpu_cores` and `memory_gb` with sensible defaults
 - Imports use GitHub raw URLs: `https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-*/ww-*.wdl`
 - Modules are self-contained: `ww-<toolname>.wdl` files never import other modules. Cross-module composition happens only in `testrun.wdl` (for test fixtures) and in pipelines. If a task needs another tool's output, add it to the existing module rather than introducing a cross-module import in the source WDL.

--- a/modules/README.md
+++ b/modules/README.md
@@ -55,10 +55,10 @@ In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.c
 
 ## Available Modules
 
-| Module | Tool | Container | Description |
-|--------|------|-----------|-------------|
+| Module | Tool | Container(s) | Description |
+|--------|------|-------------|-------------|
 | `ww-annotsv` | Structural Variant Annotator | `getwilds/annotsv:3.4.4` | Annotate structural variants with AnnotSV |
-| `ww-annovar` | Variant Annotator | `getwilds/annovar:GRCh38` | Annotate genetic variants with ANNOVAR |
+| `ww-annovar` | Variant Annotator | `getwilds/annovar:<ref_name>` | Annotate genetic variants with ANNOVAR (image tag is the reference build, e.g. hg38) |
 | `ww-aws-sso` | AWS Operations | `getwilds/awscli:2.27.49` | AWS S3 operations with SSO and temporary credential support |
 | `ww-bcftools` | Utilities for Variant Calls | `getwilds/bcftools:1.19` | Call and analyze variants with BCFtools |
 | `ww-bedparse` | Bedparse Format Converter | `getwilds/bedparse:0.2.3` | Convert GTF annotation file to BED12 format using bedparse |
@@ -66,41 +66,50 @@ In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.c
 | `ww-bowtie` | Bowtie Short-Read Aligner | `getwilds/bowtie:1.3.1` | Build Bowtie index and align short reads to a reference genome |
 | `ww-bowtie2` | Bowtie 2 Sequence Aligner | `getwilds/bowtie2:2.5.4` | Build Bowtie 2 index and align sequence reads to a reference genome |
 | `ww-bwa` | BWA Aligner | `getwilds/bwa:0.7.17` | Alignment with the Burrows-Wheeler Aligner |
-| `ww-cellranger` | Cell Ranger Gene Expression | `getwilds/cellranger:10.0.0` | Run cellranger count on gene expression reads from one GEM well |
+| `ww-cellranger` | Cell Ranger Gene Expression | See README | Run cellranger count on gene expression reads from one GEM well (Cell Ranger is not redistributable; build your own image or use an environment module) |
+| `ww-clair3` | Clair3 Variant Caller | `getwilds/clair3:2.0.0` | Deep learning-based germline small variant calling from ONT, PacBio HiFi, and Illumina data |
 | `ww-cnvkit` | CNVkit Copy Number Analysis | `getwilds/cnvkit:0.9.10` | Create CNVkit reference and run copy number analysis on tumor samples |
 | `ww-colabfold` | Protein Structure Predictor | `getwilds/colabfold:1.5.5` | Predict protein structures with ColabFold (AlphaFold2 + MMseqs2) |
-| `ww-consensus` | Consensus Variant Caller | `getwilds/consensus:0.1.1` | Multi-caller consensus variant integration |
+| `ww-consensus` | Consensus Variant Caller | `rocker/tidyverse:4.4.2` | Multi-caller consensus variant integration |
 | `ww-deeptools` | deepTools Coverage and Visualization | `getwilds/deeptools:3.5.6` | Analyze and visualize high-throughput sequencing data including coverage tracks and heatmaps |
 | `ww-deepvariant` | DeepVariant Variant Caller | `google/deepvariant:1.10.0` | Call germline variants from aligned reads using deep learning |
 | `ww-delly` | Structural Variant Caller | `getwilds/delly:1.2.9` | Call structural variants with Delly |
 | `ww-deseq2` | DESeq2 Differential Expression | `getwilds/deseq2:1.40.2` | Differential expression analysis using DESeq2 |
 | `ww-diamond` | DIAMOND Protein Aligner | `getwilds/diamond:2.1.16` | Create DIAMOND database and align protein sequences using BLASTP |
 | `ww-ena` | ENA Data Downloader | `getwilds/ena-tools:2.1.1` | Download sequencing data from the European Nucleotide Archive (ENA) |
+| `ww-esmfold` | ESMFold Structure Predictor | `getwilds/esmfold:2.0.0` | Fast single-sequence protein structure prediction using the ESM-2 language model |
 | `ww-fastp` | Fastp Quality Trimmer | `getwilds/fastp:1.1.0` | Quality filtering, adapter trimming, and QC reporting for FASTQ files |
 | `ww-fastqc` | FastQC Quality Control | `getwilds/fastqc:0.12.1` | Run FastQC quality control analysis on FASTQ files |
 | `ww-gatk` | GATK Variant Calling | `getwilds/gatk:4.6.1.0` | Variant calling and processing with GATK |
 | `ww-gdc` | GDC Data Downloader | `getwilds/gdc-client:2.3.0` | Download files from GDC using manifest files or file UUIDs |
-| `ww-glimpse2` | GLIMPSE2 Imputation | `getwilds/glimpse2:2.0.1` | Low-coverage whole genome sequencing imputation including reference panel preparation and phasing |
+| `ww-gffread` | GFFRead Annotation Converter | `getwilds/gffread:0.12.7` | Normalize and convert GTF/GFF3 annotation files for use in RNA-seq pipelines |
+| `ww-glimpse2` | GLIMPSE2 Imputation | `getwilds/glimpse2:2.0.1-infofix` | Low-coverage whole genome sequencing imputation including reference panel preparation and phasing |
 | `ww-ichorcna` | Tumor Fraction Estimator | `getwilds/ichorcna:0.2.0` | Estimate tumor fraction with ichorCNA |
 | `ww-jcast` | JCAST Alternative Splicing | `getwilds/jcast:0.3.5` | Translate alternative splicing events from rMATS output into protein sequences |
 | `ww-manta` | Structural Variant Caller | `getwilds/manta:1.6.0` | Call structural variants with Manta |
 | `ww-megahit` | MEGAHIT Metagenome Assembler | `getwilds/megahit:1.2.9` | De novo metagenome assembly using MEGAHIT |
+| `ww-multiqc` | MultiQC Report Aggregator | `getwilds/multiqc:1.33` | Aggregate results from multiple bioinformatics tools into a single interactive HTML report |
 | `ww-rmats-turbo` | rMATS-turbo Splicing Analysis | `getwilds/rmats-turbo:4.3.0` | Detect and quantify differential alternative splicing events from RNA-seq data |
 | `ww-rseqc` | RSeQC Quality Control | `getwilds/rseqc:5.0.4` | Run comprehensive quality control metrics on aligned RNA-seq data |
 | `ww-salmon` | Salmon Transcript Quantifier | `getwilds/salmon:1.10.3` | Build Salmon index and quantify transcript expression from RNA-seq reads |
-| `ww-samtools` | Utilities for SAM/BAM/CRAM Files | `getwilds/samtools:1.11` | Work with Sequence Alignment/Map (SAM) format files |
+| `ww-samtools` | Utilities for SAM/BAM/CRAM Files | `getwilds/samtools:1.19` | Work with Sequence Alignment/Map (SAM) format files |
+| `ww-seurat` | Seurat Single-Cell Analyzer | `getwilds/seurat:5.2.1` | Single-cell RNA-seq analysis including QC, normalization, dimensionality reduction, and clustering |
 | `ww-shapemapper` | ShapeMapper RNA Structure | `getwilds/shapemapper:2.3` | Analyze RNA structure probing data and generate reactivity profiles |
 | `ww-sjl` | Solar Jetlag Tile Processor | `getwilds/r-utils:0.1.0` | Calculate sunrise/sunset times for geographic tiles as part of the SJL model pipeline |
-| `ww-smoove` | Structural Variant Caller | `brentp/smoove:latest` | Call structural variants with Smoove |
+| `ww-smoove` | Structural Variant Caller | `getwilds/smoove:0.2.8` | Call structural variants with Smoove |
 | `ww-sourmash` | Sourmash K-mer Sketch | `getwilds/sourmash:4.8.2` | Generate sourmash sketches from BAM or FASTA files for sequence comparison |
 | `ww-spades` | SPAdes Genome Assembler | `getwilds/spades:4.2.0` | De novo metagenomic assembly using metaSPAdes |
 | `ww-sra` | SRA Toolkit | `getwilds/sra-tools:3.1.1` | Download sequencing data from NCBI SRA |
 | `ww-star` | STAR Aligner | `getwilds/star:2.7.6a` | RNA-seq alignment with two-pass methodology |
 | `ww-starling` | STARLING Ensemble Generator | `getwilds/starling:2.0.0a3` | Generate structural ensembles for intrinsically disordered proteins |
 | `ww-strelka` | Strelka Variant Caller | `getwilds/strelka:2.9.10` | Run Strelka germline and somatic variant calling |
-| `ww-testdata` | Test Data Downloader | `getwilds/awscli:2.27.49` | Download reference genomes and test datasets |
-| `ww-tritonnp` | TritonNP Nucleosome Positioning | `python:bullseye` | Nucleosome positioning analysis from cfDNA using FFT-based fragment size analysis |
+| `ww-template` | WILDS WDL Template | `getwilds/bwa:0.7.17` | Canonical example module demonstrating WILDS WDL best practices; copy-paste starting point for new modules |
+| `ww-testdata` | Test Data Downloader | Multiple | Download reference genomes and test datasets (uses awscli, samtools, bcftools, and others) |
+| `ww-trimgalore` | Trim Galore Quality Trimmer | `getwilds/trim-galore:0.6.11` | Adapter and quality trimming for paired-end and single-end FASTQ files using Trim Galore |
+| `ww-tritonnp` | TritonNP Nucleosome Positioning | `getwilds/python-utils:0.1.0` | Nucleosome positioning analysis from cfDNA using FFT-based fragment size analysis |
+| `ww-umi-tools` | UMI-tools UMI Handler | `getwilds/umitools:1.1.6` | Deduplicate reads and handle Unique Molecular Identifiers (UMIs) in NGS data |
 | `ww-varscan` | VarScan Variant Caller | `getwilds/varscan:2.4.6` | Run VarScan somatic and germline variant calling |
+| `ww-viennarna` | ViennaRNA Structure Predictor | `getwilds/viennarna:2.7.2` | RNA secondary structure prediction and analysis including folding, suboptimal structures, and cofold |
 
 ## Using Modules
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -85,7 +85,7 @@ In anticipation of the proposed WDL v1.4 [module manifest spec](https://github.c
 | `ww-jcast` | JCAST Alternative Splicing | `getwilds/jcast:0.3.5` | Translate alternative splicing events from rMATS output into protein sequences |
 | `ww-manta` | Structural Variant Caller | `getwilds/manta:1.6.0` | Call structural variants with Manta |
 | `ww-megahit` | MEGAHIT Metagenome Assembler | `getwilds/megahit:1.2.9` | De novo metagenome assembly using MEGAHIT |
-| `ww-rmats-turbo` | rMATS-turbo Splicing Analysis | `getwilds/rmats-turbo:latest` | Detect and quantify differential alternative splicing events from RNA-seq data |
+| `ww-rmats-turbo` | rMATS-turbo Splicing Analysis | `getwilds/rmats-turbo:4.3.0` | Detect and quantify differential alternative splicing events from RNA-seq data |
 | `ww-rseqc` | RSeQC Quality Control | `getwilds/rseqc:5.0.4` | Run comprehensive quality control metrics on aligned RNA-seq data |
 | `ww-salmon` | Salmon Transcript Quantifier | `getwilds/salmon:1.10.3` | Build Salmon index and quantify transcript expression from RNA-seq reads |
 | `ww-samtools` | Utilities for SAM/BAM/CRAM Files | `getwilds/samtools:1.11` | Work with Sequence Alignment/Map (SAM) format files |

--- a/modules/ww-annotsv/README.md
+++ b/modules/ww-annotsv/README.md
@@ -34,6 +34,7 @@ Annotates structural variants with comprehensive genomic and clinical informatio
 - `overlap_threshold` (Int): Minimum percentage overlap with genomic features (default: 70)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 4)
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/annotsv:3.4.4`)
 
 **Outputs:**
 - `annotated_tsv` (File): Tab-delimited file with detailed annotations per SV

--- a/modules/ww-annotsv/ww-annotsv.wdl
+++ b/modules/ww-annotsv/ww-annotsv.wdl
@@ -35,6 +35,7 @@ task annotsv_annotate {
     overlap_threshold: "Minimum percentage overlap with genomic features"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -46,6 +47,7 @@ task annotsv_annotate {
     Boolean exclude_benign = false
     Int sv_min_size = 50
     Int overlap_threshold = 70
+    String docker_image = "getwilds/annotsv:3.4.4"
     Int cpu_cores = 4
     Int memory_gb = 8
   }
@@ -92,7 +94,7 @@ task annotsv_annotate {
   }
 
   runtime {
-    docker: "getwilds/annotsv:3.4.4"
+    docker: docker_image
     memory: "~{memory_gb}GB"
     cpu: cpu_cores
   }

--- a/modules/ww-annovar/README.md
+++ b/modules/ww-annovar/README.md
@@ -27,6 +27,7 @@ Annotates variants using Annovar with customizable protocols and operations.
 - `annovar_operation` (String): Comma-separated list of operations corresponding to protocols
 - `cpu_cores` (Int, optional): Number of CPU cores to allocate (default: 2)
 - `memory_gb` (Int, optional): Memory in GB to allocate (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/annovar:~{ref_name}`)
 
 **Outputs**:
 - `annotated_vcf` (File): VCF file with Annovar annotations added

--- a/modules/ww-annovar/ww-annovar.wdl
+++ b/modules/ww-annovar/ww-annovar.wdl
@@ -32,6 +32,7 @@ task annovar_annotate {
     annovar_operation: "Comma-separated list of operations corresponding to the protocols"
     cpu_cores: "Number of CPU cores to allocate for the annotation task"
     memory_gb: "Memory in GB to allocate for the annotation task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -41,6 +42,7 @@ task annovar_annotate {
     String annovar_operation
     Int cpu_cores = 2
     Int memory_gb = 8
+    String docker_image = "getwilds/annovar:~{ref_name}"
   }
 
   String base_vcf_name = basename(vcf_to_annotate, ".vcf.gz")
@@ -63,7 +65,7 @@ task annovar_annotate {
   }
 
   runtime {
-    docker: "getwilds/annovar:~{ref_name}"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-aws-sso/README.md
+++ b/modules/ww-aws-sso/README.md
@@ -32,6 +32,7 @@ Downloads a single file from an S3 bucket with support for both public and priva
 - `aws_credentials_file` (File?): Path to AWS credentials file (optional)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 1)
 - `memory_gb` (Int): Memory allocation in GB (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs:**
 - `downloaded_file` (File): Downloaded file from S3
@@ -47,6 +48,7 @@ Uploads a single file to an S3 bucket (requires AWS credentials).
 - `aws_credentials_file` (File?): Path to AWS credentials file (optional)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 1)
 - `memory_gb` (Int): Memory allocation in GB (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs:**
 - `s3_uri` (String): S3 URI of the uploaded file
@@ -62,6 +64,7 @@ Lists contents of an S3 bucket or prefix with comprehensive configuration option
 - `human_readable` (Boolean): Use human-readable file sizes (default: true)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 1)
 - `memory_gb` (Int): Memory allocation in GB (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs:**
 - `file_list` (File): Text file containing list of S3 objects

--- a/modules/ww-aws-sso/ww-aws-sso.wdl
+++ b/modules/ww-aws-sso/ww-aws-sso.wdl
@@ -37,6 +37,7 @@ task s3_download_file {
     aws_credentials_file: "Path to AWS credentials file (optional)"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -46,6 +47,7 @@ task s3_download_file {
     File? aws_credentials_file
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   String final_filename = select_first([output_filename, basename(s3_uri)])
@@ -84,7 +86,7 @@ task s3_download_file {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -118,6 +120,7 @@ task s3_upload_file {
     aws_credentials_file: "Path to AWS credentials file (optional)"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -128,6 +131,7 @@ task s3_upload_file {
     File? aws_credentials_file
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   String final_key = select_first([s3_key, basename(file_to_upload)])
@@ -157,7 +161,7 @@ task s3_upload_file {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -192,6 +196,7 @@ task s3_list_bucket {
     human_readable: "Use human-readable file sizes (default: true)"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -202,6 +207,7 @@ task s3_list_bucket {
     Boolean human_readable = true
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   Boolean use_credentials = defined(aws_config_file)
@@ -243,7 +249,7 @@ task s3_list_bucket {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-bcftools/README.md
+++ b/modules/ww-bcftools/README.md
@@ -36,6 +36,7 @@ Calls variants using bcftools mpileup and call pipeline with comprehensive param
 - `max_idepth` (Int): Maximum per-sample indel depth (default: 10000)
 - `memory_gb` (Int): Memory allocation (default: 8)
 - `cpu_cores` (Int): CPU cores (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bcftools:1.19`)
 
 **Outputs:**
 - `mpileup_vcf` (File): Compressed VCF file with called variants
@@ -52,6 +53,7 @@ Concatenate multiple VCF/BCF files into a single file using bcftools concat. Inp
 - `allow_overlaps` (Boolean): Allow overlapping positions in input files (default: false)
 - `cpu_cores` (Int): Number of CPU cores (default: 4)
 - `memory_gb` (Int): Memory allocation (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bcftools:1.19`)
 
 **Outputs:**
 - `concatenated_vcf` (File): Concatenated VCF/BCF file

--- a/modules/ww-bcftools/ww-bcftools.wdl
+++ b/modules/ww-bcftools/ww-bcftools.wdl
@@ -38,6 +38,7 @@ task mpileup_call {
     max_idepth: "Maximum per-sample depth for indel calling"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -53,6 +54,7 @@ task mpileup_call {
     Int max_idepth = 10000
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/bcftools:1.19"
   }
 
   command <<<
@@ -99,7 +101,7 @@ task mpileup_call {
   }
 
   runtime {
-    docker: "getwilds/bcftools:1.19"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -134,6 +136,7 @@ task concat {
     allow_overlaps: "Allow overlapping positions in input files (default: false)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -144,6 +147,7 @@ task concat {
     Boolean allow_overlaps = false
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/bcftools:1.19"
   }
 
   command <<<
@@ -186,7 +190,7 @@ task concat {
   }
 
   runtime {
-    docker: "getwilds/bcftools:1.19"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-bedparse/README.md
+++ b/modules/ww-bedparse/README.md
@@ -23,6 +23,20 @@ This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds
 
 - **gtf2bed**: Converts GTF annotation files to BED12 format
 
+### `gtf2bed`
+
+Converts GTF annotation files to BED12 format.
+
+**Inputs:**
+
+- `gtf_file` (File): GTF annotation file to convert
+- `extra_fields` (String?): Comma-separated list of extra GTF fields to add after column 12 (e.g., "gene_id,gene_name")
+- `filter_key` (String?): GTF extra field on which to apply filtering
+- `filter_type` (String?): Comma-separated list of filterKey field values to retain
+- `cpu_cores` (Int): Number of CPU cores (default: 1)
+- `memory_gb` (Int): Memory allocation in GB (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bedparse:0.2.3`)
+
 ## Usage
 
 ### Requirements
@@ -59,6 +73,7 @@ workflow convert_gtf {
 | `filter_type` | Comma-separated list of filterKey field values to retain | String | No | - |
 | `cpu_cores` | Number of CPU cores | Int | No | 1 |
 | `memory_gb` | Memory allocation in GB | Int | No | 2 |
+| `docker_image` | Docker image to use for this task | String | No | `getwilds/bedparse:0.2.3` |
 
 ### Advanced Usage with Filtering
 

--- a/modules/ww-bedparse/ww-bedparse.wdl
+++ b/modules/ww-bedparse/ww-bedparse.wdl
@@ -31,6 +31,7 @@ task gtf2bed {
     filter_type: "Comma separated list of filterKey field values to retain"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -40,6 +41,7 @@ task gtf2bed {
     String? filter_type
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/bedparse:0.2.3"
   }
 
   command <<<
@@ -63,7 +65,7 @@ task gtf2bed {
   }
 
   runtime {
-    docker: "getwilds/bedparse:0.2.3"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-bedtools/README.md
+++ b/modules/ww-bedtools/README.md
@@ -29,6 +29,7 @@ Calculates mean read coverage across BED intervals using BEDTools coverage.
 - `sample_name` (String): Sample name for output files
 - `cpu_cores` (Int): CPU cores (default: 2)
 - `memory_gb` (Int): Memory allocation (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bedtools:2.31.1`)
 
 **Outputs:**
 - `name` (String): Sample name that was processed
@@ -44,6 +45,7 @@ Performs BEDTools intersect between BED intervals and BAM alignments.
 - `flags` (String): BEDTools intersect command flags (default: "-header -wo")
 - `cpu_cores` (Int): CPU cores (default: 2)
 - `memory_gb` (Int): Memory allocation (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bedtools:2.31.1`)
 
 **Outputs:**
 - `name` (String): Sample name that was processed
@@ -63,6 +65,7 @@ Creates genomic windows and counts reads per window across specified chromosomes
 - `tmp_dir` (String): Path to temporary directory
 - `cpu_cores` (Int): CPU cores (default: 10)
 - `memory_gb` (Int): Memory allocation (default: 24)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bedtools:2.31.1`)
 
 **Outputs:**
 - `name` (String): Sample name that was processed

--- a/modules/ww-bedtools/ww-bedtools.wdl
+++ b/modules/ww-bedtools/ww-bedtools.wdl
@@ -31,6 +31,7 @@ task coverage {
     sample_name: "Name of the sample provided for output files"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -39,6 +40,7 @@ task coverage {
     String sample_name
     Int cpu_cores = 2
     Int memory_gb = 16
+    String docker_image = "getwilds/bedtools:2.31.1"
   }
 
   command <<<
@@ -58,7 +60,7 @@ task coverage {
   }
 
   runtime {
-    docker: "getwilds/bedtools:2.31.1"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -92,6 +94,7 @@ task intersect {
     flags: "BEDTools intersect command flags"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -101,6 +104,7 @@ task intersect {
     String flags = "-header -wo"
     Int cpu_cores = 2
     Int memory_gb = 16
+    String docker_image = "getwilds/bedtools:2.31.1"
   }
 
   command <<<
@@ -114,7 +118,7 @@ task intersect {
   }
 
   runtime {
-    docker: "getwilds/bedtools:2.31.1"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -152,6 +156,7 @@ task makewindows {
     tmp_dir: "Path to a temporary directory"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -165,6 +170,7 @@ task makewindows {
     String tmp_dir
     Int cpu_cores = 10
     Int memory_gb = 24
+    String docker_image = "getwilds/bedtools:2.31.1"
   }
 
  command <<<
@@ -193,7 +199,7 @@ task makewindows {
   }
 
   runtime {
-    docker: "getwilds/bedtools:2.31.1"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-bowtie/README.md
+++ b/modules/ww-bowtie/README.md
@@ -28,6 +28,7 @@ Builds Bowtie index files from a reference FASTA file.
 - `index_prefix` (String, default="bowtie_index"): Prefix for the Bowtie index files
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=16): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bowtie:1.3.1`)
 
 **Outputs:**
 - `bowtie_index_tar` (File): Compressed tarball containing Bowtie genome index files
@@ -44,6 +45,7 @@ Aligns short reads to a reference genome using Bowtie.
 - `mates` (File, optional): FASTQ file for reverse (R2) reads for paired-end alignment
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bowtie:1.3.1`)
 
 **Outputs:**
 - `sorted_bam` (File): Sorted Bowtie alignment output BAM file

--- a/modules/ww-bowtie/ww-bowtie.wdl
+++ b/modules/ww-bowtie/ww-bowtie.wdl
@@ -29,6 +29,7 @@ task bowtie_build {
     index_prefix: "Prefix for the Bowtie index files"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -36,6 +37,7 @@ task bowtie_build {
     String index_prefix = "bowtie_index"
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/bowtie:1.3.1"
   }
 
   command <<<
@@ -60,7 +62,7 @@ task bowtie_build {
   }
 
   runtime {
-    docker: "getwilds/bowtie:1.3.1"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -95,6 +97,7 @@ task bowtie_align {
     mates: "Optional FASTQ file for reverse (R2) reads for paired-end alignment"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -105,6 +108,7 @@ task bowtie_align {
     File? mates
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/bowtie:1.3.1"
   }
 
   command <<<
@@ -154,7 +158,7 @@ task bowtie_align {
   }
 
   runtime {
-    docker: "getwilds/bowtie:1.3.1"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-bowtie2/README.md
+++ b/modules/ww-bowtie2/README.md
@@ -28,6 +28,7 @@ Builds Bowtie 2 index files from a reference FASTA file.
 - `index_prefix` (String, default="bowtie2_index"): Prefix for the Bowtie 2 index files
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=16): Memory allocated for the task in GB
+- `docker_image` (String, default=`getwilds/bowtie2:2.5.4`): Docker image to use for this task
 
 **Outputs:**
 - `bowtie2_index_tar` (File): Compressed tarball containing Bowtie 2 genome index files
@@ -49,6 +50,7 @@ Aligns reads to a reference using Bowtie 2, optionally filtering the output usin
 - `extra_bowtie2_args` (String, default=""): Additional arguments forwarded verbatim to bowtie2 (e.g. `--no-mixed --no-discordant`).
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String, default=`getwilds/bowtie2:2.5.4`): Docker image to use for this task
 
 **Outputs:**
 - `sorted_bam` (File): Sorted Bowtie 2 alignment output BAM file

--- a/modules/ww-bowtie2/ww-bowtie2.wdl
+++ b/modules/ww-bowtie2/ww-bowtie2.wdl
@@ -29,6 +29,7 @@ task bowtie2_build {
     index_prefix: "Prefix for the Bowtie 2 index files"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -36,6 +37,7 @@ task bowtie2_build {
     String index_prefix = "bowtie2_index"
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/bowtie2:2.5.4"
   }
 
   command <<<
@@ -60,7 +62,7 @@ task bowtie2_build {
   }
 
   runtime {
-    docker: "getwilds/bowtie2:2.5.4"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -103,6 +105,7 @@ task bowtie2_align {
     extra_bowtie2_args: "Additional arguments forwarded verbatim to bowtie2 (e.g. '--no-mixed --no-discordant'). Empty by default."
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -118,6 +121,7 @@ task bowtie2_align {
     String extra_bowtie2_args = ""
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/bowtie2:2.5.4"
   }
 
   command <<<
@@ -191,7 +195,7 @@ task bowtie2_align {
   }
 
   runtime {
-    docker: "getwilds/bowtie2:2.5.4"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-bwa/README.md
+++ b/modules/ww-bwa/README.md
@@ -27,6 +27,7 @@ Builds BWA index files from reference FASTA and packages them in a compressed ta
 - `reference_fasta` (File): Reference genome FASTA file
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
 - `memory_gb` (Int): Memory allocation in GB (default: 32)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bwa:0.7.17`)
 
 **Outputs:**
 - `bwa_index_tar` (File): Compressed tarball containing BWA genome index files
@@ -43,6 +44,7 @@ Aligns paired-end reads to a reference using BWA-MEM with automatic read group a
 - `paired_end` (Boolean): Optional, indicating if reads are paired end (default: true)
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bwa:0.7.17`)
 
 **Outputs:**
 - `sorted_bam` (File): Sorted BAM alignment file

--- a/modules/ww-bwa/ww-bwa.wdl
+++ b/modules/ww-bwa/ww-bwa.wdl
@@ -28,12 +28,14 @@ task bwa_index {
     reference_fasta: "Reference genome FASTA file"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     File reference_fasta
     Int cpu_cores = 8
     Int memory_gb = 32
+    String docker_image = "getwilds/bwa:0.7.17"
   }
 
   String ref_name = basename(reference_fasta)  # Name of local copy
@@ -55,7 +57,7 @@ task bwa_index {
   }
 
   runtime {
-    docker: "getwilds/bwa:0.7.17"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -91,6 +93,7 @@ task bwa_mem {
     paired_end: "Optional boolean indicating if reads are paired end (default: true)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -102,6 +105,7 @@ task bwa_mem {
     Boolean paired_end = true
     Int cpu_cores = 8
     Int memory_gb = 16
+    String docker_image = "getwilds/bwa:0.7.17"
   }
 
     # Name of reference FASTA file, which should be in bwa_genome_tar
@@ -150,7 +154,7 @@ task bwa_mem {
   }
 
   runtime {
-    docker: "getwilds/bwa:0.7.17"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-cellranger/README.md
+++ b/modules/ww-cellranger/README.md
@@ -119,7 +119,8 @@ call cellranger_tasks.run_count_hpc_cromwell {
 
 Run `cellranger count` on gene expression reads from one GEM well from inside a minimal Lua container, with the host's Lmod tree and Cell Ranger software tree bind-mounted in. Sprocket always runs tasks inside a container under Apptainer, so this variant cannot omit the `docker` runtime key the way `run_count_hpc_cromwell` does; instead the container ships only the bits needed to execute `module load` (Lua) and the Cell Ranger binary itself comes in via host bind-mounts configured in the Sprocket HPC config.
 
-**Inputs:** Same as `run_count_hpc_cromwell`.
+**Inputs:** Same as `run_count_hpc_cromwell`, plus:
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/lua:5.3.6`)
 
 **Outputs:** Same as `run_count`.
 
@@ -145,6 +146,7 @@ Renames FASTQ files to match the Cell Ranger naming convention. Useful for prepa
 - `r1_fastq` (File): R1 FASTQ file to rename
 - `r2_fastq` (File): R2 FASTQ file to rename
 - `sample_id` (String): Sample ID to use as the prefix in the renamed file
+- `docker_image` (String): Docker image to use for this task (default: `ubuntu:22.04`)
 
 **Outputs:**
 - `r1_renamed` (File): R1 FASTQ file renamed to `{sample_id}_S1_R1_001.fastq.gz`

--- a/modules/ww-cellranger/ww-cellranger.wdl
+++ b/modules/ww-cellranger/ww-cellranger.wdl
@@ -377,6 +377,7 @@ task run_count_hpc_sprocket {
     chemistry: "Optional: Assay configuration (e.g. SC3Pv2)"
     skip_on_chemistry_failure: "When `true`, let task succeed with absent outputs if chemistry can't be auto detected."
     cellranger_module: "HPC environment module to load for Cell Ranger (e.g. 'CellRanger/10.0.0'). Compatible with Cell Ranger 8.x-10.x; v7 and earlier are not supported."
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -391,6 +392,7 @@ task run_count_hpc_sprocket {
     String? chemistry
     Boolean skip_on_chemistry_failure = false
     String cellranger_module = "CellRanger/10.0.0"
+    String docker_image = "getwilds/lua:5.3.6"
   }
 
   # Keep command block in sync with run_count and run_count_hpc_cromwell.
@@ -519,7 +521,7 @@ task run_count_hpc_sprocket {
   # execute under Apptainer. Cell Ranger itself is not in this image;
   # it comes in via the host bind-mounts in sprocket-hpc.toml.
   runtime {
-    docker: "getwilds/lua:5.3.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -541,12 +543,14 @@ task rename_fastqs {
     r1_fastq: "R1 FASTQ file to rename"
     r2_fastq: "R2 FASTQ file to rename"
     sample_id: "Sample ID to use as the prefix in the renamed file"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     File r1_fastq
     File r2_fastq
     String sample_id
+    String docker_image = "ubuntu:22.04"
   }
 
   command <<<
@@ -561,7 +565,7 @@ task rename_fastqs {
   }
 
   runtime {
-    docker: "ubuntu:22.04"
+    docker: docker_image
     cpu: 1
     memory: "2 GB"
   }

--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -53,6 +53,7 @@ Runs Clair3 to call germline variants from aligned reads using deep learning pil
 - `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for Clair3 inference. Note: the `gpus` runtime attribute is specified as a string (e.g., `"1"`) rather than an integer, as required by Fred Hutch PROOF/Cromwell configuration, but can be adjusted as necessary.
 - `cpu_cores` (Int, default=8): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=32): Memory allocated for the task in GB
+- `docker_image` (String, default=`getwilds/clair3:2.0.0`): Docker image to use for this task
 
 **Outputs:**
 - `output_vcf` (File): VCF file containing merged variant calls

--- a/modules/ww-clair3/ww-clair3.wdl
+++ b/modules/ww-clair3/ww-clair3.wdl
@@ -46,6 +46,7 @@ task run_clair3 {
     gpu_enabled: "Enable GPU acceleration for Clair3 inference (requests GPU in runtime)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -64,6 +65,7 @@ task run_clair3 {
     Boolean gpu_enabled = false
     Int cpu_cores = 8
     Int memory_gb = 32
+    String docker_image = "getwilds/clair3:2.0.0"
   }
 
   command <<<
@@ -108,7 +110,7 @@ task run_clair3 {
   }
 
   runtime {
-    docker: "getwilds/clair3:2.0.0"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
     gpus: if gpu_enabled then "1" else "0"

--- a/modules/ww-cnvkit/README.md
+++ b/modules/ww-cnvkit/README.md
@@ -39,6 +39,7 @@ Creates a CNVkit reference from normal samples or pooled reference data.
 - `antitarget_bed` (File, optional): Antitarget regions BED file
 - `cpu_cores` (Int, default=4): Number of CPU cores to use
 - `memory_gb` (Int, default=16): Memory allocation in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/cnvkit:0.9.10`)
 
 **Outputs:**
 - `reference_cnn` (File): CNVkit reference file (.cnn)
@@ -58,6 +59,7 @@ Performs CNVkit copy number analysis on tumor samples.
 - `paired_analysis` (Boolean, default=false): Whether to perform paired analysis
 - `cpu_cores` (Int, default=4): Number of CPU cores to use
 - `memory_gb` (Int, default=16): Memory allocation in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/cnvkit:0.9.10`)
 
 **Outputs:**
 - `cnv_segments` (File): CNV segments file (.cnr)

--- a/modules/ww-cnvkit/ww-cnvkit.wdl
+++ b/modules/ww-cnvkit/ww-cnvkit.wdl
@@ -34,6 +34,7 @@ task create_reference {
     reference_fasta_index: "Reference genome FASTA index file"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -45,6 +46,7 @@ task create_reference {
     File? antitarget_bed
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/cnvkit:0.9.10"
   }
 
   command <<<
@@ -104,7 +106,7 @@ task create_reference {
   }
 
   runtime {
-    docker: "getwilds/cnvkit:0.9.10"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -143,6 +145,7 @@ task run_cnvkit {
     paired_analysis: "Whether to perform paired tumor/normal analysis"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -156,6 +159,7 @@ task run_cnvkit {
     Boolean paired_analysis = false
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/cnvkit:0.9.10"
   }
 
   command <<<
@@ -206,7 +210,7 @@ task run_cnvkit {
   }
 
   runtime {
-    docker: "getwilds/cnvkit:0.9.10"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-colabfold/README.md
+++ b/modules/ww-colabfold/README.md
@@ -30,6 +30,7 @@ Download AlphaFold2 model weights for use with ColabFold predictions. Weights ar
 **Inputs:**
 - `cpu_cores` (Int, default=2): CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/colabfold:1.5.5`)
 
 **Outputs:**
 - `weights_tarball` (File): Compressed tarball containing AlphaFold2 model weights (~15-20 GB)
@@ -54,6 +55,7 @@ Predict protein structures from amino acid sequences using ColabFold (AlphaFold2
 - `cpu_cores` (Int, default=8): CPU cores
 - `memory_gb` (Int, default=48): Memory in GB
 - `gpu_enabled` (Boolean, default=true): Enable GPU for prediction (controls JAX CPU/GPU mode and PROOF GPU allocation)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/colabfold:1.5.5`)
 
 **Outputs:**
 - `results_tarball` (File): Compressed tarball containing all ColabFold outputs (PDB files, PAE/pLDDT plots, coverage plots, prediction metrics)

--- a/modules/ww-colabfold/ww-colabfold.wdl
+++ b/modules/ww-colabfold/ww-colabfold.wdl
@@ -30,11 +30,13 @@ task download_weights {
   parameter_meta {
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 2
     Int memory_gb = 8
+    String docker_image = "getwilds/colabfold:1.5.5"
   }
 
   command <<<
@@ -61,7 +63,7 @@ task download_weights {
   }
 
   runtime {
-    docker: "getwilds/colabfold:1.5.5"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -103,6 +105,7 @@ task colabfold_predict {
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
     gpu_enabled: "Enable GPU for prediction (controls JAX CPU/GPU mode and PROOF GPU allocation)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -121,6 +124,7 @@ task colabfold_predict {
     Int cpu_cores = 8
     Int memory_gb = 48
     Boolean gpu_enabled = true
+    String docker_image = "getwilds/colabfold:1.5.5"
   }
 
   command <<<
@@ -163,7 +167,7 @@ task colabfold_predict {
   }
 
   runtime {
-    docker: "getwilds/colabfold:1.5.5"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
     gpus: if gpu_enabled then "1" else "0"

--- a/modules/ww-consensus/README.md
+++ b/modules/ww-consensus/README.md
@@ -31,6 +31,7 @@ Generates consensus variant calls by combining annotated variant tables from thr
 - `base_file_name` (String): Base name for output files
 - `cpu_cores` (Int): Number of CPU cores to use (default: 1)
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `rocker/tidyverse:4.4.2`)
 
 **Outputs:**
 - `consensus_tsv` (File): Tab-separated file containing consensus variant calls with evidence from all callers

--- a/modules/ww-consensus/ww-consensus.wdl
+++ b/modules/ww-consensus/ww-consensus.wdl
@@ -44,7 +44,7 @@ task consensus_processing {
     String base_file_name
     Int cpu_cores = 1
     Int memory_gb = 8
-    String docker_image = "rocker/tidyverse:4"
+    String docker_image = "rocker/tidyverse:4.4.2"
   }
 
   command <<<

--- a/modules/ww-consensus/ww-consensus.wdl
+++ b/modules/ww-consensus/ww-consensus.wdl
@@ -34,6 +34,7 @@ task consensus_processing {
     base_file_name: "Base name for output files"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -43,6 +44,7 @@ task consensus_processing {
     String base_file_name
     Int cpu_cores = 1
     Int memory_gb = 8
+    String docker_image = "rocker/tidyverse:4"
   }
 
   command <<<
@@ -65,6 +67,6 @@ task consensus_processing {
   runtime {
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    docker: "rocker/tidyverse:4"
+    docker: docker_image
   }
 }

--- a/modules/ww-deeptools/README.md
+++ b/modules/ww-deeptools/README.md
@@ -37,6 +37,7 @@ Generates a normalized coverage track (bigWig or bedGraph) from a BAM file.
 - `extra_args` (String, default=""): Additional bamCoverage arguments
 - `cpu_cores` (Int, default=4): CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deeptools:3.5.6`)
 
 **Outputs:**
 - `coverage_file` (File): Normalized coverage track file
@@ -59,6 +60,7 @@ Compares two BAM files (e.g., treatment vs. control) and generates a comparison 
 - `extra_args` (String, default=""): Additional bamCompare arguments
 - `cpu_cores` (Int, default=4): CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deeptools:3.5.6`)
 
 **Outputs:**
 - `comparison_file` (File): Coverage comparison track file
@@ -79,6 +81,7 @@ Computes a matrix of signal values from bigWig files over genomic regions for vi
 - `extra_args` (String, default=""): Additional computeMatrix arguments
 - `cpu_cores` (Int, default=4): CPU cores
 - `memory_gb` (Int, default=16): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deeptools:3.5.6`)
 
 **Outputs:**
 - `matrix_gz` (File): Compressed matrix for plotting
@@ -96,6 +99,7 @@ Creates a heatmap visualization of signal enrichment over genomic regions.
 - `extra_args` (String, default=""): Additional plotHeatmap arguments
 - `cpu_cores` (Int, default=1): CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deeptools:3.5.6`)
 
 **Outputs:**
 - `heatmap` (File): Heatmap image file
@@ -111,6 +115,7 @@ Creates a profile plot of average signal enrichment over genomic regions.
 - `extra_args` (String, default=""): Additional plotProfile arguments
 - `cpu_cores` (Int, default=1): CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deeptools:3.5.6`)
 
 **Outputs:**
 - `profile` (File): Profile plot image file
@@ -129,6 +134,7 @@ Computes read coverage summary across multiple BAM files for sample comparison.
 - `extra_args` (String, default=""): Additional multiBamSummary arguments
 - `cpu_cores` (Int, default=4): CPU cores
 - `memory_gb` (Int, default=16): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deeptools:3.5.6`)
 
 **Outputs:**
 - `summary_npz` (File): Compressed numpy array for analysis
@@ -147,6 +153,7 @@ Generates a correlation heatmap or scatterplot from multiBamSummary output.
 - `extra_args` (String, default=""): Additional plotCorrelation arguments
 - `cpu_cores` (Int, default=1): CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deeptools:3.5.6`)
 
 **Outputs:**
 - `correlation_plot` (File): Correlation plot image
@@ -163,6 +170,7 @@ Generates a PCA plot from multiBamSummary output.
 - `extra_args` (String, default=""): Additional plotPCA arguments
 - `cpu_cores` (Int, default=1): CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deeptools:3.5.6`)
 
 **Outputs:**
 - `pca_plot` (File): PCA plot image
@@ -181,6 +189,7 @@ Generates a fingerprint plot to assess ChIP enrichment quality.
 - `extra_args` (String, default=""): Additional plotFingerprint arguments
 - `cpu_cores` (Int, default=4): CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deeptools:3.5.6`)
 
 **Outputs:**
 - `fingerprint_plot` (File): Fingerprint plot image

--- a/modules/ww-deeptools/ww-deeptools.wdl
+++ b/modules/ww-deeptools/ww-deeptools.wdl
@@ -41,6 +41,7 @@ task bam_coverage {
     extra_args: "Additional arguments to pass to bamCoverage"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -57,6 +58,7 @@ task bam_coverage {
     String extra_args = ""
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/deeptools:3.5.6"
   }
 
   String ext = if output_format == "bigwig" then ".bw" else ".bedgraph"
@@ -83,7 +85,7 @@ task bam_coverage {
   }
 
   runtime {
-    docker: "getwilds/deeptools:3.5.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -123,6 +125,7 @@ task bam_compare {
     extra_args: "Additional arguments to pass to bamCompare"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -139,6 +142,7 @@ task bam_compare {
     String extra_args = ""
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/deeptools:3.5.6"
   }
 
   String ext = if output_format == "bigwig" then ".bw" else ".bedgraph"
@@ -164,7 +168,7 @@ task bam_compare {
   }
 
   runtime {
-    docker: "getwilds/deeptools:3.5.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -203,6 +207,7 @@ task compute_matrix {
     extra_args: "Additional arguments to pass to computeMatrix"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -217,6 +222,7 @@ task compute_matrix {
     String extra_args = ""
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/deeptools:3.5.6"
   }
 
   Boolean is_reference_point = mode == "reference-point"
@@ -244,7 +250,7 @@ task compute_matrix {
   }
 
   runtime {
-    docker: "getwilds/deeptools:3.5.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -278,6 +284,7 @@ task plot_heatmap {
     extra_args: "Additional arguments to pass to plotHeatmap"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -288,6 +295,7 @@ task plot_heatmap {
     String extra_args = ""
     Int cpu_cores = 1
     Int memory_gb = 8
+    String docker_image = "getwilds/deeptools:3.5.6"
   }
 
   command <<<
@@ -305,7 +313,7 @@ task plot_heatmap {
   }
 
   runtime {
-    docker: "getwilds/deeptools:3.5.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -338,6 +346,7 @@ task plot_profile {
     extra_args: "Additional arguments to pass to plotProfile"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -347,6 +356,7 @@ task plot_profile {
     String extra_args = ""
     Int cpu_cores = 1
     Int memory_gb = 8
+    String docker_image = "getwilds/deeptools:3.5.6"
   }
 
   command <<<
@@ -363,7 +373,7 @@ task plot_profile {
   }
 
   runtime {
-    docker: "getwilds/deeptools:3.5.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -400,6 +410,7 @@ task multi_bam_summary {
     extra_args: "Additional arguments to pass to multiBamSummary"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -412,6 +423,7 @@ task multi_bam_summary {
     String extra_args = ""
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/deeptools:3.5.6"
   }
 
   Boolean is_bins_mode = mode == "bins"
@@ -435,7 +447,7 @@ task multi_bam_summary {
   }
 
   runtime {
-    docker: "getwilds/deeptools:3.5.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -471,6 +483,7 @@ task plot_correlation {
     extra_args: "Additional arguments to pass to plotCorrelation"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -482,6 +495,7 @@ task plot_correlation {
     String extra_args = ""
     Int cpu_cores = 1
     Int memory_gb = 8
+    String docker_image = "getwilds/deeptools:3.5.6"
   }
 
   command <<<
@@ -502,7 +516,7 @@ task plot_correlation {
   }
 
   runtime {
-    docker: "getwilds/deeptools:3.5.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -536,6 +550,7 @@ task plot_pca {
     extra_args: "Additional arguments to pass to plotPCA"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -545,6 +560,7 @@ task plot_pca {
     String extra_args = ""
     Int cpu_cores = 1
     Int memory_gb = 8
+    String docker_image = "getwilds/deeptools:3.5.6"
   }
 
   command <<<
@@ -563,7 +579,7 @@ task plot_pca {
   }
 
   runtime {
-    docker: "getwilds/deeptools:3.5.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -599,6 +615,7 @@ task plot_fingerprint {
     extra_args: "Additional arguments to pass to plotFingerprint"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -610,6 +627,7 @@ task plot_fingerprint {
     String extra_args = ""
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/deeptools:3.5.6"
   }
 
   command <<<
@@ -630,7 +648,7 @@ task plot_fingerprint {
   }
 
   runtime {
-    docker: "getwilds/deeptools:3.5.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-deepvariant/README.md
+++ b/modules/ww-deepvariant/README.md
@@ -37,6 +37,7 @@ Runs DeepVariant to call germline variants from aligned reads. Optionally produc
 - `regions` (String?, optional): Genomic regions to restrict variant calling
 - `cpu_cores` (Int, default=8): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=32): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `google/deepvariant:1.10.0`)
 
 **Outputs:**
 - `output_vcf` (File): VCF file containing variant calls

--- a/modules/ww-deepvariant/ww-deepvariant.wdl
+++ b/modules/ww-deepvariant/ww-deepvariant.wdl
@@ -40,6 +40,7 @@ task run_deepvariant {
     regions: "Optional genomic regions to restrict variant calling (e.g., chr1)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -53,6 +54,7 @@ task run_deepvariant {
     String? regions
     Int cpu_cores = 8
     Int memory_gb = 32
+    String docker_image = "google/deepvariant:1.10.0"
   }
 
   command <<<
@@ -76,7 +78,7 @@ task run_deepvariant {
   }
 
   runtime {
-    docker: "google/deepvariant:1.10.0"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-delly/README.md
+++ b/modules/ww-delly/README.md
@@ -34,6 +34,7 @@ Calls structural variants from aligned BAM files using Delly.
 - `sv_type` (String): Structural variant type to call (DEL, DUP, INV, TRA, INS) or empty for all types (default: "")
 - `cpu_cores` (Int): Number of CPU cores to use (default: 8)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/delly:1.2.9`)
 
 **Outputs:**
 - `vcf` (File): Structural variants in compressed VCF format

--- a/modules/ww-delly/ww-delly.wdl
+++ b/modules/ww-delly/ww-delly.wdl
@@ -36,6 +36,7 @@ task delly_call {
     sv_type: "Structural variant type to call (DEL, DUP, INV, TRA, INS) or empty for all"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -48,6 +49,7 @@ task delly_call {
     String sv_type = ""
     Int cpu_cores = 8
     Int memory_gb = 16
+    String docker_image = "getwilds/delly:1.2.9"
   }
 
   String sample_name = basename(aligned_bam, ".bam")
@@ -93,7 +95,7 @@ task delly_call {
   }
 
   runtime {
-    docker: "getwilds/delly:1.2.9"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb}GB"
   }

--- a/modules/ww-deseq2/README.md
+++ b/modules/ww-deseq2/README.md
@@ -47,6 +47,7 @@ Combines STAR gene count files from multiple samples into a single count matrix 
   - 2 = unstranded counts
   - 3 = stranded counts, first read forward
   - 4 = stranded counts, first read reverse
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/python-utils:0.1.0`)
 
 **Outputs:**
 - `counts_matrix` (File): Combined matrix of gene-level counts from all samples
@@ -72,6 +73,7 @@ This ensures the analysis works reliably across diverse dataset sizes, from smal
 - `shrinkage_method` (String): LFC shrinkage method — `apeglm`, `ashr`, or `normal`; empty = no shrinkage (default: "")
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deseq2:1.40.2`)
 
 **Outputs:**
 - `deseq2_results` (File): Complete DESeq2 differential expression results with statistics (used to make volcano plot)
@@ -92,8 +94,9 @@ Merges DESeq2 differential expression results with normalized counts and gene an
 - `normalized_counts` (File): DESeq2 normalized counts CSV (output of `run_deseq2`)
 - `gtf_file` (File): GTF annotation file for extracting gene descriptions. Use the original (non-normalized) GTF so NCBI/Ensembl-specific attributes like `gene_biotype`, `product`, and `locus_tag` are preserved.
 - `output_name` (String): Name for the output CSV file (default: "deseq2_compiled_results.csv")
-- `memory_gb` (Int): Memory allocation in GB (default: 4)
-- `cpu_cores` (Int): Number of CPU cores (default: 1)
+- `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `cpu_cores` (Int): Number of CPU cores (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/python-utils:0.1.0`)
 
 **Outputs:**
 - `compiled_results` (File): Combined CSV with DESeq2 statistics, normalized counts, and gene annotations (gene_name, gene_biotype, product, locus_tag, db_xref where available; columns that are entirely empty are dropped)

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -33,6 +33,7 @@ task combine_count_matrices {
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
     count_column: "Column number in STAR count files to extract (2=unstranded, 3=forward strand, 4=reverse strand)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -41,6 +42,7 @@ task combine_count_matrices {
     Array[String] sample_conditions
     Int memory_gb = 4
     Int cpu_cores = 1
+    String docker_image = "getwilds/python-utils:0.1.0"
     Int count_column = 2
         # Column to extract from ReadsPerGene.out.tab files:
         # 2 = unstranded counts
@@ -68,7 +70,7 @@ task combine_count_matrices {
   }
 
   runtime {
-    docker: "getwilds/python-utils:0.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -121,6 +123,7 @@ task run_deseq2 {
     shrinkage_method: "LFC shrinkage method: apeglm, ashr, or normal (empty = no shrinkage)"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -134,6 +137,7 @@ task run_deseq2 {
     String shrinkage_method = ""
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/deseq2:1.40.2"
   }
 
   command <<<
@@ -167,7 +171,7 @@ task run_deseq2 {
   }
 
   runtime {
-    docker: "getwilds/deseq2:1.40.2"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -199,6 +203,7 @@ task compile_deseq2_results {
     output_name: "Name for the output CSV file"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -208,6 +213,7 @@ task compile_deseq2_results {
     String output_name = "deseq2_compiled_results.csv"
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/python-utils:0.1.0"
   }
 
   command <<<
@@ -228,7 +234,7 @@ task compile_deseq2_results {
   }
 
   runtime {
-    docker: "getwilds/python-utils:0.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-diamond/README.md
+++ b/modules/ww-diamond/README.md
@@ -26,6 +26,7 @@ Creates a DIAMOND database from a protein FASTA file.
 - `fasta` (File): Input FASTA file containing protein sequences
 - `memory_gb` (Int): Memory allocation in GB (default: 2)
 - `cpu_cores` (Int): Number of CPU cores (default: 1)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/diamond:2.1.16`)
 
 **Outputs:**
 - `diamond_db` (File): DIAMOND database file (.dmnd) created from input FASTA
@@ -44,6 +45,7 @@ Aligns protein sequences to a DIAMOND database using the BLASTP algorithm.
 - `blocksize` (Float): Billions of sequence letters to process at a time (default: "2.0")
 - `memory_gb` (Int): Memory allocation in GB (default: 2)
 - `cpu_cores` (Int): Number of CPU cores (default: 1)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/diamond:2.1.16`)
 
 **Outputs:**
 - `aln` (File): Compressed alignment file in tabular format (outfmt 6), gzip-compressed

--- a/modules/ww-diamond/ww-diamond.wdl
+++ b/modules/ww-diamond/ww-diamond.wdl
@@ -29,12 +29,14 @@ task make_database {
     fasta: "Input FASTA file containing protein sequences"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     File fasta
     Int memory_gb = 2
     Int cpu_cores = 1
+    String docker_image = "getwilds/diamond:2.1.16"
   }
 
   String fasta_base = sub(basename(fasta), ".*/", "")
@@ -50,7 +52,7 @@ task make_database {
   }
 
   runtime {
-    docker: "getwilds/diamond:2.1.16"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -86,6 +88,7 @@ task diamond_blastp {
     blocksize: "Block size in billions of sequence letters to be processed at a time."
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -98,6 +101,7 @@ task diamond_blastp {
     Float blocksize = 2.0
     Int memory_gb = 2
     Int cpu_cores = 1
+    String docker_image = "getwilds/diamond:2.1.16"
   }
 
   String db_name = basename(diamond_db, ".dmnd")
@@ -127,7 +131,7 @@ task diamond_blastp {
   }
 
   runtime {
-    docker: "getwilds/diamond:2.1.16"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-ena/README.md
+++ b/modules/ww-ena/README.md
@@ -37,6 +37,7 @@ Downloads sequencing data files from ENA using accession numbers. Supports singl
 - `output_dir_name` (String, default="ena_downloads"): Name for the output directory
 - `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/ena-tools:2.1.1`)
 
 **Note:** Either `accessions` or `accessions_file` must be provided. When using `protocol = "HTTP"`, the `accessions` string input is required (accessions_file is not supported). The HTTP option uses `wget` to fetch files via the ENA portal API rather than the ENA File Downloader tool.
 
@@ -57,6 +58,7 @@ Downloads sequencing data files from ENA using a search query. Allows filtering 
 - `output_dir_name` (String, default="ena_downloads"): Name for the output directory
 - `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/ena-tools:2.1.1`)
 
 **Outputs:**
 - `downloaded_files` (Array[File]): Array of downloaded files from ENA
@@ -69,6 +71,7 @@ Extracts FASTQ files from downloaded ENA files for downstream processing. Suppor
 
 **Inputs:**
 - `downloaded_files` (Array[File]): Array of files downloaded from ENA (typically from `download_files` task)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/ena-tools:2.1.1`)
 
 **Outputs:**
 - `r1_files` (Array[File]): Array of Read 1 FASTQ files, parallel with `r2_files`, `accessions`, and `is_paired_end_list`

--- a/modules/ww-ena/ww-ena.wdl
+++ b/modules/ww-ena/ww-ena.wdl
@@ -36,6 +36,7 @@ task download_files {
     output_dir_name: "Name for the output directory where files will be downloaded (default: ena_downloads)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -54,6 +55,7 @@ task download_files {
     # Resource parameters
     Int cpu_cores = 2
     Int memory_gb = 8
+    String docker_image = "getwilds/ena-tools:2.1.1"
   }
 
   # Resolve accessions input - prefer string accessions over file
@@ -114,7 +116,7 @@ task download_files {
   }
 
   runtime {
-    docker: "getwilds/ena-tools:2.1.1"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -150,6 +152,7 @@ task download_by_query {
     output_dir_name: "Name for the output directory where files will be downloaded"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -166,6 +169,7 @@ task download_by_query {
     # Resource parameters
     Int cpu_cores = 2
     Int memory_gb = 8
+    String docker_image = "getwilds/ena-tools:2.1.1"
   }
 
   command <<<
@@ -203,7 +207,7 @@ task download_by_query {
   }
 
   runtime {
-    docker: "getwilds/ena-tools:2.1.1"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -234,10 +238,12 @@ task extract_fastq_pairs {
 
   parameter_meta {
     downloaded_files: "Array of files downloaded from ENA"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Array[File] downloaded_files
+    String docker_image = "getwilds/ena-tools:2.1.1"
   }
 
   command <<<
@@ -309,7 +315,7 @@ task extract_fastq_pairs {
   }
 
   runtime {
-    docker: "getwilds/ena-tools:2.1.1"
+    docker: docker_image
     cpu: 1
     memory: "2 GB"
   }

--- a/modules/ww-esmfold/README.md
+++ b/modules/ww-esmfold/README.md
@@ -33,6 +33,7 @@ Predict protein 3D structures from amino acid sequences using ESMFold.
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=16): Memory allocated for the task in GB
 - `gpu_enabled` (Boolean, default=true): Enable GPU for prediction
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/esmfold:2.0.0`)
 
 **Outputs:**
 - `pdb_output` (File): Compressed tarball containing predicted PDB structure files with pLDDT confidence scores

--- a/modules/ww-esmfold/ww-esmfold.wdl
+++ b/modules/ww-esmfold/ww-esmfold.wdl
@@ -38,6 +38,7 @@ task esmfold_predict {
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
     gpu_enabled: "Enable GPU for prediction (recommended for production use)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -50,6 +51,7 @@ task esmfold_predict {
     Int cpu_cores = 4
     Int memory_gb = 16
     Boolean gpu_enabled = true
+    String docker_image = "getwilds/esmfold:2.0.0"
   }
 
   command <<<
@@ -81,7 +83,7 @@ task esmfold_predict {
   }
 
   runtime {
-    docker: "getwilds/esmfold:2.0.0"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
     gpus: if gpu_enabled then "1" else "0"

--- a/modules/ww-fastp/README.md
+++ b/modules/ww-fastp/README.md
@@ -35,6 +35,7 @@ Run fastp on paired-end FASTQ files for quality filtering, adapter trimming, and
 - `umi_len` (Int, default=6): Length of the UMI in basepairs. Only consulted when `umi_loc` is set.
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/fastp:1.1.0`)
 
 **Outputs:**
 - `r1_trimmed` (File): Trimmed and filtered R1 FASTQ file
@@ -56,6 +57,7 @@ Run fastp on single-end FASTQ files for quality filtering, adapter trimming, and
 - `umi_len` (Int, default=6): Length of the UMI in basepairs. Only consulted when `umi_loc` is set.
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/fastp:1.1.0`)
 
 **Outputs:**
 - `trimmed_fastq` (File): Trimmed and filtered FASTQ file

--- a/modules/ww-fastp/ww-fastp.wdl
+++ b/modules/ww-fastp/ww-fastp.wdl
@@ -42,6 +42,7 @@ task fastp_paired {
     umi_len: "Length of the UMI in basepairs. Required when umi_loc is set; ignored otherwise (default: 6)"
     cpu_cores: "Number of CPU cores allocated for the task (default: 4)"
     memory_gb: "Memory allocated for the task in GB (default: 8)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -56,6 +57,7 @@ task fastp_paired {
     Int umi_len = 6
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/fastp:1.1.0"
   }
 
   command <<<
@@ -96,7 +98,7 @@ task fastp_paired {
   }
 
   runtime {
-    docker: "getwilds/fastp:1.1.0"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -134,6 +136,7 @@ task fastp_single {
     umi_len: "Length of the UMI in basepairs. Required when umi_loc is set; ignored otherwise (default: 6)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -146,6 +149,7 @@ task fastp_single {
     Int umi_len = 6
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/fastp:1.1.0"
   }
 
   command <<<
@@ -179,7 +183,7 @@ task fastp_single {
   }
 
   runtime {
-    docker: "getwilds/fastp:1.1.0"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-fastqc/README.md
+++ b/modules/ww-fastqc/README.md
@@ -32,6 +32,7 @@ Run FastQC quality control analysis on FASTQ files.
 - `adapters` (File, optional): Adapter sequences file for contamination screening
 - `limits` (File, optional): Limits file to override default warning/error thresholds
 - `contaminants` (File, optional): Contaminants file for contamination screening
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/fastqc:0.12.1`)
 
 **Outputs:**
 - `html_reports` (Array[File]): FastQC HTML quality control reports

--- a/modules/ww-fastqc/ww-fastqc.wdl
+++ b/modules/ww-fastqc/ww-fastqc.wdl
@@ -34,6 +34,7 @@ task run_fastqc {
     adapters: "Optional adapter sequences file for contamination screening"
     limits: "Optional limits file to override default warning/error thresholds"
     contaminants: "Optional contaminants file for contamination screening"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -44,6 +45,7 @@ task run_fastqc {
     File? adapters
     File? limits
     File? contaminants
+    String docker_image = "getwilds/fastqc:0.12.1"
   }
 
   command <<<
@@ -97,7 +99,7 @@ task run_fastqc {
   }
 
   runtime {
-    docker: "getwilds/fastqc:0.12.1"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-gatk/README.md
+++ b/modules/ww-gatk/README.md
@@ -40,6 +40,7 @@ Marks duplicate reads in aligned BAM files to improve variant calling accuracy.
 - `base_file_name` (String): Base name for the output files
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `markdup_bam` (File): BAM file with duplicate reads marked
@@ -61,6 +62,7 @@ Performs Base Quality Score Recalibration (BQSR) to improve the accuracy of base
 - `intervals` (File?): Optional interval list file defining target regions
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `recalibrated_bam` (File): BAM file with recalibrated base quality scores
@@ -82,6 +84,7 @@ Performs duplicate marking, base recalibration, and WGS metrics collection in a 
 - `intervals` (File?): Optional interval list file defining target regions
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 - `minimum_mapping_quality` (Int): Minimum mapping quality for reads (default: 20)
 - `minimum_base_quality` (Int): Minimum base quality for bases (default: 20)
 - `coverage_cap` (Int): Maximum coverage depth to analyze (default: 250)
@@ -109,6 +112,7 @@ Calls germline variants using GATK HaplotypeCaller for individual intervals in s
 - `intervals` (File?): Optional interval list file defining target regions
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `vcf` (File): Compressed VCF file containing germline variant calls
@@ -128,6 +132,7 @@ Calls germline variants using GATK HaplotypeCaller with internal parallelization
 - `base_file_name` (String): Base name for output files
 - `memory_gb` (Int): Memory allocation in GB, minimum 8 (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (should match number of intervals) (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `vcf` (File): Compressed VCF file containing germline variant calls
@@ -148,6 +153,7 @@ Calls somatic variants using GATK Mutect2 in tumor-only mode with filtering for 
 - `max_mnp_distance` (Int): Distance at which to merge MNPs (default: 1, use 0 for PON creation)
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `vcf` (File): Compressed VCF file containing filtered somatic variant calls
@@ -172,6 +178,7 @@ Calls somatic variants using GATK Mutect2 with internal parallelization for redu
 - `max_mnp_distance` (Int): Distance at which to merge MNPs (default: 1, use 0 for PON creation)
 - `memory_gb` (Int): Memory allocation in GB, minimum 8 (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `vcf` (File): Compressed VCF file containing filtered somatic variant calls
@@ -199,6 +206,7 @@ Creates a somatic panel of normals (PON) from Mutect2 VCF files for filtering ge
 - `germline_resource` (File?): Optional gnomAD VCF for additional germline filtering
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `pon_vcf` (File): Gzipped VCF file containing the panel of normals
@@ -218,6 +226,7 @@ Automatically splits genome intervals into optimal chunks for parallel processin
 - `filter_to_canonical_chromosomes` (Boolean): Whether to restrict analysis to canonical chromosomes (chr1-22,X,Y,M) (default: true)
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `interval_files` (Array[File]): Array of interval files optimized for parallel processing
@@ -235,6 +244,7 @@ Extracts reads from specific intervals using GATK PrintReads for scatter-gather 
 - `output_basename` (String): Base name for output files
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `interval_bams` (Array[File]): Array of BAM files containing reads from specified intervals
@@ -250,6 +260,7 @@ Merges multiple VCF files from parallel processing into a single consolidated VC
 - `reference_dict` (File): Reference sequence dictionary
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `merged_vcf` (File): Merged VCF file
@@ -263,6 +274,7 @@ Merges Mutect2 statistics files from parallel processing.
 - `base_file_name` (String): Base name for output files
 - `memory_gb` (Int): Memory allocation in GB (default: 4)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 1)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `merged_stats` (File): Merged Mutect2 statistics file
@@ -283,6 +295,7 @@ Converts paired FASTQ files to unmapped BAM/SAM format using GATK FastqToSam.
 - `read_group_name` (String?): Read group name (if not provided, defaults to sample_name)
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `unmapped_bam` (File): Unmapped BAM file containing reads from input FASTQ files
@@ -300,6 +313,7 @@ Validates BAM/CRAM/SAM files for formatting issues using GATK ValidateSamFile.
 - `reference_fasta` (File?): Reference genome FASTA (required for CRAM files)
 - `memory_gb` (Int): Memory allocation in GB (default: 4)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `validation_report` (File): Text file containing validation statistics and any errors/warnings
@@ -313,6 +327,7 @@ Creates a sequence dictionary file from a reference FASTA file.
 - `reference_fasta` (File): Reference genome FASTA file
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `sequence_dict` (File): Sequence dictionary file (.dict) for the reference genome
@@ -329,6 +344,7 @@ Collects whole genome sequencing metrics using GATK CollectWgsMetrics.
 - `base_file_name` (String): Base name for output files
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 - `minimum_mapping_quality` (Int): Minimum mapping quality for reads (default: 20)
 - `minimum_base_quality` (Int): Minimum base quality for bases (default: 20)
 - `coverage_cap` (Int): Maximum coverage depth to analyze (default: 250)
@@ -354,6 +370,7 @@ Analyzes saturation mutagenesis data using GATK AnalyzeSaturationMutagenesis to 
 - `base_file_name` (String): Base name for output files
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gatk:4.6.1.0`)
 
 **Outputs:**
 - `aa_counts` (File): Amino acid count table

--- a/modules/ww-gatk/ww-gatk.wdl
+++ b/modules/ww-gatk/ww-gatk.wdl
@@ -28,12 +28,14 @@ task create_sequence_dictionary {
     reference_fasta: "Reference genome FASTA file"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     File reference_fasta
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   String dict_basename = basename(basename(reference_fasta, ".fa"), ".fasta")
@@ -53,7 +55,7 @@ task create_sequence_dictionary {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -87,6 +89,7 @@ task mark_duplicates {
     base_file_name: "Base name for the output files"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -95,6 +98,7 @@ task mark_duplicates {
     String base_file_name
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -117,7 +121,7 @@ task mark_duplicates {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -157,6 +161,7 @@ task base_recalibrator {
     intervals: "Optional interval list file defining target regions"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -171,6 +176,7 @@ task base_recalibrator {
     File? intervals
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -227,7 +233,7 @@ task base_recalibrator {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -265,6 +271,7 @@ task collect_wgs_metrics {
     minimum_mapping_quality: "Minimum mapping quality for reads to be included"
     minimum_base_quality: "Minimum base quality for bases to be included"
     coverage_cap: "Maximum coverage depth to analyze"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -279,6 +286,7 @@ task collect_wgs_metrics {
     Int minimum_mapping_quality = 20
     Int minimum_base_quality = 20
     Int coverage_cap = 250
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -301,7 +309,7 @@ task collect_wgs_metrics {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -346,6 +354,7 @@ task markdup_recal_metrics {
     minimum_mapping_quality: "Minimum mapping quality for reads to be included"
     minimum_base_quality: "Minimum base quality for bases to be included"
     coverage_cap: "Maximum coverage depth to analyze"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -363,6 +372,7 @@ task markdup_recal_metrics {
     Int minimum_mapping_quality = 20
     Int minimum_base_quality = 20
     Int coverage_cap = 250
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -448,7 +458,7 @@ task markdup_recal_metrics {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -483,6 +493,7 @@ task split_intervals {
     filter_to_canonical_chromosomes: "Whether to restrict analysis to canonical chromosomes (chr1-22,X,Y,M) (default: true)"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -494,6 +505,7 @@ task split_intervals {
     Boolean filter_to_canonical_chromosomes = true
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -560,7 +572,7 @@ task split_intervals {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -597,6 +609,7 @@ task print_reads {
     output_basename: "Base name for output files"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -609,6 +622,7 @@ task print_reads {
     String output_basename
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -654,7 +668,7 @@ task print_reads {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -692,6 +706,7 @@ task haplotype_caller {
     intervals: "Optional interval list file defining target regions"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -705,6 +720,7 @@ task haplotype_caller {
     File? intervals
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -738,7 +754,7 @@ task haplotype_caller {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -781,6 +797,7 @@ task mutect2 {
     max_mnp_distance: "Distance at which to merge MNPs (default: 1)"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -795,6 +812,7 @@ task mutect2 {
     Int max_mnp_distance = 1
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -843,7 +861,7 @@ task mutect2 {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -877,6 +895,7 @@ task merge_vcfs {
     reference_dict: "Reference sequence dictionary"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -886,6 +905,7 @@ task merge_vcfs {
     File reference_dict
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -905,7 +925,7 @@ task merge_vcfs {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -936,6 +956,7 @@ task merge_mutect_stats {
     base_file_name: "Base name for output files"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -943,6 +964,7 @@ task merge_mutect_stats {
     String base_file_name
     Int memory_gb = 4
     Int cpu_cores = 1
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -960,7 +982,7 @@ task merge_mutect_stats {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -998,6 +1020,7 @@ task haplotype_caller_parallel {
     base_file_name: "Base name for output files"
     memory_gb: "Memory allocation in GB (minimum: 8)"
     cpu_cores: "Number of CPU cores to use (should match number of intervals)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1011,6 +1034,7 @@ task haplotype_caller_parallel {
     String base_file_name
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -1080,7 +1104,7 @@ task haplotype_caller_parallel {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -1122,6 +1146,7 @@ task mutect2_parallel {
     max_mnp_distance: "Distance at which to merge MNPs (default: 1)"
     memory_gb: "Memory allocation in GB (minimum: 8)"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1136,6 +1161,7 @@ task mutect2_parallel {
     Int max_mnp_distance = 1
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -1243,7 +1269,7 @@ task mutect2_parallel {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -1280,6 +1306,7 @@ task fastq_to_bam {
     read_group_name: "Read group name (if not provided, defaults to sample_name)"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1293,6 +1320,7 @@ task fastq_to_bam {
     String? read_group_name
     Int memory_gb = 8
     Int cpu_cores = 4
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   String rg_name = select_first([read_group_name, sample_name])
@@ -1319,7 +1347,7 @@ task fastq_to_bam {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -1353,6 +1381,7 @@ task validate_sam_file {
     reference_fasta: "Reference genome FASTA (required for CRAM files)"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1363,6 +1392,7 @@ task validate_sam_file {
     File? reference_fasta
     Int memory_gb = 4
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -1381,7 +1411,7 @@ task validate_sam_file {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -1424,6 +1454,7 @@ task analyze_saturation_mutagenesis {
     base_file_name: "Base name for output files"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1436,6 +1467,7 @@ task analyze_saturation_mutagenesis {
     String base_file_name
     Int memory_gb = 16
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -1471,7 +1503,7 @@ task analyze_saturation_mutagenesis {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -1510,6 +1542,7 @@ task create_somatic_pon {
     germline_resource: "Optional gnomAD VCF for additional germline filtering"
     memory_gb: "Memory allocation in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1524,6 +1557,7 @@ task create_somatic_pon {
     File? germline_resource
     Int memory_gb = 8
     Int cpu_cores = 2
+    String docker_image = "getwilds/gatk:4.6.1.0"
   }
 
   command <<<
@@ -1566,7 +1600,7 @@ task create_somatic_pon {
   }
 
   runtime {
-    docker: "getwilds/gatk:4.6.1.0"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-gdc/README.md
+++ b/modules/ww-gdc/README.md
@@ -31,6 +31,7 @@ Download files from GDC using a manifest file. This is the recommended approach 
 - `wait_time` (Int, default=5): Seconds to wait between retries
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gdc-client:2.3.0`)
 
 **Outputs:**
 - `downloaded_files` (Array[File]): Array of downloaded data files from GDC
@@ -48,6 +49,7 @@ Download files from GDC using file UUIDs. Useful when you have specific file IDs
 - `wait_time` (Int, default=5): Seconds to wait between retries
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gdc-client:2.3.0`)
 
 **Outputs:**
 - `downloaded_files` (Array[File]): Array of downloaded data files from GDC

--- a/modules/ww-gdc/ww-gdc.wdl
+++ b/modules/ww-gdc/ww-gdc.wdl
@@ -34,6 +34,7 @@ task download_by_manifest {
     wait_time: "Seconds to wait between retries (default: 5)"
     cpu_cores: "Number of CPU cores allocated for the task (default: 4)"
     memory_gb: "Memory allocated for the task in GB (default: 8)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -44,6 +45,7 @@ task download_by_manifest {
     Int wait_time = 5
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/gdc-client:2.3.0"
   }
 
   command <<<
@@ -124,7 +126,7 @@ task download_by_manifest {
   }
 
   runtime {
-    docker: "getwilds/gdc-client:2.3.0"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -159,6 +161,7 @@ task download_by_uuids {
     wait_time: "Seconds to wait between retries (default: 5)"
     cpu_cores: "Number of CPU cores allocated for the task (default: 4)"
     memory_gb: "Memory allocated for the task in GB (default: 8)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -169,6 +172,7 @@ task download_by_uuids {
     Int wait_time = 5
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/gdc-client:2.3.0"
   }
 
   command <<<
@@ -252,7 +256,7 @@ EOL
   }
 
   runtime {
-    docker: "getwilds/gdc-client:2.3.0"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-gffread/README.md
+++ b/modules/ww-gffread/README.md
@@ -29,6 +29,7 @@ Normalizes a GTF file so downstream tools see exon features for every transcript
 - `output_prefix` (String, default=`"normalized"`): Prefix used for output filenames
 - `cpu_cores` (Int, default=1): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=2): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gffread:0.12.7`)
 
 **Outputs:**
 - `normalized_gtf` (File): GTF file with exon features synthesized from CDS records where needed
@@ -44,6 +45,7 @@ Converts a GFF3 annotation file to GTF format. Useful when an upstream source (e
 - `output_prefix` (String, default=`"converted"`): Prefix used for output filenames
 - `cpu_cores` (Int, default=1): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=2): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/gffread:0.12.7`)
 
 **Outputs:**
 - `gtf_file` (File): GTF-format annotation converted from the input GFF3

--- a/modules/ww-gffread/ww-gffread.wdl
+++ b/modules/ww-gffread/ww-gffread.wdl
@@ -28,6 +28,7 @@ task normalize_gtf {
     output_prefix: "Prefix used for output filenames"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -35,6 +36,7 @@ task normalize_gtf {
     String output_prefix = "normalized"
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/gffread:0.12.7"
   }
 
   command <<<
@@ -53,7 +55,7 @@ task normalize_gtf {
   }
 
   runtime {
-    docker: "getwilds/gffread:0.12.7"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -75,6 +77,7 @@ task gff3_to_gtf {
     output_prefix: "Prefix used for output filenames"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -82,6 +85,7 @@ task gff3_to_gtf {
     String output_prefix = "converted"
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/gffread:0.12.7"
   }
 
   command <<<
@@ -96,7 +100,7 @@ task gff3_to_gtf {
   }
 
   runtime {
-    docker: "getwilds/gffread:0.12.7"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-glimpse2/README.md
+++ b/modules/ww-glimpse2/README.md
@@ -40,6 +40,7 @@ Split a genomic region into chunks for parallel imputation.
 - `uniform_number_variants` (Boolean, default=false): Use uniform variants per chunk
 - `cpu_cores` (Int, default=4): Number of CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/glimpse2:2.0.1-infofix`)
 
 **Outputs:**
 - `chunks_file` (File): Text file containing chunk definitions
@@ -58,6 +59,7 @@ Convert reference panel VCF to binary format for a specific chunk.
 - `keep_monomorphic_ref_sites` (Boolean, default=true): Keep monomorphic reference sites in output
 - `cpu_cores` (Int, default=4): Number of CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/glimpse2:2.0.1-infofix`)
 
 **Outputs:**
 - `reference_chunk` (File): Binary reference chunk file
@@ -77,6 +79,7 @@ Perform imputation and phasing from VCF input.
 - `effective_population_size` (Int, default=15000): Effective population size
 - `cpu_cores` (Int, default=4): Number of CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/glimpse2:2.0.1-infofix`)
 
 **Outputs:**
 - `imputed_chunk` (File): Imputed BCF file
@@ -100,6 +103,7 @@ Perform imputation directly from CRAM/BAM files. Accepts one or more BAM/CRAM fi
 - `effective_population_size` (Int, default=15000): Effective population size
 - `cpu_cores` (Int, default=4): Number of CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/glimpse2:2.0.1-infofix`)
 
 **Outputs:**
 - `imputed_chunk` (File): Imputed BCF file
@@ -116,6 +120,7 @@ Ligate multiple imputed chunks into a single file.
 - `output_format` (String, default="bcf"): Output format (`bcf` or `vcf.gz`)
 - `cpu_cores` (Int, default=4): Number of CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/glimpse2:2.0.1-infofix`)
 
 **Outputs:**
 - `ligated_vcf` (File): Ligated VCF/BCF file
@@ -137,6 +142,7 @@ Compute concordance metrics between imputed and truth genotypes.
 - `min_val_gq` (Int, default=0): Minimum genotype quality
 - `cpu_cores` (Int, default=4): Number of CPU cores
 - `memory_gb` (Int, default=8): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/glimpse2:2.0.1-infofix`)
 
 **Outputs:**
 - `concordance_output` (Array[File]): Concordance metrics files
@@ -147,6 +153,7 @@ Utility task to parse chunks file for parallel processing.
 
 **Inputs:**
 - `chunks_file` (File): Chunks file from glimpse2_chunk
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/glimpse2:2.0.1-infofix`)
 
 **Outputs:**
 - `input_regions` (Array[String]): Input regions

--- a/modules/ww-glimpse2/ww-glimpse2.wdl
+++ b/modules/ww-glimpse2/ww-glimpse2.wdl
@@ -36,6 +36,7 @@ task glimpse2_chunk {
     uniform_number_variants: "Use uniform number of variants per chunk instead of centiMorgans-based"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -49,6 +50,7 @@ task glimpse2_chunk {
     Boolean uniform_number_variants = false
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/glimpse2:2.0.1-infofix"
   }
 
   command <<<
@@ -75,7 +77,7 @@ task glimpse2_chunk {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1-infofix"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -111,6 +113,7 @@ task glimpse2_split_reference {
     keep_monomorphic_ref_sites: "Keep monomorphic reference sites in output"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -123,6 +126,7 @@ task glimpse2_split_reference {
     Boolean keep_monomorphic_ref_sites = true
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/glimpse2:2.0.1-infofix"
   }
 
   command <<<
@@ -149,7 +153,7 @@ task glimpse2_split_reference {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1-infofix"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -187,6 +191,7 @@ task glimpse2_phase {
     effective_population_size: "Effective population size (default: 15000)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -200,6 +205,7 @@ task glimpse2_phase {
     Int effective_population_size = 15000
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/glimpse2:2.0.1-infofix"
   }
 
   command <<<
@@ -229,7 +235,7 @@ task glimpse2_phase {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1-infofix"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -270,6 +276,7 @@ task glimpse2_phase_cram {
     effective_population_size: "Effective population size (default: 15000)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -286,6 +293,7 @@ task glimpse2_phase_cram {
     Int effective_population_size = 15000
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/glimpse2:2.0.1-infofix"
   }
 
   command <<<
@@ -327,7 +335,7 @@ task glimpse2_phase_cram {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1-infofix"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -361,6 +369,7 @@ task glimpse2_ligate {
     output_format: "Output format: bcf or vcf.gz (default: bcf)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -370,6 +379,7 @@ task glimpse2_ligate {
     String output_format = "bcf"
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/glimpse2:2.0.1-infofix"
   }
 
   command <<<
@@ -411,7 +421,7 @@ task glimpse2_ligate {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1-infofix"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -449,6 +459,7 @@ task glimpse2_concordance {
     min_val_gq: "Minimum genotype quality in validation data (default: 0)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -463,6 +474,7 @@ task glimpse2_concordance {
     Int min_val_gq = 0
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/glimpse2:2.0.1-infofix"
   }
 
   command <<<
@@ -490,7 +502,7 @@ task glimpse2_concordance {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1-infofix"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -520,10 +532,12 @@ task parse_chunks_file {
 
   parameter_meta {
     chunks_file: "Chunks file from glimpse2_chunk task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     File chunks_file
+    String docker_image = "getwilds/glimpse2:2.0.1-infofix"
   }
 
   command <<<
@@ -544,7 +558,7 @@ task parse_chunks_file {
   }
 
   runtime {
-    docker: "getwilds/glimpse2:2.0.1-infofix"
+    docker: docker_image
     cpu: 1
     memory: "2 GB"
   }

--- a/modules/ww-ichorcna/README.md
+++ b/modules/ww-ichorcna/README.md
@@ -31,6 +31,7 @@ Generates tumor WIG file from aligned BAM files using HMMcopy's readCounter.
 - `window_size` (Int): Window size in base pairs for WIG format (default: 500000)
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
 - `cpus` (Int): Number of CPU cores to use (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/hmmcopy:1.0.0`)
 
 **Outputs:**
 - `wig_file` (File): WIG file created from binned read count data
@@ -51,6 +52,7 @@ Estimates cfDNA tumor fraction using ichorCNA.
 - `chrs` (String): Chromosomes to analyze as R vector (default: "c(1:22, 'X', 'Y')")
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
 - `cpus` (Int): Number of CPU cores to use (default: 6)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/ichorcna:0.2.0`)
 
 **Outputs:**
 - `params` (File): Final converged parameters for optimal solution

--- a/modules/ww-ichorcna/ww-ichorcna.wdl
+++ b/modules/ww-ichorcna/ww-ichorcna.wdl
@@ -32,6 +32,7 @@ task readcounter_wig {
     chromosomes: "Chromosomes to include in WIG file"
     memory_gb: "Memory allocated for the task in GB"
     cpus: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -42,6 +43,7 @@ task readcounter_wig {
     Int window_size = 500000
     Int memory_gb = 8
     Int cpus = 2
+    String docker_image = "getwilds/hmmcopy:1.0.0"
   }
 
   command <<<
@@ -60,7 +62,7 @@ task readcounter_wig {
   }
 
   runtime {
-    docker: "getwilds/hmmcopy:1.0.0"
+    docker: docker_image
     cpu: cpus
     memory: "~{memory_gb} GB"
   }
@@ -104,6 +106,7 @@ task ichorcna_call {
     chrs: "Chromosomes to analyze (default: chr 1-22, X, and Y)"
     memory_gb: "Memory allocated for each task in the workflow in GB"
     cpus: "Number of CPU cores allocated for each task in the workflow"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -119,6 +122,7 @@ task ichorcna_call {
     String chrs = "c(1:22, 'X', 'Y')"
     Int memory_gb = 16
     Int cpus = 6
+    String docker_image = "getwilds/ichorcna:0.2.0"
   }
 
   command <<<
@@ -159,7 +163,7 @@ task ichorcna_call {
   }
 
   runtime {
-    docker: "getwilds/ichorcna:0.2.0"
+    docker: docker_image
     cpu: cpus
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-jcast/README.md
+++ b/modules/ww-jcast/README.md
@@ -39,6 +39,7 @@ Translates alternative splicing events from rMATS output into protein sequences 
 | `splice_types` | String | No | `""` | Comma-separated splice types to process (MXE,RI,SE,A3SS,A5SS) |
 | `cpu_cores` | Int | No | `2` | Number of CPU cores allocated |
 | `memory_gb` | Int | No | `8` | Memory allocated in GB |
+| `docker_image` | String | No | `getwilds/jcast:0.3.5` | Docker image to use for this task |
 
 **Outputs:**
 - `output_fasta` (File): Combined FASTA file containing all translated protein sequences from alternative splicing events

--- a/modules/ww-jcast/ww-jcast.wdl
+++ b/modules/ww-jcast/ww-jcast.wdl
@@ -40,6 +40,7 @@ task jcast {
     splice_types: 'Comma-separated list of splice types to process (MXE,RI,SE,A3SS,A5SS). If empty, process all types (default: "")'
     cpu_cores: "Number of CPU cores allocated for the task (default: 2)"
     memory_gb: "Memory allocated for the task in GB (default: 8)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -55,6 +56,7 @@ task jcast {
     String splice_types = ""
     Int cpu_cores = 2
     Int memory_gb = 8
+    String docker_image = "getwilds/jcast:0.3.5"
   }
 
   String gmm_flag = if use_gmm then "-m" else ""
@@ -117,7 +119,7 @@ task jcast {
   }
 
   runtime {
-    docker: "getwilds/jcast:0.3.5"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-manta/README.md
+++ b/modules/ww-manta/README.md
@@ -32,6 +32,7 @@ Calls structural variants using Manta for a single sample.
 - `is_rna` (Boolean): Flag for RNA-seq mode (default: false)
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/manta:1.6.0`)
 
 **Outputs:**
 - `vcf` (File): Compressed VCF file with structural variant calls

--- a/modules/ww-manta/ww-manta.wdl
+++ b/modules/ww-manta/ww-manta.wdl
@@ -36,6 +36,7 @@ task manta_call {
     is_rna: "Boolean flag for RNA-seq mode (enables RNA-specific settings)"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -49,6 +50,7 @@ task manta_call {
     Boolean is_rna = false
     Int cpu_cores = 8
     Int memory_gb = 16
+    String docker_image = "getwilds/manta:1.6.0"
   }
 
   command <<<
@@ -80,7 +82,7 @@ task manta_call {
   }
 
   runtime {
-    docker: "getwilds/manta:1.6.0"
+    docker: docker_image
     memory: "~{memory_gb}GB"
     cpu: cpu_cores
   }

--- a/modules/ww-megahit/README.md
+++ b/modules/ww-megahit/README.md
@@ -27,6 +27,7 @@ Performs de novo metagenomic assembly using MEGAHIT.
 - `sample_name` (String): Sample name for output file naming (default: basename of input FASTQ)
 - `cpu_cores` (Int): Number of CPU cores allocated for the task (default: 2)
 - `memory_gb` (Int): Memory allocated for the task in GB (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/megahit:1.2.9`)
 
 **Outputs:**
 - `contigs` (File): Assembled contigs in compressed FASTA format (`.contigs.fasta.gz`)

--- a/modules/ww-megahit/ww-megahit.wdl
+++ b/modules/ww-megahit/ww-megahit.wdl
@@ -29,6 +29,7 @@ task megahit {
     sample_name: "Sample name for output file naming"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -36,6 +37,7 @@ task megahit {
     String sample_name = basename(input_fastq, ".fastq.gz")
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/megahit:1.2.9"
   }
 
   command <<<
@@ -58,7 +60,7 @@ task megahit {
   }
 
   runtime {
-    docker: "getwilds/megahit:1.2.9"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-multiqc/README.md
+++ b/modules/ww-multiqc/README.md
@@ -30,6 +30,7 @@ Runs MultiQC to aggregate QC reports from multiple bioinformatics tools into a s
 - `extra_args` (String, default=""): Additional command-line arguments to pass to MultiQC
 - `cpu_cores` (Int, default=1): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=4): Memory allocated for the task in GB
+- `docker_image` (String, default=`getwilds/multiqc:1.33`): Docker image to use for this task
 
 **Outputs:**
 - `html_report` (File): MultiQC interactive HTML summary report

--- a/modules/ww-multiqc/ww-multiqc.wdl
+++ b/modules/ww-multiqc/ww-multiqc.wdl
@@ -35,6 +35,7 @@ task run_multiqc {
     extra_args: "Additional command-line arguments to pass to MultiQC"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -44,6 +45,7 @@ task run_multiqc {
     String extra_args = ""
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/multiqc:1.33"
   }
 
   command <<<
@@ -74,7 +76,7 @@ task run_multiqc {
   }
 
   runtime {
-    docker: "getwilds/multiqc:1.33"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-rmats-turbo/README.md
+++ b/modules/ww-rmats-turbo/README.md
@@ -54,6 +54,7 @@ Main task that performs complete differential alternative splicing analysis betw
 | `max_exon_length` | Int | No | `500` | Maximum exon length for novel splice site detection |
 | `cpu_cores` | Int | No | `4` | Number of CPU cores allocated |
 | `memory_gb` | Int | No | `16` | Memory allocated in GB |
+| `docker_image` | String | No | `getwilds/rmats-turbo:4.3.0` | Docker image to use for this task |
 
 **Outputs:**
 - `output_directory` (File): Tarball containing all rMATS output files including splice event tables and summary statistics
@@ -78,6 +79,7 @@ Preprocesses BAM files and generates .rmats intermediate files (runs rMATS `--ta
 | `allow_clipping` | Boolean | No | `false` | Allow alignments with soft or hard clipping |
 | `cpu_cores` | Int | No | `4` | Number of CPU cores allocated |
 | `memory_gb` | Int | No | `16` | Memory allocated in GB |
+| `docker_image` | String | No | `getwilds/rmats-turbo:4.3.0` | Docker image to use for this task |
 
 **Outputs:**
 - `prep_output` (File): Tarball containing .rmats intermediate files
@@ -101,6 +103,7 @@ Loads .rmats files and performs alternative splicing event detection and statist
 | `individual_counts` | Boolean | No | `false` | Output individual count files for each sample |
 | `cpu_cores` | Int | No | `4` | Number of CPU cores allocated |
 | `memory_gb` | Int | No | `16` | Memory allocated in GB |
+| `docker_image` | String | No | `getwilds/rmats-turbo:4.3.0` | Docker image to use for this task |
 
 **Outputs:**
 - `output_directory` (File): Tarball containing all rMATS output files
@@ -122,6 +125,7 @@ Runs statistical analysis on existing rMATS output files. (runs rMATS `--task st
 | `cstat` | Float | No | `0.0001` | Cutoff splicing difference for null hypothesis test |
 | `cpu_cores` | Int | No | `4` | Number of CPU cores allocated |
 | `memory_gb` | Int | No | `16` | Memory allocated in GB |
+| `docker_image` | String | No | `getwilds/rmats-turbo:4.3.0` | Docker image to use for this task |
 
 **Outputs:**
 - `output_directory` (File): Tarball containing rMATS output files with updated statistical results
@@ -247,7 +251,7 @@ The test workflow automatically:
 
 ## Docker Container
 
-This module uses the `getwilds/rmats-turbo:latest` container image from the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library), which includes:
+This module uses the `getwilds/rmats-turbo:4.3.0` container image from the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library), which includes:
 - rMATS-turbo
 - Python 3.9
 - All required dependencies

--- a/modules/ww-rmats-turbo/ww-rmats-turbo.wdl
+++ b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl
@@ -70,7 +70,7 @@ task rmats {
     Int max_exon_length = 500
     Int cpu_cores = 4
     Int memory_gb = 16
-    String docker_image = "getwilds/rmats-turbo:latest"
+    String docker_image = "getwilds/rmats-turbo:4.3.0"
   }
 
   String variable_read_length_flag = if variable_read_length then "--variable-read-length" else ""
@@ -194,7 +194,7 @@ task rmats_prep {
     Boolean allow_clipping = false
     Int cpu_cores = 4
     Int memory_gb = 16
-    String docker_image = "getwilds/rmats-turbo:latest"
+    String docker_image = "getwilds/rmats-turbo:4.3.0"
   }
 
   String variable_read_length_flag = if variable_read_length then "--variable-read-length" else ""
@@ -303,7 +303,7 @@ task rmats_post {
     Boolean individual_counts = false
     Int cpu_cores = 4
     Int memory_gb = 16
-    String docker_image = "getwilds/rmats-turbo:latest"
+    String docker_image = "getwilds/rmats-turbo:4.3.0"
   }
 
   String stat_off_flag = if stat_off then "--statoff" else ""
@@ -408,7 +408,7 @@ task rmats_stat {
     Float cstat = 0.0001
     Int cpu_cores = 4
     Int memory_gb = 16
-    String docker_image = "getwilds/rmats-turbo:latest"
+    String docker_image = "getwilds/rmats-turbo:4.3.0"
   }
 
   String paired_stats_flag = if paired_stats then "--paired-stats" else ""

--- a/modules/ww-rmats-turbo/ww-rmats-turbo.wdl
+++ b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl
@@ -47,6 +47,7 @@ task rmats {
     max_exon_length: "Maximum exon length for novel splice site detection (default: 500)"
     cpu_cores: "Number of CPU cores allocated for the task (default: 4)"
     memory_gb: "Memory allocated for the task in GB (default: 16)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -69,6 +70,7 @@ task rmats {
     Int max_exon_length = 500
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/rmats-turbo:latest"
   }
 
   String variable_read_length_flag = if variable_read_length then "--variable-read-length" else ""
@@ -137,7 +139,7 @@ task rmats {
   }
 
   runtime {
-    docker: "getwilds/rmats-turbo:latest"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -176,6 +178,7 @@ task rmats_prep {
     allow_clipping: "Allow alignments with soft or hard clipping (default: false)"
     cpu_cores: "Number of CPU cores allocated for the task (default: 4)"
     memory_gb: "Memory allocated for the task in GB (default: 16)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -191,6 +194,7 @@ task rmats_prep {
     Boolean allow_clipping = false
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/rmats-turbo:latest"
   }
 
   String variable_read_length_flag = if variable_read_length then "--variable-read-length" else ""
@@ -246,7 +250,7 @@ task rmats_prep {
   }
 
   runtime {
-    docker: "getwilds/rmats-turbo:latest"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -284,6 +288,7 @@ task rmats_post {
     individual_counts: "Output individual count files for each sample (default: false)"
     cpu_cores: "Number of CPU cores allocated for the task (default: 4)"
     memory_gb: "Memory allocated for the task in GB (default: 16)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -298,6 +303,7 @@ task rmats_post {
     Boolean individual_counts = false
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/rmats-turbo:latest"
   }
 
   String stat_off_flag = if stat_off then "--statoff" else ""
@@ -353,7 +359,7 @@ task rmats_post {
   }
 
   runtime {
-    docker: "getwilds/rmats-turbo:latest"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -389,6 +395,7 @@ task rmats_stat {
     cstat: "Cutoff splicing difference for null hypothesis test (default: 0.0001)"
     cpu_cores: "Number of CPU cores allocated for the task (default: 4)"
     memory_gb: "Memory allocated for the task in GB (default: 16)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -401,6 +408,7 @@ task rmats_stat {
     Float cstat = 0.0001
     Int cpu_cores = 4
     Int memory_gb = 16
+    String docker_image = "getwilds/rmats-turbo:latest"
   }
 
   String paired_stats_flag = if paired_stats then "--paired-stats" else ""
@@ -455,7 +463,7 @@ task rmats_stat {
   }
 
   runtime {
-    docker: "getwilds/rmats-turbo:latest"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-rseqc/README.md
+++ b/modules/ww-rseqc/README.md
@@ -31,6 +31,7 @@ Run comprehensive RSeQC quality control metrics on aligned RNA-seq data.
 - `skip_gene_body_cov` (Boolean, default=true): Whether to skip the `geneBody_coverage.py` analysis (see [Gene Body Coverage](#2-gene-body-coverage) for details)
 - `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=4): Memory allocated for the task in GB
+- `docker_image` (String, default=`getwilds/rseqc:5.0.4`): Docker image to use for this task
 
 **Outputs:**
 - `read_distribution` (File): Distribution of reads across genomic features

--- a/modules/ww-rseqc/ww-rseqc.wdl
+++ b/modules/ww-rseqc/ww-rseqc.wdl
@@ -38,6 +38,7 @@ task run_rseqc {
     skip_gene_body_cov: "Whether to skip the geneBody_coverage.py analysis (default: true)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -48,6 +49,7 @@ task run_rseqc {
     Boolean skip_gene_body_cov = true
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/rseqc:5.0.4"
   }
 
   command <<<
@@ -126,7 +128,7 @@ EOF
   }
 
   runtime {
-    docker: "getwilds/rseqc:5.0.4"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-salmon/README.md
+++ b/modules/ww-salmon/README.md
@@ -25,6 +25,7 @@ Builds Salmon index from a reference transcriptome FASTA file.
 - `transcriptome_fasta` (File): Reference transcriptome in FASTA format
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/salmon:1.10.3`)
 
 **Important**: Salmon requires a **transcriptome FASTA** file (mature mRNA sequences), not a genome FASTA. The transcriptome contains only the exonic sequences for each transcript, which Salmon uses for quasi-mapping. See [Salmon documentation](https://salmon.readthedocs.io/) for details on obtaining or building transcriptome references.
 
@@ -41,6 +42,7 @@ Quantifies transcript expression from RNA-seq reads using Salmon. Supports both 
 - `fastq_r2` (File?, optional): FASTQ file for read 2 (omit for single-end data)
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/salmon:1.10.3`)
 
 **Outputs:**
 - `salmon_quant_dir` (File): Compressed tarball containing Salmon quantification results including abundance estimates
@@ -54,6 +56,7 @@ Merges Salmon quantification results from multiple samples into TPM and count ma
 - `sample_names` (Array[String]): Array of sample names corresponding to the quantification directories
 - `cpu_cores` (Int): Number of CPU cores (default: 4)
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/salmon:1.10.3`)
 
 **Outputs:**
 - `tpm_matrix` (File): Tab-separated matrix of TPM (Transcripts Per Million) values for all samples

--- a/modules/ww-salmon/ww-salmon.wdl
+++ b/modules/ww-salmon/ww-salmon.wdl
@@ -29,12 +29,14 @@ task build_index {
     transcriptome_fasta: "Reference transcriptome in FASTA format"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     File transcriptome_fasta
     Int cpu_cores = 8
     Int memory_gb = 16
+    String docker_image = "getwilds/salmon:1.10.3"
   }
 
   command <<<
@@ -65,7 +67,7 @@ task build_index {
   }
 
   runtime {
-    docker: "getwilds/salmon:1.10.3"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -99,6 +101,7 @@ task quantify {
     fastq_r2: "Optional FASTQ file for read 2 (omit for single-end data)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -108,6 +111,7 @@ task quantify {
     File? fastq_r2
     Int cpu_cores = 8
     Int memory_gb = 16
+    String docker_image = "getwilds/salmon:1.10.3"
   }
 
   command <<<
@@ -146,7 +150,7 @@ task quantify {
   }
 
   runtime {
-    docker: "getwilds/salmon:1.10.3"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -179,6 +183,7 @@ task merge_results {
     sample_names: "Array of sample names corresponding to the quantification directories"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -186,6 +191,7 @@ task merge_results {
     Array[String] sample_names
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/salmon:1.10.3"
   }
 
   command <<<
@@ -228,7 +234,7 @@ task merge_results {
   }
 
   runtime {
-    docker: "getwilds/salmon:1.10.3"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-samtools/README.md
+++ b/modules/ww-samtools/README.md
@@ -25,8 +25,9 @@ Merges one or more CRAM/BAM/SAM files for a sample, sorts by read name, and conv
 **Inputs:**
 - `cram_files` (Array[String]): List of CRAM/BAM/SAM files to merge and convert
 - `name` (String): Sample name used for output filenames
-- `cpu_cores` (Int): Number of CPU cores to use (default: 23)
-- `memory_gb` (Int): Memory allocation in GB (default: 36)
+- `cpu_cores` (Int): Number of CPU cores to use (default: 2)
+- `memory_gb` (Int): Memory allocation in GB (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.19`)
 
 **Outputs:**
 - `fastq_file` (File): FASTQ output file (`.fastq.gz`)
@@ -41,6 +42,7 @@ Merges multiple BAM files into a single CRAM file using samtools merge.
 - `base_file_name` (String): Base name for output CRAM file
 - `cpu_cores` (Int): Number of CPU cores to use (threads = cpu_cores - 1) (default: 6)
 - `memory_gb` (Int): Memory allocation in GB (default: 12)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.19`)
 
 **Outputs:**
 - `cram` (File): Merged CRAM file containing all reads from input BAMs
@@ -59,6 +61,7 @@ Generates a pileup file from a BAM file using samtools mpileup. The pileup forma
 - `min_baseq` (Int?): Minimum base quality for bases to be included (default: 13)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 2)
 - `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.19`)
 
 **Outputs:**
 - `pileup` (File): Pileup file
@@ -74,6 +77,7 @@ Filters a coordinate-sorted, indexed BAM down to reads on contigs whose names st
 - `sample_name` (String): Sample name used for output file naming
 - `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=4): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.19`)
 
 **Outputs:**
 - `filtered_bam` (File): Coordinate-sorted BAM containing only reads on contigs matching the prefix

--- a/modules/ww-samtools/ww-samtools.wdl
+++ b/modules/ww-samtools/ww-samtools.wdl
@@ -31,6 +31,7 @@ task crams_to_fastq {
     name: "Name of the sample (used for file naming)"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -39,6 +40,7 @@ task crams_to_fastq {
     String name
     Int cpu_cores = 2
     Int memory_gb = 16
+    String docker_image = "getwilds/samtools:1.19"
   }
 
   command <<<
@@ -70,7 +72,7 @@ task crams_to_fastq {
   runtime {
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
-    docker: "getwilds/samtools:1.19"
+    docker: docker_image
   }
 }
 
@@ -100,6 +102,7 @@ task merge_bams_to_cram {
     base_file_name: "Base name for output CRAM file"
     cpu_cores: "Number of CPU cores to use (threads = cpu_cores - 1)"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -107,6 +110,7 @@ task merge_bams_to_cram {
     String base_file_name
     Int cpu_cores = 6
     Int memory_gb = 12
+    String docker_image = "getwilds/samtools:1.19"
   }
 
   command <<<
@@ -125,7 +129,7 @@ task merge_bams_to_cram {
   runtime {
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
-    docker: "getwilds/samtools:1.19"
+    docker: docker_image
   }
 }
 
@@ -148,6 +152,7 @@ task filter_bam_by_chrom_prefix {
     sample_name: "Sample name used for output file naming"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -157,6 +162,7 @@ task filter_bam_by_chrom_prefix {
     String sample_name
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/samtools:1.19"
   }
 
   command <<<
@@ -196,7 +202,7 @@ task filter_bam_by_chrom_prefix {
   runtime {
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
-    docker: "getwilds/samtools:1.19"
+    docker: docker_image
   }
 }
 
@@ -229,6 +235,7 @@ task mpileup {
     min_baseq: "Minimum base quality for bases to be included"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -240,6 +247,7 @@ task mpileup {
     Int min_baseq = 13
     Int cpu_cores = 2
     Int memory_gb = 8
+    String docker_image = "getwilds/samtools:1.19"
   }
 
   command <<<
@@ -264,6 +272,6 @@ task mpileup {
   runtime {
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
-    docker: "getwilds/samtools:1.19"
+    docker: docker_image
   }
 }

--- a/modules/ww-seurat/README.md
+++ b/modules/ww-seurat/README.md
@@ -47,8 +47,9 @@ Performs QC, normalization, clustering, and marker gene identification on a Cell
 | `min_features` | Int | 200 | Minimum number of features (genes) a cell must have to pass QC |
 | `max_percent_mt` | Float | 10.0 | Maximum mitochondrial gene percentage allowed per cell |
 | `resolution` | Float | 0.5 | Louvain clustering resolution (higher values produce more clusters) |
-| `memory_gb` | Int | 16 | Memory allocated for the task in GB |
-| `cpu_cores` | Int | 4 | Number of CPU cores allocated for the task |
+| `memory_gb` | Int | 4 | Memory allocated for the task in GB |
+| `cpu_cores` | Int | 2 | Number of CPU cores allocated for the task |
+| `docker_image` | String | `getwilds/seurat:5.2.1` | Docker image to use for this task |
 
 **Outputs:**
 

--- a/modules/ww-seurat/ww-seurat.wdl
+++ b/modules/ww-seurat/ww-seurat.wdl
@@ -36,6 +36,7 @@ task run_seurat {
     resolution: "Louvain clustering resolution (higher = more clusters)"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -47,6 +48,7 @@ task run_seurat {
     Float resolution = 0.5
     Int memory_gb = 4
     Int cpu_cores = 2
+    String docker_image = "getwilds/seurat:5.2.1"
   }
 
   command <<<
@@ -75,7 +77,7 @@ task run_seurat {
   }
 
   runtime {
-    docker: "getwilds/seurat:5.2.1"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-shapemapper/README.md
+++ b/modules/ww-shapemapper/README.md
@@ -37,6 +37,7 @@ Run ShapeMapper to analyze RNA structure probing data and generate reactivity pr
 - `is_amplicon` (Boolean, default=false): Set to true if data is from amplicon sequencing
 - `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String, default=`getwilds/shapemapper:2.3`): Docker image to use for this task
 
 **Outputs:**
 - `output_tar` (File): Compressed tarball of a folder containing ShapeMapper outputs

--- a/modules/ww-shapemapper/ww-shapemapper.wdl
+++ b/modules/ww-shapemapper/ww-shapemapper.wdl
@@ -38,6 +38,7 @@ task run_shapemapper {
     is_amplicon: "Set to true if data is from amplicon sequencing (default: false)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -52,6 +53,7 @@ task run_shapemapper {
     Boolean is_amplicon = false
     Int cpu_cores = 2
     Int memory_gb = 8
+    String docker_image = "getwilds/shapemapper:2.3"
   }
 
   command <<<
@@ -86,7 +88,7 @@ task run_shapemapper {
   }
 
   runtime {
-    docker: "getwilds/shapemapper:2.3"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-sjl/README.md
+++ b/modules/ww-sjl/README.md
@@ -15,7 +15,7 @@ This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds
 - **Tasks**: `sjl_tiles`
 - **Test workflow**: `testrun.wdl` (demonstration workflow that executes all tasks)
 - **Script**: `sjl_tiles.R` (pulled from GitHub at runtime)
-- **Container**: `rocker/tidyverse:4`
+- **Container**: `getwilds/r-utils:0.1.0`
 
 ## Tasks
 
@@ -30,6 +30,7 @@ Calculates sunrise/sunset times and sun time differences for each point within a
 - `missing_prefix` (String, default: `"missing_"`): Filename prefix for missing results output. Set to `""` to keep the original input filename.
 - `cpu_cores` (Int, default: 1): Number of CPU cores to use
 - `memory_gb` (Int, default: 8): Memory allocation in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/r-utils:0.1.0`)
 
 **Outputs:**
 - `matched_points` (File): RDS file containing points with sunrise/sunset difference values (in seconds) (named `<matched_prefix><input_filename>.rds`)

--- a/modules/ww-sjl/ww-sjl.wdl
+++ b/modules/ww-sjl/ww-sjl.wdl
@@ -36,6 +36,7 @@ task sjl_tiles {
     missing_prefix: "Filename prefix for missing results output (default: 'missing_')"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -46,6 +47,7 @@ task sjl_tiles {
     String missing_prefix = "missing_"
     Int cpu_cores = 1
     Int memory_gb = 8
+    String docker_image = "getwilds/r-utils:0.1.0"
   }
 
   String tile_basename = basename(tile_path, ".rds")
@@ -75,6 +77,6 @@ task sjl_tiles {
   runtime {
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    docker: "getwilds/r-utils:0.1.0"
+    docker: docker_image
   }
 }

--- a/modules/ww-smoove/README.md
+++ b/modules/ww-smoove/README.md
@@ -32,6 +32,7 @@ Calls structural variants using Smoove for a single sample.
 - `exclude_chroms` (String?): Optional comma-separated list of chromosomes to exclude
 - `cpu_cores` (Int): Number of CPU cores to use (default: 8)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/smoove:0.2.8`)
 
 **Outputs:**
 - `vcf` (File): Compressed VCF file with structural variant calls

--- a/modules/ww-smoove/ww-smoove.wdl
+++ b/modules/ww-smoove/ww-smoove.wdl
@@ -36,6 +36,7 @@ task smoove_call {
     exclude_chroms: "Optional comma-separated list of chromosomes to exclude"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -49,6 +50,7 @@ task smoove_call {
     String? exclude_chroms
     Int cpu_cores = 8
     Int memory_gb = 16
+    String docker_image = "getwilds/smoove:0.2.8"
   }
 
   String vcf_filename = "${sample_name}.smoove.vcf.gz"
@@ -99,7 +101,7 @@ task smoove_call {
   }
 
   runtime {
-    docker: "getwilds/smoove:0.2.8"
+    docker: docker_image
     cpu: cpu_cores
     memory: "${memory_gb}GB"
   }

--- a/modules/ww-sourmash/README.md
+++ b/modules/ww-sourmash/README.md
@@ -32,6 +32,7 @@ Generate sourmash MinHash signatures from BAM or FASTA files.
 - `track_abundance` (Boolean): Whether to track k-mer abundance (default: true)
 - `cpu_cores` (Int): Number of CPU cores to use (only used for BAM input) (default: 4)
 - `memory_gb` (Int): Memory allocated for the task in GB (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/sourmash:4.8.2`)
 - `output_name` (String?): Optional custom output name (defaults to input file basename)
 
 **Important:** This WDL assumes DNA input (not RNA or protein)
@@ -49,6 +50,7 @@ Run sourmash gather to decompose metagenome samples and identify constituent gen
 - `threshold_bp` (Int): Minimum number of base pairs to report a match (default: 50000)
 - `memory_gb` (Int): Memory allocated for the task in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/sourmash:4.8.2`)
 - `output_name` (String?): Optional custom output name (defaults to query basename)
 
 **Important:** Signatures and databases must use identical parameters (same k-mer size, same scaled factor)
@@ -66,6 +68,7 @@ Generate similarity matrix from signature files using sourmash compare.
 - `k_value` (Int): Value of k used for sourmash sketch files
 - `memory_gb` (Int): Memory allocated for the task in GB (default: 8)
 - `cpu_cores` (Int): Number of CPU cores to use (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/sourmash:4.8.2`)
 
 **Outputs:**
 - `npy` (File): Numpy binary matrix file of angular similarity matrix

--- a/modules/ww-sourmash/ww-sourmash.wdl
+++ b/modules/ww-sourmash/ww-sourmash.wdl
@@ -32,6 +32,7 @@ task sketch {
     cpu_cores: "Number of CPU cores to use (only used for BAM input)"
     memory_gb: "Memory allocated for the task in GB"
     output_name: "Optional custom output name (defaults to input basename)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -42,6 +43,7 @@ task sketch {
     Boolean track_abundance = true
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/sourmash:4.8.2"
     String? output_name
   }
 
@@ -66,7 +68,7 @@ task sketch {
   }
 
   runtime {
-    docker: "getwilds/sourmash:4.8.2"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -99,6 +101,7 @@ task gather {
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores to use"
     output_name: "Optional custom output name (defaults to query basename)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -107,6 +110,7 @@ task gather {
     Int threshold_bp = 50000
     Int memory_gb = 8
     Int cpu_cores = 4
+    String docker_image = "getwilds/sourmash:4.8.2"
     String? output_name
   }
 
@@ -128,7 +132,7 @@ task gather {
   }
 
   runtime {
-    docker: "getwilds/sourmash:4.8.2"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -161,6 +165,7 @@ task compare {
     k_value: "Value of k used for sourmash sketch"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores to use"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -169,6 +174,7 @@ task compare {
     Int k_value
     Int memory_gb = 8
     Int cpu_cores = 4
+    String docker_image = "getwilds/sourmash:4.8.2"
   }
 
   command <<<
@@ -197,7 +203,7 @@ task compare {
   }
 
   runtime {
-    docker: "getwilds/sourmash:4.8.2"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-spades/README.md
+++ b/modules/ww-spades/README.md
@@ -27,8 +27,9 @@ Performs de novo metagenomic assembly using metaSPAdes in assembler-only mode (s
 - `r2_fastq` (File, optional): Read 2 FASTQ file
 - `interleaved_fastq` (File, optional): Interleaved FASTQ file of paired-end reads
 - `sample_name` (String): Sample name for output file naming
-- `cpu_cores` (Int): Number of CPU cores allocated for the task (default: 16)
-- `memory_gb` (Int): Memory allocated for the task in GB (default: 64)
+- `cpu_cores` (Int): Number of CPU cores allocated for the task (default: 4)
+- `memory_gb` (Int): Memory allocated for the task in GB (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/spades:4.2.0`)
 
 **Note**: You must provide either `interleaved_fastq` OR both `r1_fastq` and `r2_fastq`. Input must be from a single, paired-end library.
 

--- a/modules/ww-spades/ww-spades.wdl
+++ b/modules/ww-spades/ww-spades.wdl
@@ -33,6 +33,7 @@ task metaspades {
     sample_name: "Sample name for output file naming"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -42,6 +43,7 @@ task metaspades {
     String sample_name
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/spades:4.2.0"
   }
 
   command <<<
@@ -97,7 +99,7 @@ task metaspades {
   }
 
   runtime {
-    docker: "getwilds/spades:4.2.0"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-sra/README.md
+++ b/modules/ww-sra/README.md
@@ -34,6 +34,7 @@ Downloads FASTQ files from SRA accessions with automatic read structure detectio
 - `ncpu` (Int): Number of CPUs for parallel download (default: 8)
 - `max_reads` (Int, optional): Maximum number of reads to download for testing/downsampling
 - `ngc_file` (File, optional): NGC repository key file for downloading controlled-access dbGaP data
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/sra-tools:3.1.1`)
 
 **Outputs:**
 - `r1_end` (File): R1 FASTQ file

--- a/modules/ww-sra/ww-sra.wdl
+++ b/modules/ww-sra/ww-sra.wdl
@@ -32,6 +32,7 @@ task fastqdump {
     ncpu: "number of cpus to use during download"
     max_reads: "Optional maximum number of reads to download (for testing/downsampling). If not specified, downloads all reads."
     ngc_file: "Optional NGC repository key file for downloading controlled-access dbGaP data. Must be obtained through an approved dbGaP project."
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -39,6 +40,7 @@ task fastqdump {
     Int ncpu = 8
     Int? max_reads
     File? ngc_file
+    String docker_image = "getwilds/sra-tools:3.1.1"
   }
 
   command <<<
@@ -183,7 +185,7 @@ task fastqdump {
 
   runtime {
     memory: 2 * ncpu + " GB"
-    docker: "getwilds/sra-tools:3.1.1"
+    docker: docker_image
     cpu: ncpu
   }
 }

--- a/modules/ww-star/README.md
+++ b/modules/ww-star/README.md
@@ -28,6 +28,7 @@ Builds STAR genome index from reference FASTA and GTF files.
 - `genome_sa_index_nbases` (Int): SA pre-indexing string length (default: 14)
 - `memory_gb` (Int): Memory allocation in GB (default: 64)
 - `cpu_cores` (Int): Number of CPU cores (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/star:2.7.6a`)
 
 **Outputs:**
 - `star_index_tar` (File): Compressed tarball containing STAR genome index
@@ -45,6 +46,7 @@ Performs RNA-seq alignment using STAR's two-pass methodology.
 - `memory_gb` (Int): Memory allocation in GB (default: 62)
 - `cpu_cores` (Int): Total CPU cores (default: 8)
 - `star_threads` (Int): STAR-specific thread count (default: 6)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/star:2.7.6a`)
 
 **Outputs:**
 - `bam` (File): Sorted BAM alignment file

--- a/modules/ww-star/ww-star.wdl
+++ b/modules/ww-star/ww-star.wdl
@@ -31,6 +31,7 @@ task build_index {
     genome_sa_index_nbases: "Length (bases) of the SA pre-indexing string, typically between 10-15 (scales with genome size)"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -40,6 +41,7 @@ task build_index {
     Int genome_sa_index_nbases = 14
     Int memory_gb = 64
     Int cpu_cores = 8
+    String docker_image = "getwilds/star:2.7.6a"
   }
 
   command <<<
@@ -69,7 +71,7 @@ task build_index {
   }
 
   runtime {
-    docker: "getwilds/star:2.7.6a"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -111,6 +113,7 @@ task align_two_pass {
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Total number of CPU cores allocated for the task"
     star_threads: "Number of threads to use for STAR alignment (subset of cpu_cores)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -123,6 +126,7 @@ task align_two_pass {
     Int memory_gb = 62
     Int cpu_cores = 8
     Int star_threads = 6
+    String docker_image = "getwilds/star:2.7.6a"
   }
 
   command <<<
@@ -177,7 +181,7 @@ task align_two_pass {
   }
 
   runtime {
-    docker: "getwilds/star:2.7.6a"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }

--- a/modules/ww-starling/README.md
+++ b/modules/ww-starling/README.md
@@ -30,6 +30,7 @@ Generate a structural ensemble for an intrinsically disordered protein sequence.
 - `gpu_enabled` (Boolean, default=true): Enable GPU for STARLING inference (sets device to cuda and requests GPU in runtime)
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/starling:2.0.0a3`)
 
 **Outputs:**
 - `starling_file` (File): STARLING ensemble file containing predicted conformations
@@ -46,6 +47,7 @@ Generate structural ensembles for multiple protein sequences from a FASTA file.
 - `gpu_enabled` (Boolean, default=true): Enable GPU for STARLING inference (sets device to cuda and requests GPU in runtime)
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/starling:2.0.0a3`)
 
 **Outputs:**
 - `starling_files` (Array[File]): Array of STARLING ensemble files, one per sequence
@@ -61,6 +63,7 @@ Split a multi-sequence FASTA file into smaller batch files for parallel processi
 - `sequences_per_batch` (Int, default=10): Maximum number of sequences per output batch file
 - `cpu_cores` (Int, default=1): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=2): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `ubuntu:22.04`)
 
 **Outputs:**
 - `batch_files` (Array[File]): Array of FASTA files, each containing up to `sequences_per_batch` sequences
@@ -74,6 +77,7 @@ Query metadata and summary information from a STARLING ensemble file.
 - `sample_name` (String): Name identifier for the output file
 - `cpu_cores` (Int, default=1): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=4): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/starling:2.0.0a3`)
 
 **Outputs:**
 - `info_file` (File): Text file containing ensemble metadata and summary statistics

--- a/modules/ww-starling/ww-starling.wdl
+++ b/modules/ww-starling/ww-starling.wdl
@@ -36,6 +36,7 @@ task generate_ensemble {
     gpu_enabled: "Enable GPU for STARLING inference (sets device to cuda and requests GPU in runtime)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -45,6 +46,7 @@ task generate_ensemble {
     Boolean gpu_enabled = true
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/starling:2.0.0a3"
   }
 
   String device = if gpu_enabled then "cuda" else "cpu"
@@ -75,7 +77,7 @@ task generate_ensemble {
   }
 
   runtime {
-    docker: "getwilds/starling:2.0.0a3"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
     gpus: if gpu_enabled then "1" else "0"
@@ -110,6 +112,7 @@ task generate_ensemble_batch {
     gpu_enabled: "Enable GPU for STARLING inference (sets device to cuda and requests GPU in runtime)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -118,6 +121,7 @@ task generate_ensemble_batch {
     Boolean gpu_enabled = true
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/starling:2.0.0a3"
   }
 
   String device = if gpu_enabled then "cuda" else "cpu"
@@ -149,7 +153,7 @@ task generate_ensemble_batch {
   }
 
   runtime {
-    docker: "getwilds/starling:2.0.0a3"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
     gpus: if gpu_enabled then "1" else "0"
@@ -181,6 +185,7 @@ task split_fasta {
     sequences_per_batch: "Maximum number of sequences per output batch file"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -188,6 +193,7 @@ task split_fasta {
     Int sequences_per_batch = 10
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "ubuntu:22.04"
   }
 
   command <<<
@@ -211,7 +217,7 @@ task split_fasta {
   }
 
   runtime {
-    docker: "ubuntu:22.04"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -242,6 +248,7 @@ task ensemble_info {
     sample_name: "Name identifier for the output file"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -249,6 +256,7 @@ task ensemble_info {
     String sample_name
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/starling:2.0.0a3"
   }
 
   command <<<
@@ -262,7 +270,7 @@ task ensemble_info {
   }
 
   runtime {
-    docker: "getwilds/starling:2.0.0a3"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-strelka/README.md
+++ b/modules/ww-strelka/README.md
@@ -142,6 +142,9 @@ Performs germline variant calling on individual samples.
 - Reference genome FASTA and index
 - Optional target regions BED file
 - Exome sequencing flag
+- `cpus` (Int): Number of CPU cores (default: 4)
+- `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/strelka:2.9.10`)
 
 **Outputs:**
 - Compressed germline variants VCF
@@ -157,6 +160,9 @@ Performs somatic variant calling on tumor/normal pairs.
 - Reference genome FASTA and index
 - Optional target regions BED file
 - Exome sequencing flag
+- `cpus` (Int): Number of CPU cores (default: 4)
+- `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/strelka:2.9.10`)
 
 **Outputs:**
 - Compressed somatic SNVs VCF

--- a/modules/ww-strelka/ww-strelka.wdl
+++ b/modules/ww-strelka/ww-strelka.wdl
@@ -35,6 +35,7 @@ task strelka_germline {
     is_exome: "Whether this is exome sequencing data (enables exome-specific settings)"
     cpus: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -47,6 +48,7 @@ task strelka_germline {
     Boolean is_exome = false
     Int cpus = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/strelka:2.9.10"
   }
 
   String exome_flag = if is_exome then "--exome" else ""
@@ -98,7 +100,7 @@ task strelka_germline {
   }
 
   runtime {
-    docker: "getwilds/strelka:2.9.10"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpus
   }
@@ -140,6 +142,7 @@ task strelka_somatic {
     is_exome: "Whether this is exome sequencing data (enables exome-specific settings)"
     cpus: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -155,6 +158,7 @@ task strelka_somatic {
     Boolean is_exome = false
     Int cpus = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/strelka:2.9.10"
   }
 
   String exome_flag = if is_exome then "--exome" else ""
@@ -217,7 +221,7 @@ task strelka_somatic {
   }
 
   runtime {
-    docker: "getwilds/strelka:2.9.10"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpus
   }

--- a/modules/ww-template/README.md
+++ b/modules/ww-template/README.md
@@ -30,6 +30,7 @@ Simple template processing task that creates a hello world output file.
 - `input_file` (File): Input file (any file type works for this template)
 - `cpu_cores` (Int, default=1): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=4): Memory allocated for the task in GB
+- `docker_image` (String, default=`getwilds/bwa:0.7.17`): Docker image to use for this task
 
 **Outputs:**
 - `output_file` (File): Simple text file with hello world message and sample information

--- a/modules/ww-template/ww-template.wdl
+++ b/modules/ww-template/ww-template.wdl
@@ -36,6 +36,7 @@ task process_sample {
     input_file: "Input file (any file type works for this template)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   # Specify inputs required for the task
@@ -44,6 +45,7 @@ task process_sample {
     File input_file
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/bwa:0.7.17"
   }
 
   # Define the command section to execute the task's functionality
@@ -68,7 +70,7 @@ task process_sample {
   # Specify runtime requirements for the task
   runtime {
     # Replace with your tool's Docker image
-    docker: "getwilds/bwa:0.7.17"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-testdata/README.md
+++ b/modules/ww-testdata/README.md
@@ -21,7 +21,7 @@ Rather than maintaining large static test datasets, `ww-testdata` enables:
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
 
-- **Tasks**: `download_ref_data`, `merge_fastas_with_prefix`, `download_rrna_reference`, `download_fastq_data`, `download_test_transcriptome`, `interleave_fastq`, `download_cram_data`, `download_bam_data`, `inject_synthetic_umis`, `download_ichor_data`, `download_dbsnp_vcf`, `download_known_indels_vcf`, `download_gnomad_vcf`, `download_annotsv_vcf`, `generate_pasilla_counts`, `create_clean_amplicon_reference`, `create_gdc_manifest`, `download_shapemapper_data`, `download_test_cellranger_ref`, `download_10x_h5_data`, `create_diamond_data`, `create_test_protein_fasta`, `download_glimpse2_genetic_map`, `download_glimpse2_reference_panel`, `download_glimpse2_test_gl_vcf`, `download_glimpse2_truth_vcf`, `generate_sjl_data`, `download_jcast_test_data`, `download_pao1_ref`
+- **Tasks**: `download_ref_data`, `merge_fastas_with_prefix`, `download_rrna_reference`, `download_fastq_data`, `download_test_transcriptome`, `interleave_fastq`, `download_cram_data`, `download_bam_data`, `inject_synthetic_umis`, `download_ichor_data`, `download_tritonnp_data`, `download_dbsnp_vcf`, `download_known_indels_vcf`, `download_gnomad_vcf`, `download_annotsv_vcf`, `generate_pasilla_counts`, `create_clean_amplicon_reference`, `create_gdc_manifest`, `download_shapemapper_data`, `download_test_cellranger_ref`, `download_10x_h5_data`, `create_diamond_data`, `create_test_protein_fasta`, `create_test_idp_fasta`, `download_glimpse2_genetic_map`, `download_glimpse2_reference_panel`, `download_glimpse2_test_gl_vcf`, `download_glimpse2_truth_vcf`, `generate_sjl_data`, `download_jcast_test_data`, `download_pao1_ref`
 - **Test workflow**: `testrun.wdl` (demonstration workflow that executes all tasks)
 
 ## Usage
@@ -250,6 +250,7 @@ Downloads a UCSC reference chromosome FASTA + GTF + BED + samtools index/dict fo
 - `output_name` (String, optional): Name for output files (default: uses chromo name)
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
 
 **Note**: In the test workflow, `chromo` is hardcoded to "chr1", `version` to "hg38", and `region` to "1-10000000" for faster testing.
 
@@ -271,6 +272,7 @@ Builds a merged FASTA by concatenating two input FASTAs and prepending a configu
 - `output_name` (String): Output filename prefix (without the `.fa` extension)
 - `cpu_cores` (Int, default=1): CPU allocation
 - `memory_gb` (Int, default=2): Memory allocation in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
 
 **Outputs**:
 - `merged_fasta` (File): Merged FASTA — first_fasta contigs unchanged, second_fasta contigs renamed with the prefix
@@ -284,6 +286,7 @@ Downloads the human 45S rRNA precursor (NCBI accession `NR_046235.3`, ~13 kb) fr
 - `output_name` (String, default="human_45S_rRNA"): Output filename prefix (without the `.fa` extension)
 - `cpu_cores` (Int, default=1): CPU allocation
 - `memory_gb` (Int, default=2): Memory allocation in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
 
 **Outputs**:
 - `fasta` (File): Human 45S rRNA precursor FASTA
@@ -297,6 +300,7 @@ Downloads small example FASTQ files for testing. Renames to Illumina naming conv
 - `gzip_output` (Boolean): Compress output files with gzip (default: false)
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `r1_fastq` (File): R1 FASTQ file named `<prefix>_S1_L001_R1_001.fastq[.gz]`
@@ -320,6 +324,7 @@ Downloads protein-coding transcriptome from GENCODE for RNA-seq quantification t
 **Inputs**:
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `transcriptome_fasta` (File): Protein-coding transcriptome FASTA file (~150MB uncompressed, ~20,000 transcripts from GENCODE release 47)
@@ -328,7 +333,8 @@ Downloads protein-coding transcriptome from GENCODE for RNA-seq quantification t
 
 Creates a test GDC manifest file containing small open-access files for testing the ww-gdc module. This task generates a properly formatted tab-separated manifest file with file UUIDs, filenames, MD5 checksums, file sizes, and release status.
 
-**Inputs**: None
+**Inputs**:
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `manifest` (File): GDC manifest file containing 3 small open-access TCGA files (total ~210KB)
@@ -342,6 +348,7 @@ Downloads the official ShapeMapper example data (TPP riboswitch) from the Weeks-
 **Inputs**:
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
 
 **Outputs**:
 - `target_fa` (File): Target RNA FASTA file (TPP riboswitch sequence, ~200 nucleotides)
@@ -359,6 +366,7 @@ Downloads the official ShapeMapper example data (TPP riboswitch) from the Weeks-
 - `r2_fq` (File): R2 FASTQ file for paired-end sequencing
 - `cpu_cores` (Int): CPU allocation (default: 2)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `inter_fastq` (File): Interleaved FASTQ file
@@ -370,6 +378,7 @@ Downloads the official ShapeMapper example data (TPP riboswitch) from the Weeks-
 - `chromosome` (String): Chromosome to extract reads for (default: "chr1")
 - `cpu_cores` (Int): CPU allocation (default: 2)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `cram` (File): Example CRAM alignment file filtered to the specified chromosome
@@ -381,6 +390,7 @@ Downloads the official ShapeMapper example data (TPP riboswitch) from the Weeks-
 - `filename` (String): Filename to save the BAM file as (default: "NA12878_chr1.bam")
 - `cpu_cores` (Int): CPU allocation (default: 2)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `bam` (File): Processed BAM alignment file (chr1 only, primary alignments, 10% subsampled)
@@ -399,6 +409,7 @@ Appends a deterministic synthetic 6-mer UMI to each read name in a BAM, mimickin
 - `umi_separator` (String): Character separating the read ID from the appended UMI in the read name (default: `":"`)
 - `cpu_cores` (Int): CPU allocation (default: 2)
 - `memory_gb` (Int): Memory allocation in GB (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `umi_bam` (File): Coordinate-sorted BAM with synthetic UMIs appended to read names
@@ -425,12 +436,31 @@ call umi_tools_tasks.dedup { input:
 **Inputs**:
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
 
 **Outputs**:
 - `wig_gc` (File): GC content in 500kb bins
 - `wig_map` (File): Mappability in 500kb bins
 - `centromeres` (File): Centromere coordinates
 - `panel_of_norm_rds` (File): Panel of normals for normalization
+
+### download_tritonnp_data
+
+Downloads reference and test data for TritonNP analysis, including a WGS test BAM, GC bias estimates, gene annotations, and the full hg19 reference genome.
+
+**Inputs**:
+- `cpu_cores` (Int): CPU allocation (default: 1)
+- `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
+
+**Outputs**:
+- `annotation` (File): BED annotation file
+- `plot_list` (File): Genes to plot
+- `bam` (File): WGS test file
+- `bam_index` (File): WGS test file index
+- `bias` (File): GC bias
+- `reference` (File): hg19 reference genome FASTA
+- `reference_index` (File): Index for hg19 reference genome FASTA
 
 ### download_dbsnp_vcf
 
@@ -439,6 +469,7 @@ call umi_tools_tasks.dedup { input:
 - `filter_name` (String): Filename tag for output (default: "hg38")
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bcftools:1.19`)
 
 **Outputs**:
 - `dbsnp_vcf` (File): Filtered and compressed dbSNP VCF file
@@ -450,6 +481,7 @@ call umi_tools_tasks.dedup { input:
 - `filter_name` (String): Filename tag for output (default: "hg38")
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bcftools:1.19`)
 
 **Outputs**:
 - `known_indels_vcf` (File): Filtered and compressed known indels VCF file
@@ -461,6 +493,7 @@ call umi_tools_tasks.dedup { input:
 - `filter_name` (String): Filename tag for output (default: "hg38")
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bcftools:1.19`)
 
 **Outputs**:
 - `gnomad_vcf` (File): Filtered and compressed gnomAD VCF file
@@ -470,6 +503,7 @@ call umi_tools_tasks.dedup { input:
 **Inputs**:
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
 
 **Outputs**:
 - `test_vcf` (File): Example VCF file for testing structural variant annotation
@@ -485,6 +519,7 @@ Generates DESeq2 test count matrices using the Pasilla Bioconductor dataset. Use
 - `output_prefix` (String): Prefix for output files (default: "pasilla")
 - `memory_gb` (Int): Memory allocation in GB (default: 4)
 - `cpu_cores` (Int): CPU allocation (default: 1)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/deseq2:1.40.2`)
 
 **Outputs**:
 - `individual_count_files` (Array[File]): Individual STAR-format count files for each sample (*.ReadsPerGene.out.tab)
@@ -505,6 +540,7 @@ Extracts and cleans a reference sequence region for saturation mutagenesis analy
 - `replace_n_with` (String): Base to replace N's with (default: "A"). Use empty string to fail if N's are found.
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
 
 **Outputs**:
 - `clean_fasta` (File): Cleaned reference FASTA file with no ambiguous bases
@@ -539,6 +575,7 @@ Downloads a minimal Cell Ranger reference transcriptome for testing single-cell 
 **Inputs**:
 - `cpu_cores` (Int): CPU allocation (default: 2)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `ref_tar` (File): Cell Ranger reference transcriptome tarball containing chromosomes 21 and 22
@@ -567,6 +604,7 @@ Downloads a 10X Genomics example filtered feature-barcode matrix in HDF5 format 
 - `sample_name` (String): Output filename prefix (default: "2500_Wistar_Rat_PBMCs_Singleplex")
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `h5_matrix` (File): Filtered feature-barcode matrix in HDF5 format (`<sample_name>_filtered_feature_bc_matrix.h5`)
@@ -592,6 +630,7 @@ Downloads E. coli Swiss-Prot reference proteome and creates a small subset for t
 **Inputs**:
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `reference` (File): Full E. coli reference proteome FASTA file (ecoli_proteins.fasta, ~4,400 protein sequences)
@@ -623,6 +662,7 @@ Creates a minimal protein FASTA file with a short peptide for testing structure 
 **Inputs**:
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `ubuntu:22.04`)
 
 **Outputs**:
 - `test_fasta` (File): FASTA file containing a short test protein sequence (Trp-cage miniprotein, 20 residues)
@@ -638,6 +678,20 @@ call colabfold_tasks.colabfold_predict {
 }
 ```
 
+### create_test_idp_fasta
+
+Creates a minimal multi-sequence protein FASTA file containing four short, well-characterized intrinsically disordered protein (IDP) regions for testing ensemble generation tools.
+
+**Use Case**: When testing tools that model intrinsically disordered regions (e.g., ensemble generation), you need short, recognizable disordered sequences that run quickly. The included regions (p53 N-terminal transactivation domain, ASH1 IDR, NUPR1, and the p27Kip1 kinase inhibitory domain) are classic IDP examples suitable for CI testing.
+
+**Inputs**:
+- `cpu_cores` (Int): CPU allocation (default: 1)
+- `memory_gb` (Int): Memory allocation (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `ubuntu:22.04`)
+
+**Outputs**:
+- `test_fasta` (File): FASTA file containing four short intrinsically disordered protein sequences
+
 ### download_glimpse2_genetic_map
 
 Downloads genetic map files for GLIMPSE2 imputation from the official GLIMPSE repository.
@@ -649,6 +703,7 @@ Downloads genetic map files for GLIMPSE2 imputation from the official GLIMPSE re
 - `genome_build` (String): Genome build version, "b37" or "b38" (default: "b38")
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
 
 **Outputs**:
 - `genetic_map` (File): Compressed genetic map file for the specified chromosome
@@ -667,6 +722,7 @@ Downloads and prepares a 1000 Genomes reference panel subset for GLIMPSE2 testin
 - `exclude_samples` (String): Comma-separated list of samples to exclude, useful for leave-one-out validation (default: "NA12878")
 - `cpu_cores` (Int): CPU allocation (default: 2)
 - `memory_gb` (Int): Memory allocation (default: 8)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bcftools:1.19`)
 
 **Outputs**:
 - `reference_vcf` (File): Reference panel BCF file for imputation
@@ -688,6 +744,7 @@ Downloads low-coverage sequencing data from 1000 Genomes and extracts a VCF with
 - `sample_name` (String): Sample to extract from 1000 Genomes (default: "NA12878")
 - `cpu_cores` (Int): CPU allocation (default: 2)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bcftools:1.19`)
 
 **Outputs**:
 - `gl_vcf` (File): VCF file with genotype likelihoods (GL field) for imputation
@@ -720,6 +777,7 @@ Downloads example rMATS output files and Ensembl reference data for JCAST altern
 **Inputs**:
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
 
 **Outputs**:
 - `rmats_output` (File): Tarball containing rMATS output files (SE.MATS.JC.txt, MXE.MATS.JC.txt, RI.MATS.JC.txt, A3SS.MATS.JC.txt, A5SS.MATS.JC.txt)
@@ -754,6 +812,7 @@ Downloads high-coverage truth genotypes from 1000 Genomes for GLIMPSE2 concordan
 - `sample_name` (String): Sample to extract as truth (default: "NA12878"). Must be in the high-coverage dataset.
 - `cpu_cores` (Int): CPU allocation (default: 2)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/bcftools:1.19`)
 
 **Outputs**:
 - `truth_vcf` (File): Truth VCF file with high-confidence genotypes for concordance evaluation
@@ -789,6 +848,7 @@ Generates synthetic tile and border points data for testing the `ww-sjl` module 
 - `year` (Int): Year to embed in the synthetic data (default: 2022)
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/r-utils:0.1.0`)
 
 **Outputs**:
 - `tile_rds` (File): Synthetic tile RDS file with 5 geographic points across two timezones
@@ -802,6 +862,7 @@ Downloads the Pseudomonas aeruginosa PAO1 reference genome (FASTA + GTF) from NC
 - `output_prefix` (String): Prefix used for output filenames (default: "pao1")
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/samtools:1.11`)
 
 **Outputs**:
 - `fasta` (File): PAO1 reference genome FASTA (sequence: NC_002516.2)

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -26,6 +26,7 @@ task download_ref_data {
     output_name: "Optional name for output files (default: uses chromo name)"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -35,6 +36,7 @@ task download_ref_data {
     String? output_name
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   String final_output_name = select_first([output_name, chromo])
@@ -109,7 +111,7 @@ task download_ref_data {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -134,6 +136,7 @@ task merge_fastas_with_prefix {
     output_name: "Output filename prefix (without the .fa extension)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -143,6 +146,7 @@ task merge_fastas_with_prefix {
     String output_name
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   command <<<
@@ -160,7 +164,7 @@ task merge_fastas_with_prefix {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -181,12 +185,14 @@ task download_rrna_reference {
     output_name: "Output filename prefix (without the .fa extension)"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     String output_name = "human_45S_rRNA"
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   command <<<
@@ -208,7 +214,7 @@ task download_rrna_reference {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -231,6 +237,7 @@ task download_fastq_data {
     gzip_output: "Compress output files with gzip (default: false)"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -238,6 +245,7 @@ task download_fastq_data {
     String prefix = "testdata"
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   # Determine output filenames based on prefix and gzip setting
@@ -267,7 +275,7 @@ task download_fastq_data {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -289,6 +297,7 @@ task interleave_fastq {
     r2_fq: "Reverse (R2) FASTQ file"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -296,6 +305,7 @@ task interleave_fastq {
     File r2_fq
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   command <<<
@@ -311,7 +321,7 @@ task interleave_fastq {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -335,6 +345,7 @@ task download_cram_data {
     output_name: "Optional name for output CRAM file (default: NA12878_{chromosome})"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -343,6 +354,7 @@ task download_cram_data {
     String? output_name
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   String final_name = select_first([output_name, "NA12878_~{chromosome}"])
@@ -399,7 +411,7 @@ task download_cram_data {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -421,12 +433,14 @@ task download_bam_data {
     filename: "Filename to save the BAM file as"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     String filename = "NA12878_chr1.bam"
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   command <<<
@@ -469,7 +483,7 @@ task download_bam_data {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -494,6 +508,7 @@ task inject_synthetic_umis {
     umi_separator: "Character separating the read ID from the appended UMI in the read name"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -503,6 +518,7 @@ task inject_synthetic_umis {
     String umi_separator = ":"
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   command <<<
@@ -541,7 +557,7 @@ task inject_synthetic_umis {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -564,11 +580,13 @@ task download_ichor_data {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   command <<<
@@ -590,7 +608,7 @@ task download_ichor_data {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -616,11 +634,13 @@ task download_tritonnp_data {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   command <<<
@@ -651,7 +671,7 @@ task download_tritonnp_data {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -674,6 +694,7 @@ task download_dbsnp_vcf {
     filter_name: "Filename tag to save the dbSNP vcf with"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -681,6 +702,7 @@ task download_dbsnp_vcf {
     String filter_name = "hg38"
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/bcftools:1.19"
   }
 
   command <<<
@@ -731,7 +753,7 @@ task download_dbsnp_vcf {
   }
 
   runtime {
-    docker: "getwilds/bcftools:1.19"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -754,6 +776,7 @@ task download_known_indels_vcf {
     filter_name: "Filename tag to save the known indels vcf with"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -761,6 +784,7 @@ task download_known_indels_vcf {
     String filter_name = "hg38"
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/bcftools:1.19"
   }
 
   command <<<
@@ -780,7 +804,7 @@ task download_known_indels_vcf {
   }
 
   runtime {
-    docker: "getwilds/bcftools:1.19"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -803,6 +827,7 @@ task download_gnomad_vcf {
     filter_name: "Filename tag to save the gnomad vcf with"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -810,6 +835,7 @@ task download_gnomad_vcf {
     String filter_name = "hg38"
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/bcftools:1.19"
   }
 
   command <<<
@@ -828,7 +854,7 @@ task download_gnomad_vcf {
   }
 
   runtime {
-    docker: "getwilds/bcftools:1.19"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -848,11 +874,13 @@ task download_annotsv_vcf {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   command <<<
@@ -867,7 +895,7 @@ task download_annotsv_vcf {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -894,6 +922,7 @@ task generate_pasilla_counts {
     output_prefix: "Prefix for output files"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -903,6 +932,7 @@ task generate_pasilla_counts {
     String output_prefix = "pasilla"
     Int memory_gb = 4
     Int cpu_cores = 1
+    String docker_image = "getwilds/deseq2:1.40.2"
   }
 
   command <<<
@@ -928,7 +958,7 @@ task generate_pasilla_counts {
   }
 
   runtime {
-    docker: "getwilds/deseq2:1.40.2"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -948,11 +978,13 @@ task download_test_transcriptome {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   command <<<
@@ -972,7 +1004,7 @@ task download_test_transcriptome {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -998,6 +1030,7 @@ task create_clean_amplicon_reference {
     replace_n_with: "Base to replace N's with (default: 'A'). Use empty string to fail if N's are found."
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1007,6 +1040,7 @@ task create_clean_amplicon_reference {
     String replace_n_with = "A"
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   command <<<
@@ -1068,7 +1102,7 @@ task create_clean_amplicon_reference {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -1083,6 +1117,14 @@ task create_gdc_manifest {
     outputs: {
         manifest: "GDC manifest file containing test file UUIDs"
     }
+  }
+
+  parameter_meta {
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   command <<<
@@ -1105,7 +1147,7 @@ EOF
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     memory: "2 GB"
     cpu: 1
   }
@@ -1129,11 +1171,13 @@ task download_shapemapper_data {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   command <<<
@@ -1193,7 +1237,7 @@ task download_shapemapper_data {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1213,11 +1257,13 @@ task download_test_cellranger_ref {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   command <<<
@@ -1239,7 +1285,7 @@ task download_test_cellranger_ref {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     memory: "~{memory_gb} GB"
     cpu: cpu_cores
   }
@@ -1260,11 +1306,13 @@ task create_diamond_data {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   command <<<
@@ -1327,7 +1375,7 @@ FASTA
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1347,11 +1395,13 @@ task create_test_protein_fasta {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "ubuntu:22.04"
   }
 
   command <<<
@@ -1369,7 +1419,7 @@ FASTA
   }
 
   runtime {
-    docker: "ubuntu:22.04"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1391,6 +1441,7 @@ task download_glimpse2_genetic_map {
     genome_build: "Genome build version (b37 or b38)"
     cpu_cores: "Number of CPU cores to use for downloading"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1398,6 +1449,7 @@ task download_glimpse2_genetic_map {
     String genome_build = "b38"
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   command <<<
@@ -1425,7 +1477,7 @@ task download_glimpse2_genetic_map {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1451,6 +1503,7 @@ task download_glimpse2_reference_panel {
     exclude_samples: "Comma-separated list of samples to exclude (useful for validation)"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1459,6 +1512,7 @@ task download_glimpse2_reference_panel {
     String exclude_samples = "NA12878"
     Int cpu_cores = 2
     Int memory_gb = 8
+    String docker_image = "getwilds/bcftools:1.19"
   }
 
   command <<<
@@ -1503,7 +1557,7 @@ task download_glimpse2_reference_panel {
   }
 
   runtime {
-    docker: "getwilds/bcftools:1.19"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1527,6 +1581,7 @@ task download_glimpse2_truth_vcf {
     sample_name: "Sample to extract as truth (must be in the high-coverage dataset)"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1535,6 +1590,7 @@ task download_glimpse2_truth_vcf {
     String sample_name = "NA12878"
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/bcftools:1.19"
   }
 
   command <<<
@@ -1564,7 +1620,7 @@ task download_glimpse2_truth_vcf {
   }
 
   runtime {
-    docker: "getwilds/bcftools:1.19"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1586,12 +1642,14 @@ task generate_sjl_data {
     year: "Year to embed in the synthetic data"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int year = 2022
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/r-utils:0.1.0"
   }
 
   command <<<
@@ -1630,7 +1688,7 @@ task generate_sjl_data {
   }
 
   runtime {
-    docker: "getwilds/r-utils:0.1.0"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1654,6 +1712,7 @@ task download_glimpse2_test_gl_vcf {
     sample_name: "Sample to extract from 1000 Genomes (must be in low-coverage dataset)"
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -1662,6 +1721,7 @@ task download_glimpse2_test_gl_vcf {
     String sample_name = "NA12878"
     Int cpu_cores = 2
     Int memory_gb = 4
+    String docker_image = "getwilds/bcftools:1.19"
   }
 
   command <<<
@@ -1692,7 +1752,7 @@ task download_glimpse2_test_gl_vcf {
   }
 
   runtime {
-    docker: "getwilds/bcftools:1.19"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1714,11 +1774,13 @@ task download_jcast_test_data {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use for downloading"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   command <<<
@@ -1768,7 +1830,7 @@ task download_jcast_test_data {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1788,11 +1850,13 @@ task create_test_idp_fasta {
   parameter_meta {
     cpu_cores: "Number of CPU cores to use"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "ubuntu:22.04"
   }
 
   command <<<
@@ -1815,7 +1879,7 @@ FASTA
   }
 
   runtime {
-    docker: "ubuntu:22.04"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1839,12 +1903,14 @@ task download_pao1_ref {
     output_prefix: "Prefix used for output filenames"
     cpu_cores: "Number of CPU cores to use for downloading and processing"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     String output_prefix = "pao1"
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/samtools:1.11"
   }
 
   command <<<
@@ -1881,7 +1947,7 @@ task download_pao1_ref {
   }
 
   runtime {
-    docker: "getwilds/samtools:1.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -1902,12 +1968,14 @@ task download_10x_h5_data {
     sample_name: "Sample name used as the output filename prefix"
     cpu_cores: "Number of CPU cores to use for downloading"
     memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     String sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
     Int cpu_cores = 1
     Int memory_gb = 2
+    String docker_image = "getwilds/awscli:2.27.49"
   }
 
   command <<<
@@ -1922,7 +1990,7 @@ task download_10x_h5_data {
   }
 
   runtime {
-    docker: "getwilds/awscli:2.27.49"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-trimgalore/README.md
+++ b/modules/ww-trimgalore/README.md
@@ -35,6 +35,7 @@ Run Trim Galore on paired-end FASTQ files for adapter and quality trimming.
 - `adapter2` (String?, optional): Adapter sequence for R2 (auto-detected if not specified)
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/trim-galore:0.6.11`)
 
 **Outputs:**
 - `r1_trimmed` (File): Trimmed and validated R1 FASTQ file
@@ -56,6 +57,7 @@ Run Trim Galore on a single-end FASTQ file for adapter and quality trimming.
 - `adapter` (String?, optional): Adapter sequence (auto-detected if not specified)
 - `cpu_cores` (Int, default=4): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/trim-galore:0.6.11`)
 
 **Outputs:**
 - `trimmed_fastq` (File): Trimmed FASTQ file

--- a/modules/ww-trimgalore/ww-trimgalore.wdl
+++ b/modules/ww-trimgalore/ww-trimgalore.wdl
@@ -42,6 +42,7 @@ task trimgalore_paired {
     adapter2: "Optional adapter sequence for R2 (auto-detected if not specified)"
     cpu_cores: "Number of CPU cores allocated for the task (default: 4)"
     memory_gb: "Memory allocated for the task in GB (default: 8)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -56,6 +57,7 @@ task trimgalore_paired {
     String? adapter2
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/trim-galore:0.6.11"
   }
 
   command <<<
@@ -97,7 +99,7 @@ task trimgalore_paired {
   }
 
   runtime {
-    docker: "getwilds/trim-galore:0.6.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -134,6 +136,7 @@ task trimgalore_single {
     adapter: "Optional adapter sequence (auto-detected if not specified)"
     cpu_cores: "Number of CPU cores allocated for the task (default: 4)"
     memory_gb: "Memory allocated for the task in GB (default: 8)"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -146,6 +149,7 @@ task trimgalore_single {
     String? adapter
     Int cpu_cores = 4
     Int memory_gb = 8
+    String docker_image = "getwilds/trim-galore:0.6.11"
   }
 
   command <<<
@@ -180,7 +184,7 @@ task trimgalore_single {
   }
 
   runtime {
-    docker: "getwilds/trim-galore:0.6.11"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-tritonnp/README.md
+++ b/modules/ww-tritonnp/README.md
@@ -36,6 +36,8 @@ Runs TritonNP on a single sample to generate phasing feature matrices.
 - `size_range` (String): Size ranges for phasing as a space-delimited string, such as '15 500'
 - `cpus` (Int): Number of CPUs to use
 - `plot_list` (File): File containing names of genes to plot
+- `memory_gb` (Int): Memory allocation in GB (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/python-utils:0.1.0`)
 
 **Outputs:**
 - `fm_file` (File): Phasing feature matrix output file
@@ -47,6 +49,8 @@ Combines phasing feature matrices from multiple samples.
 **Inputs:**
 - `fm_files` (Array[File]): Array of output files from TritonNP
 - `results_dir` (String): Output directory name
+- `memory_gb` (Int): Memory allocation in GB (default: 4)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/python-utils:0.1.0`)
 
 **Outputs:**
 - `final` (File): Aggregated output file from TritonNP

--- a/modules/ww-tritonnp/ww-tritonnp.wdl
+++ b/modules/ww-tritonnp/ww-tritonnp.wdl
@@ -37,8 +37,9 @@ task triton_main {
     size_range: "Size range as a space-delimited string, such as '15 500'"
     ncpus: "Number of CPUs to use"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
-  
+
   input {
     String sample_name
     File bam_path
@@ -53,6 +54,7 @@ task triton_main {
     String size_range = "15 500"
     Int ncpus = 4
     Int memory_gb = 4
+    String docker_image = "getwilds/python-utils:0.1.0"
   }
 
   command <<<
@@ -60,7 +62,7 @@ task triton_main {
 
     # Create results directory if it doesn't exist
     mkdir -p ~{results_dir}
-    
+
     # Download script
     git clone https://github.com/caalo/TritonNP.git
 
@@ -85,7 +87,7 @@ task triton_main {
   runtime {
     cpu: ncpus
     memory: "~{memory_gb} GB"
-    docker: "getwilds/python-utils:0.1.0"
+    docker: docker_image
   }
 }
 
@@ -113,12 +115,14 @@ task combine_fms {
     fm_files: "Array of output files from TritonNP"
     results_dir: "Output directory name"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
     Array[File] fm_files
     String results_dir
     Int memory_gb = 4
+    String docker_image = "getwilds/python-utils:0.1.0"
   }
 
   command <<<
@@ -143,6 +147,6 @@ task combine_fms {
   runtime {
     cpu: 1
     memory: "~{memory_gb} GB"
-    docker: "getwilds/python-utils:0.1.0"
+    docker: docker_image
   }
 }

--- a/modules/ww-umi-tools/README.md
+++ b/modules/ww-umi-tools/README.md
@@ -35,6 +35,7 @@ Deduplicates a coordinate-sorted, indexed BAM using `umi_tools dedup` and re-ind
 - `extra_args` (String, default=`""`): Additional flags passed verbatim to `umi_tools dedup`
 - `cpu_cores` (Int, default=2): CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String, default=`"getwilds/umitools:1.1.6"`): Docker image to use for this task
 
 **Outputs:**
 - `deduped_bam` (File): Deduplicated BAM file

--- a/modules/ww-umi-tools/ww-umi-tools.wdl
+++ b/modules/ww-umi-tools/ww-umi-tools.wdl
@@ -31,6 +31,7 @@ task dedup {
     extra_args: "Additional arguments to pass to umi_tools dedup"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -43,6 +44,7 @@ task dedup {
     String extra_args = ""
     Int cpu_cores = 2
     Int memory_gb = 8
+    String docker_image = "getwilds/umitools:1.1.6"
   }
 
   command <<<
@@ -71,7 +73,7 @@ task dedup {
   }
 
   runtime {
-    docker: "getwilds/umitools:1.1.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-varscan/README.md
+++ b/modules/ww-varscan/README.md
@@ -31,6 +31,7 @@ Performs somatic variant calling on tumor-normal pairs using pre-generated mpile
 - `tumor_pileup` (File): Samtools mpileup file for the tumor sample
 - `cpu_cores` (Int): Number of CPU cores (default: 4)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/varscan:2.4.6`)
 
 **Important**: VarScan2 requires **mpileup files** as input, not BAM or FASTQ files. Mpileup files can be generated using SAMtools from aligned BAM files. See the `ww-samtools` [module](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-samtools) and the [Samtools documentation](http://www.htslib.org/doc/samtools-mpileup.html) for details on creating mpileup files.
 
@@ -46,6 +47,7 @@ Performs germline variant calling on a single sample using a pre-generated mpile
 - `pileup` (File): Samtools mpileup file generated with `--no-BAQ` flag and reference FASTA
 - `cpu_cores` (Int): Number of CPU cores (default: 4)
 - `memory_gb` (Int): Memory allocation in GB (default: 16)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/varscan:2.4.6`)
 
 **Important**: The mpileup file must be generated from a sorted BAM file using the `--no-BAQ` flag. See the [VarScan documentation](https://dkoboldt.github.io/varscan/germline-calling.html) for more information and the the `ww-samtools` [module](https://github.com/getwilds/wilds-wdl-library/tree/main/modules/ww-samtools) for running `samtools mpileup` using a WILDS WDL.
 

--- a/modules/ww-varscan/ww-varscan.wdl
+++ b/modules/ww-varscan/ww-varscan.wdl
@@ -32,6 +32,7 @@ task somatic {
     tumor_pileup: "Samtools mpileup file for the tumor sample"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -40,6 +41,7 @@ task somatic {
     File tumor_pileup
     Int memory_gb = 16
     Int cpu_cores = 4
+    String docker_image = "getwilds/varscan:2.4.6"
   }
 
   command <<<
@@ -58,7 +60,7 @@ task somatic {
   }
 
   runtime {
-    docker: "getwilds/varscan:2.4.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -90,6 +92,7 @@ task mpileup2cns {
     pileup: "Samtools mpileup file generated with `--no-BAQ` and reference FASTA"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -97,6 +100,7 @@ task mpileup2cns {
     File pileup
     Int memory_gb = 16
     Int cpu_cores = 4
+    String docker_image = "getwilds/varscan:2.4.6"
   }
 
   command <<<
@@ -115,7 +119,7 @@ task mpileup2cns {
   }
 
   runtime {
-    docker: "getwilds/varscan:2.4.6"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }

--- a/modules/ww-viennarna/README.md
+++ b/modules/ww-viennarna/README.md
@@ -31,6 +31,7 @@ Predict minimum free energy (MFE) secondary structures and optionally compute pa
 - `extra_args` (String, default=""): Additional command-line arguments
 - `cpu_cores` (Int, default=1): Number of CPU cores
 - `memory_gb` (Int, default=4): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/viennarna:2.7.2`)
 
 **Outputs:**
 - `structure_output` (File): Predicted MFE structures in dot-bracket notation with free energies
@@ -48,6 +49,7 @@ Enumerate suboptimal secondary structures within an energy range of the MFE.
 - `extra_args` (String, default=""): Additional command-line arguments
 - `cpu_cores` (Int, default=1): Number of CPU cores
 - `memory_gb` (Int, default=4): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/viennarna:2.7.2`)
 
 **Outputs:**
 - `subopt_output` (File): Suboptimal structures in dot-bracket notation with energies
@@ -64,6 +66,7 @@ Predict the joint secondary structure and hybridization energy of two interactin
 - `extra_args` (String, default=""): Additional command-line arguments
 - `cpu_cores` (Int, default=1): Number of CPU cores
 - `memory_gb` (Int, default=4): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/viennarna:2.7.2`)
 
 **Outputs:**
 - `cofold_output` (File): Predicted joint MFE structure with interaction energy
@@ -82,6 +85,7 @@ Compute local base pair probabilities using a sliding window approach, useful fo
 - `extra_args` (String, default=""): Additional command-line arguments
 - `cpu_cores` (Int, default=1): Number of CPU cores
 - `memory_gb` (Int, default=4): Memory in GB
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/viennarna:2.7.2`)
 
 **Outputs:**
 - `accessibility_profiles` (Array[File]): Accessibility profile files with unpaired probabilities

--- a/modules/ww-viennarna/ww-viennarna.wdl
+++ b/modules/ww-viennarna/ww-viennarna.wdl
@@ -36,6 +36,7 @@ task rnafold {
     extra_args: "Additional command-line arguments to pass to RNAfold"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -46,6 +47,7 @@ task rnafold {
     String extra_args = ""
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/viennarna:2.7.2"
   }
 
   command <<<
@@ -66,7 +68,7 @@ task rnafold {
   }
 
   runtime {
-    docker: "getwilds/viennarna:2.7.2"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -100,6 +102,7 @@ task rnasubopt {
     extra_args: "Additional command-line arguments to pass to RNAsubopt"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -110,6 +113,7 @@ task rnasubopt {
     String extra_args = ""
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/viennarna:2.7.2"
   }
 
   command <<<
@@ -129,7 +133,7 @@ task rnasubopt {
   }
 
   runtime {
-    docker: "getwilds/viennarna:2.7.2"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -164,6 +168,7 @@ task rnacofold {
     extra_args: "Additional command-line arguments to pass to RNAcofold"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -174,6 +179,7 @@ task rnacofold {
     String extra_args = ""
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/viennarna:2.7.2"
   }
 
   command <<<
@@ -193,7 +199,7 @@ task rnacofold {
   }
 
   runtime {
-    docker: "getwilds/viennarna:2.7.2"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }
@@ -229,6 +235,7 @@ task rnaplfold {
     extra_args: "Additional command-line arguments to pass to RNAplfold"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
   }
 
   input {
@@ -240,6 +247,7 @@ task rnaplfold {
     String extra_args = ""
     Int cpu_cores = 1
     Int memory_gb = 4
+    String docker_image = "getwilds/viennarna:2.7.2"
   }
 
   command <<<
@@ -260,7 +268,7 @@ task rnaplfold {
   }
 
   runtime {
-    docker: "getwilds/viennarna:2.7.2"
+    docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
   }


### PR DESCRIPTION
## Type of Change

- Enhancement (existing modules)
- Documentation update

## Description

Makes the Docker container image configurable as an input parameter in every WILDS WDL task, closing #222.

**Before:** each task hard-coded its image in the `runtime` block:

```wdl
runtime {
  docker: "getwilds/bwa:0.7.17"
}
```

**After:** the image is a `String` input with the pinned WILDS image as the default, so users can substitute a private ECR mirror, a different version, or an organization-standard image without modifying the WDL:

```wdl
input {
  String docker_image = "getwilds/bwa:0.7.17"
}
runtime {
  docker: docker_image
}
```

Changes made across the repo:

- **53 module WDLs** — every task in every module now declares `String docker_image = "..."` in its `input` block and uses `docker: docker_image` in `runtime`. The default preserves the existing pinned image, so behavior is unchanged for existing users who don't override it.
- **53 module READMEs** — each task's `**Inputs:**` list now documents `docker_image` with its type and default. READMEs that previously omitted `cpu_cores`/`memory_gb` from their input lists have been backfilled for consistency. Two previously undocumented `ww-testdata` tasks (`download_tritonnp_data`, `create_test_idp_fasta`) now have full README sections.
- **`modules/README.md` summary table** — column renamed to `Container(s)`, 9 previously missing modules added, 6 stale/wrong container values corrected, and multi-image and non-redistributable modules given appropriate notes.
- **`ww-rmats-turbo`** — pinned from `:latest` to `4.3.0` (the only published version tag) in both the WDL default and README.
- **`ww-consensus`** — WDL default and README aligned to `rocker/tidyverse:4.4.2` (the tested version, previously inconsistent between WDL and docs).
- **`AGENTS.md`, `create-module` skill files** — updated to document the `docker_image` input-parameter convention so new modules generated via the skill follow this pattern automatically.

## Related Issue

Fixes #222

## Testing

The `testrun.wdl` import URLs were not updated to point at this branch, so the CI below pulled the module WDLs from main rather than the branch. A full module & pipeline test run will be executed immediately after merging this PR into `main` via manually triggered GitHub Actions.

**Update**: both the [module](https://github.com/getwilds/wilds-wdl-library/actions/runs/28044240415) and [pipeline](https://github.com/getwilds/wilds-wdl-library/actions/runs/28047440153) test run GitHub Actions succeeded on `main`

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- **No breaking change:** all `docker_image` inputs use the original pinned image as the default, so existing `inputs.json` files and workflow calls that don't specify `docker_image` continue to work identically.
- **`ww-cellranger`** is a partial exception: `run_count_hpc_cromwell` intentionally has no `docker_image` input (it runs directly on an HPC compute node via environment modules). The other three `ww-cellranger` tasks do have the new input.
- **Pre-existing README drift** discovered and fixed during the doc pass (not caused by this PR): `ww-samtools` `crams_to_fastq` had cpu=23/mem=36 in the README vs cpu=2/mem=16 in the WDL; `ww-seurat` had cpu=4/mem=16 vs cpu=2/mem=4; `ww-spades` had cpu=16/mem=64 vs cpu=4/mem=8; `ww-deseq2` `compile_deseq2_results` had cpu=1/mem=4 vs cpu=2/mem=8. All corrected.