### PR TITLE
Adding CellBender post-processing and organized outputs for `ww-sra-cellranger`

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -159,6 +159,16 @@ tools:
         role: Research Informatics Data Scientist
         affiliation: Fred Hutch Cancer Center
         orcid: 0009-0002-2052-1084
+      - name: Emma Bishop
+        email: ebishop@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0003-4484-3336
+      - name: Hrishi Venkatesh
+        email: hvenkate@fredhutch.org
+        role: Post-Doctoral Research Fellow
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0000-0002-2938-3856
     topic: WDL module for removing ambient RNA from single-cell RNA-seq data using CellBender
     enableAutoDois: true
     filters:

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -149,6 +149,22 @@ tools:
       branches:
         - main
 
+  - name: ww-cellbender
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-cellbender/ww-cellbender.wdl
+    readMePath: /modules/ww-cellbender/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for removing ambient RNA from single-cell RNA-seq data using CellBender
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-cellranger
     subclass: WDL
     primaryDescriptorPath: /modules/ww-cellranger/ww-cellranger.wdl

--- a/modules/ww-cellbender/README.md
+++ b/modules/ww-cellbender/README.md
@@ -1,0 +1,182 @@
+# ww-cellbender Module
+
+[![Project Status: Prototype – Useable, some support, open to feedback, unstable API.](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for removing ambient RNA contamination and barcode swapping artifacts from single-cell RNA sequencing data using [CellBender](https://cellbender.readthedocs.io/).
+
+## Overview
+
+CellBender uses a deep generative model to distinguish real cell signal from technical noise sources in UMI-based scRNA-seq, snRNA-seq, and CITE-seq experiments. Its `remove-background` command takes the raw (unfiltered) feature-barcode matrix produced by Cell Ranger and outputs a cleaned count matrix suitable for downstream analysis.
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and follows the standard WILDS module structure:
+
+- **Main WDL file**: `ww-cellbender.wdl` - Contains task definitions for the module
+- **Test workflow**: `testrun.wdl` - Demonstration workflow for testing and examples
+- **Documentation**: This README with usage examples and parameter descriptions
+
+## Available Tasks
+
+### `remove_background`
+
+Runs CellBender `remove-background` on a raw 10x Genomics feature-barcode matrix to remove ambient RNA and barcode swapping noise.
+
+**Inputs:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `input_h5` | File | required | Raw feature-barcode matrix HDF5 file from Cell Ranger (`raw_feature_bc_matrix.h5`) |
+| `sample_name` | String | required | Sample name used as output file prefix |
+| `expected_cells` | Int? | auto | Estimated number of real cells; helps CellBender set priors |
+| `total_droplets_included` | Int? | auto | Total droplets to analyze (ranked by UMI count) |
+| `fpr` | String | `"0.01"` | False positive rate target(s), space-separated for multiple (e.g. `"0.01 0.05"`) |
+| `epochs` | Int | `150` | Number of training epochs |
+| `learning_rate` | Float | `0.0001` | Base learning rate for the variational inference optimizer |
+| `model` | String | `"full"` | CellBender model variant: `naive`, `simple`, `ambient`, `swapping`, or `full` |
+| `low_count_threshold` | Int | `5` | Droplets below this UMI count are excluded from analysis |
+| `exclude_feature_types` | String? | none | Space-separated feature types to exclude (e.g. `"Antibody Capture"`) |
+| `cpu_cores` | Int | `4` | Number of CPU cores allocated for the task |
+| `memory_gb` | Int | `32` | Memory allocated for the task in GB |
+| `docker_image` | String | `getwilds/cellbender:0.3.2` | Docker image to use for this task |
+
+**Outputs:**
+
+| Output | Type | Description |
+|--------|------|-------------|
+| `output_h5` | File | Full cleaned count matrix in H5 format (all input barcodes retained) |
+| `filtered_h5` | File | Filtered cleaned count matrix (barcodes with >50% cell probability only) |
+| `report_html` | File | Interactive HTML report with training diagnostics and quality plots |
+| `summary_pdf` | File | PDF summary of the inference procedure |
+| `log_file` | File | Run log with diagnostics and parameter summary |
+| `cell_barcodes_csv` | File | Plain-text list of cell barcodes exceeding 50% cell probability threshold |
+| `metrics_csv` | File | Run metrics CSV (one row per FPR value) |
+| `checkpoint_tar` | File | Trained model checkpoint tarball (can be used to resume or inspect training) |
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellbender/ww-cellbender.wdl" as cellbender_tasks
+
+workflow my_scrna_pipeline {
+  input {
+    File raw_h5
+    String sample_name
+    Int expected_cells
+  }
+
+  call cellbender_tasks.remove_background {
+    input:
+      input_h5 = raw_h5,
+      sample_name = sample_name,
+      expected_cells = expected_cells
+  }
+
+  output {
+    File cleaned_h5      = remove_background.filtered_h5
+    File qc_report       = remove_background.report_html
+    File cell_barcodes   = remove_background.cell_barcodes_csv
+  }
+}
+```
+
+### Advanced Usage: Multiple FPR Values
+
+```wdl
+call cellbender_tasks.remove_background {
+  input:
+    input_h5 = raw_h5,
+    sample_name = "my_sample",
+    expected_cells = 5000,
+    total_droplets_included = 15000,
+    fpr = "0.01 0.05 0.1",
+    epochs = 200,
+    cpu_cores = 8,
+    memory_gb = 64
+}
+```
+
+### Integration with ww-cellranger
+
+CellBender is typically run after Cell Ranger. The `raw_h5` output from `ww-cellranger` can be passed directly as input:
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellranger/ww-cellranger.wdl" as cellranger_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellbender/ww-cellbender.wdl" as cellbender_tasks
+
+workflow scrna_pipeline {
+  # ... Cell Ranger step ...
+  call cellranger_tasks.cellranger_count { ... }
+
+  call cellbender_tasks.remove_background {
+    input:
+      input_h5 = cellranger_count.raw_h5,
+      sample_name = sample_name
+  }
+}
+```
+
+## Testing the Module
+
+The module includes a test workflow (`testrun.wdl`) that downloads a public 10x Genomics raw feature-barcode matrix and runs CellBender on it.
+
+```bash
+# Using Sprocket
+sprocket run testrun.wdl
+
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+```
+
+## Docker Container
+
+This module uses the `getwilds/cellbender:0.3.2` container image from the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library), which includes:
+
+- CellBender 0.3.2
+- Python 3 with PyTorch and all CellBender dependencies
+- CPU-only runtime (GPU is not required but will accelerate training if available)
+
+## Citation
+
+> CellBender remove-background: a deep generative model for unsupervised removal of background noise from scRNA-seq datasets
+> Stephen J Fleming, Mark D Chaffin, Alessandro Arduini, Amer-Denis Akkad, Eric Banks, John C Marioni, Anthony A Philippakis, Patrick T Ellinor, Mehrtash Babadi
+> bioRxiv 2019.12.9.869750; doi: https://doi.org/10.1101/791699
+
+## Parameters and Resource Requirements
+
+### Default Resources
+- **CPU**: 4 cores
+- **Memory**: 32 GB
+- **Runtime**: Variable depending on dataset size and epoch count; typically 30-120 minutes per sample on CPU
+
+### Resource Scaling
+- For large datasets (>20,000 cells or >100,000 droplets), increase `memory_gb` to 64 GB or more
+- Increasing `cpu_cores` up to 8 can speed up posterior computation
+- The `epochs` parameter controls training time: fewer epochs are faster but may reduce accuracy; the default of 150 is suitable for most datasets
+
+## Contributing
+
+To improve this module or report issues:
+1. Fork the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library)
+2. Make your changes following WILDS conventions
+3. Test thoroughly with the demonstration workflow
+4. Submit a pull request with detailed documentation
+
+## Support and Feedback
+
+For questions about this module or to report issues:
+- Open an issue in the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library/issues)
+- Contact the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org
+
+## Related Resources
+
+- **[CellBender Documentation](https://cellbender.readthedocs.io/)**: Official CellBender documentation
+- **[WILDS Docker Library](https://github.com/getwilds/wilds-docker-library)**: Container images used by WDL workflows
+- **[WILDS Documentation](https://getwilds.org/)**: Comprehensive guides and best practices
+- **[WDL Specification](https://openwdl.org/)**: Official WDL language documentation

--- a/modules/ww-cellbender/README.md
+++ b/modules/ww-cellbender/README.md
@@ -30,7 +30,7 @@ Runs CellBender `remove-background` on a raw 10x Genomics feature-barcode matrix
 | `input_h5` | File | required | Raw feature-barcode matrix HDF5 file from Cell Ranger (`raw_feature_bc_matrix.h5`) |
 | `sample_name` | String | required | Sample name used as output file prefix |
 | `expected_cells` | Int? | auto | Estimated number of real cells; helps CellBender set priors |
-| `total_droplets_included` | Int? | auto | Total droplets to analyze (ranked by UMI count) |
+| `total_droplets_included` | Int? | auto | Total droplets to analyze |
 | `fpr` | String | `"0.01"` | False positive rate target(s), space-separated for multiple (e.g. `"0.01 0.05"`) |
 | `epochs` | Int | `150` | Number of training epochs |
 | `learning_rate` | Float | `0.0001` | Base learning rate for the variational inference optimizer |

--- a/modules/ww-cellbender/README.md
+++ b/modules/ww-cellbender/README.md
@@ -78,9 +78,9 @@ workflow my_scrna_pipeline {
   }
 
   output {
-    File cleaned_h5      = remove_background.filtered_h5
-    File qc_report       = remove_background.report_html
-    File cell_barcodes   = remove_background.cell_barcodes_csv
+    File cleaned_h5 = remove_background.filtered_h5
+    File qc_report = remove_background.report_html
+    File cell_barcodes = remove_background.cell_barcodes_csv
   }
 }
 ```

--- a/modules/ww-cellbender/README.md
+++ b/modules/ww-cellbender/README.md
@@ -37,6 +37,8 @@ Runs CellBender `remove-background` on a raw 10x Genomics feature-barcode matrix
 | `model` | String | `"full"` | CellBender model variant: `naive`, `simple`, `ambient`, `swapping`, or `full` |
 | `low_count_threshold` | Int | `5` | Droplets below this UMI count are excluded from analysis |
 | `exclude_feature_types` | String? | none | Space-separated feature types to exclude (e.g. `"Antibody Capture"`) |
+| `checkpoint_mins` | Float | `7.0` | How frequently (in minutes) to save a training checkpoint |
+| `gpu_enabled` | Boolean | `true` | Enable GPU acceleration (`--cuda`); set to `false` for CPU-only execution |
 | `cpu_cores` | Int | `4` | Number of CPU cores allocated for the task |
 | `memory_gb` | Int | `32` | Memory allocated for the task in GB |
 | `docker_image` | String | `getwilds/cellbender:0.3.2` | Docker image to use for this task |

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -13,8 +13,8 @@ workflow cellbender_example {
   # Run CellBender remove-background on the test sample (CPU-only for CI)
   call ww_cellbender.remove_background { input:
     input_h5 = download_raw_h5.raw_h5_matrix,
-    sample_name = "2500_Wistar_Rat_PBMCs_Singleplex",
-    expected_cells = 2500,
+    sample_name = "pbmc_10k_v3",
+    expected_cells = 10000,
     epochs = 150,
     gpu_enabled = false,
     cpu_cores = 4,

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -24,13 +24,13 @@ workflow cellbender_example {
   }
 
   output {
-    File output_h5         = remove_background.output_h5
-    File filtered_h5       = remove_background.filtered_h5
-    File report_html       = remove_background.report_html
-    File summary_pdf       = remove_background.summary_pdf
-    File log_file          = remove_background.log_file
+    File output_h5 = remove_background.output_h5
+    File filtered_h5 = remove_background.filtered_h5
+    File report_html = remove_background.report_html
+    File summary_pdf = remove_background.summary_pdf
+    File log_file = remove_background.log_file
     File cell_barcodes_csv = remove_background.cell_barcodes_csv
-    File metrics_csv       = remove_background.metrics_csv
-    File checkpoint_tar    = remove_background.checkpoint_tar
+    File metrics_csv = remove_background.metrics_csv
+    File checkpoint_tar = remove_background.checkpoint_tar
   }
 }

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module under test and testdata module using relative paths for local linting/testing
-import "ww-cellbender.wdl" as ww_cellbender
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-cellbender/ww-cellbender.wdl" as ww_cellbender
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 
@@ -17,7 +17,7 @@ workflow cellbender_example {
     sample_name = "pbmc_10k_v3",
     expected_cells = 500,
     total_droplets_included = 5000,
-    epochs = 150,
+    epochs = 10,
     epoch_elbo_fail_fraction = 1.0,
     final_elbo_fail_fraction = 1.0,
     gpu_enabled = false,

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -19,6 +19,7 @@ workflow cellbender_example {
     expected_cells = 500,
     total_droplets_included = 5000,
     epochs = 10,
+    checkpoint_mins = 0.1,
     gpu_enabled = false,
     cpu_cores = 4,
     memory_gb = 8

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -11,15 +11,13 @@ workflow cellbender_example {
   call ww_testdata.download_10x_raw_h5_data as download_raw_h5 { }
 
   # Run CellBender remove-background on the test sample (CPU-only for CI).
-  # epochs and total_droplets_included are deliberately small to keep
-  # runtime under the 6-hour GitHub Actions limit on CPU.
+  # total_droplets_included caps the barcode count to keep runtime manageable.
   call ww_cellbender.remove_background { input:
     input_h5 = download_raw_h5.raw_h5_matrix,
     sample_name = "pbmc_10k_v3",
     expected_cells = 500,
     total_droplets_included = 5000,
-    epochs = 10,
-    checkpoint_mins = 0.1,
+    epochs = 150,
     gpu_enabled = false,
     cpu_cores = 4,
     memory_gb = 8

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -18,8 +18,6 @@ workflow cellbender_example {
     expected_cells = 500,
     total_droplets_included = 5000,
     epochs = 10,
-    epoch_elbo_fail_fraction = 1.0,
-    final_elbo_fail_fraction = 1.0,
     gpu_enabled = false,
     cpu_cores = 4,
     memory_gb = 8

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -10,12 +10,15 @@ workflow cellbender_example {
   # Download a 10x raw feature-barcode matrix for testing
   call ww_testdata.download_10x_raw_h5_data as download_raw_h5 { }
 
-  # Run CellBender remove-background on the test sample (CPU-only for CI)
+  # Run CellBender remove-background on the test sample (CPU-only for CI).
+  # epochs and total_droplets_included are deliberately small to keep
+  # runtime under the 6-hour GitHub Actions limit on CPU.
   call ww_cellbender.remove_background { input:
     input_h5 = download_raw_h5.raw_h5_matrix,
     sample_name = "pbmc_10k_v3",
-    expected_cells = 10000,
-    epochs = 150,
+    expected_cells = 500,
+    total_droplets_included = 5000,
+    epochs = 10,
     gpu_enabled = false,
     cpu_cores = 4,
     memory_gb = 8

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module under test and testdata module using relative paths for local linting/testing
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-cellbender/ww-cellbender.wdl" as ww_cellbender
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-cellbender/ww-cellbender.wdl" as ww_cellbender
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -1,0 +1,34 @@
+version 1.0
+
+# Import module under test and testdata module using relative paths for local linting/testing
+import "ww-cellbender.wdl" as ww_cellbender
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+
+#### TEST WORKFLOW DEFINITION ####
+
+workflow cellbender_example {
+  # Download a 10x raw feature-barcode matrix for testing
+  call ww_testdata.download_10x_raw_h5_data as download_raw_h5 { }
+
+  # Run CellBender remove-background on the test sample (CPU-only for CI)
+  call ww_cellbender.remove_background { input:
+    input_h5 = download_raw_h5.raw_h5_matrix,
+    sample_name = "2500_Wistar_Rat_PBMCs_Singleplex",
+    expected_cells = 2500,
+    epochs = 150,
+    gpu_enabled = false,
+    cpu_cores = 4,
+    memory_gb = 32
+  }
+
+  output {
+    File output_h5         = remove_background.output_h5
+    File filtered_h5       = remove_background.filtered_h5
+    File report_html       = remove_background.report_html
+    File summary_pdf       = remove_background.summary_pdf
+    File log_file          = remove_background.log_file
+    File cell_barcodes_csv = remove_background.cell_barcodes_csv
+    File metrics_csv       = remove_background.metrics_csv
+    File checkpoint_tar    = remove_background.checkpoint_tar
+  }
+}

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -18,7 +18,7 @@ workflow cellbender_example {
     epochs = 150,
     gpu_enabled = false,
     cpu_cores = 4,
-    memory_gb = 32
+    memory_gb = 8
   }
 
   output {

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -18,6 +18,8 @@ workflow cellbender_example {
     expected_cells = 500,
     total_droplets_included = 5000,
     epochs = 150,
+    epoch_elbo_fail_fraction = 1.0,
+    final_elbo_fail_fraction = 1.0,
     gpu_enabled = false,
     cpu_cores = 4,
     memory_gb = 8

--- a/modules/ww-cellbender/testrun_hpc.wdl
+++ b/modules/ww-cellbender/testrun_hpc.wdl
@@ -24,13 +24,13 @@ workflow cellbender_example {
   }
 
   output {
-    File output_h5         = remove_background.output_h5
-    File filtered_h5       = remove_background.filtered_h5
-    File report_html       = remove_background.report_html
-    File summary_pdf       = remove_background.summary_pdf
-    File log_file          = remove_background.log_file
+    File output_h5 = remove_background.output_h5
+    File filtered_h5 = remove_background.filtered_h5
+    File report_html = remove_background.report_html
+    File summary_pdf = remove_background.summary_pdf
+    File log_file = remove_background.log_file
     File cell_barcodes_csv = remove_background.cell_barcodes_csv
-    File metrics_csv       = remove_background.metrics_csv
-    File checkpoint_tar    = remove_background.checkpoint_tar
+    File metrics_csv = remove_background.metrics_csv
+    File checkpoint_tar = remove_background.checkpoint_tar
   }
 }

--- a/modules/ww-cellbender/testrun_hpc.wdl
+++ b/modules/ww-cellbender/testrun_hpc.wdl
@@ -1,0 +1,36 @@
+version 1.0
+
+# HPC variant of the CellBender testrun. Runs remove-background with GPU enabled.
+# Uses the same test data as testrun.wdl; the only difference is gpu_enabled = true,
+# which adds --cuda to the CellBender command and requests 1 GPU in the runtime block.
+import "ww-cellbender.wdl" as ww_cellbender
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+
+#### TEST WORKFLOW DEFINITION ####
+
+workflow cellbender_example {
+  # Download a 10x raw feature-barcode matrix for testing
+  call ww_testdata.download_10x_raw_h5_data as download_raw_h5 { }
+
+  # Run CellBender remove-background with GPU acceleration
+  call ww_cellbender.remove_background { input:
+    input_h5 = download_raw_h5.raw_h5_matrix,
+    sample_name = "2500_Wistar_Rat_PBMCs_Singleplex",
+    expected_cells = 2500,
+    epochs = 150,
+    gpu_enabled = true,
+    cpu_cores = 4,
+    memory_gb = 32
+  }
+
+  output {
+    File output_h5         = remove_background.output_h5
+    File filtered_h5       = remove_background.filtered_h5
+    File report_html       = remove_background.report_html
+    File summary_pdf       = remove_background.summary_pdf
+    File log_file          = remove_background.log_file
+    File cell_barcodes_csv = remove_background.cell_barcodes_csv
+    File metrics_csv       = remove_background.metrics_csv
+    File checkpoint_tar    = remove_background.checkpoint_tar
+  }
+}

--- a/modules/ww-cellbender/testrun_hpc.wdl
+++ b/modules/ww-cellbender/testrun_hpc.wdl
@@ -15,8 +15,8 @@ workflow cellbender_example {
   # Run CellBender remove-background with GPU acceleration
   call ww_cellbender.remove_background { input:
     input_h5 = download_raw_h5.raw_h5_matrix,
-    sample_name = "2500_Wistar_Rat_PBMCs_Singleplex",
-    expected_cells = 2500,
+    sample_name = "pbmc_10k_v3",
+    expected_cells = 10000,
     epochs = 150,
     gpu_enabled = true,
     cpu_cores = 4,

--- a/modules/ww-cellbender/testrun_hpc.wdl
+++ b/modules/ww-cellbender/testrun_hpc.wdl
@@ -3,8 +3,8 @@ version 1.0
 # HPC variant of the CellBender testrun. Runs remove-background with GPU enabled.
 # Uses the same test data as testrun.wdl; the only difference is gpu_enabled = true,
 # which adds --cuda to the CellBender command and requests 1 GPU in the runtime block.
-import "ww-cellbender.wdl" as ww_cellbender
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-cellbender/ww-cellbender.wdl" as ww_cellbender
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-cellbender/testrun_hpc.wdl
+++ b/modules/ww-cellbender/testrun_hpc.wdl
@@ -3,8 +3,8 @@ version 1.0
 # HPC variant of the CellBender testrun. Runs remove-background with GPU enabled.
 # Uses the same test data as testrun.wdl; the only difference is gpu_enabled = true,
 # which adds --cuda to the CellBender command and requests 1 GPU in the runtime block.
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-cellbender/ww-cellbender.wdl" as ww_cellbender
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-cellbender/ww-cellbender.wdl" as ww_cellbender
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-cellbender/ww-cellbender.wdl
+++ b/modules/ww-cellbender/ww-cellbender.wdl
@@ -46,6 +46,9 @@ task remove_background {
     low_count_threshold: "Droplets with total UMI count below this value are excluded from analysis"
     exclude_feature_types: "Optional space-separated list of feature types to exclude (e.g. 'Antibody Capture')"
     checkpoint_mins: "How frequently (in minutes) to save a training checkpoint; default matches CellBender's built-in default of 7 minutes"
+    epoch_elbo_fail_fraction: "Optional fraction of initial ELBO loss at which a per-epoch ELBO is considered a failure and triggers a training retry; set to 1.0 to disable per-epoch early stopping"
+    final_elbo_fail_fraction: "Optional fraction of initial ELBO loss at which the final ELBO is considered a failure and triggers a training retry; set to 1.0 to disable final-ELBO early stopping"
+    num_training_tries: "Number of times to attempt training if ELBO failures occur (default: CellBender uses 1)"
     gpu_enabled: "Enable GPU acceleration (adds --cuda flag and requests 1 GPU in runtime); set to false for CPU-only execution"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
@@ -64,6 +67,9 @@ task remove_background {
     Int low_count_threshold = 5
     String? exclude_feature_types
     Float checkpoint_mins = 7.0
+    Float? epoch_elbo_fail_fraction
+    Float? final_elbo_fail_fraction
+    Int? num_training_tries
     Boolean gpu_enabled = true
     Int cpu_cores = 4
     Int memory_gb = 32
@@ -85,6 +91,9 @@ task remove_background {
       ~{"--total-droplets-included " + total_droplets_included} \
       ~{"--exclude-feature-types " + exclude_feature_types} \
       --checkpoint-mins ~{checkpoint_mins} \
+      ~{"--epoch-elbo-fail-fraction " + epoch_elbo_fail_fraction} \
+      ~{"--final-elbo-fail-fraction " + final_elbo_fail_fraction} \
+      ~{"--num-training-tries " + num_training_tries} \
       ~{if gpu_enabled then "--cuda" else ""} \
       --cpu-threads ~{cpu_cores}
   >>>

--- a/modules/ww-cellbender/ww-cellbender.wdl
+++ b/modules/ww-cellbender/ww-cellbender.wdl
@@ -45,6 +45,7 @@ task remove_background {
     model: "CellBender model variant: naive, simple, ambient, swapping, or full"
     low_count_threshold: "Droplets with total UMI count below this value are excluded from analysis"
     exclude_feature_types: "Optional space-separated list of feature types to exclude (e.g. 'Antibody Capture')"
+    checkpoint_mins: "How frequently (in minutes) to save a training checkpoint; default matches CellBender's built-in default of 7 minutes"
     gpu_enabled: "Enable GPU acceleration (adds --cuda flag and requests 1 GPU in runtime); set to false for CPU-only execution"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
@@ -62,6 +63,7 @@ task remove_background {
     String model = "full"
     Int low_count_threshold = 5
     String? exclude_feature_types
+    Float checkpoint_mins = 7.0
     Boolean gpu_enabled = true
     Int cpu_cores = 4
     Int memory_gb = 32
@@ -82,6 +84,7 @@ task remove_background {
       ~{"--expected-cells " + expected_cells} \
       ~{"--total-droplets-included " + total_droplets_included} \
       ~{"--exclude-feature-types " + exclude_feature_types} \
+      --checkpoint-mins ~{checkpoint_mins} \
       ~{if gpu_enabled then "--cuda" else ""} \
       --cpu-threads ~{cpu_cores}
   >>>

--- a/modules/ww-cellbender/ww-cellbender.wdl
+++ b/modules/ww-cellbender/ww-cellbender.wdl
@@ -30,7 +30,7 @@ task remove_background {
     input_sample_optional: "none"
     input_reference_required: "none"
     input_reference_optional: "none"
-    output_sample: "output_h5:gene_expression_matrix:h5,filtered_h5:gene_expression_matrix:h5,report_html:quality_control_report:html,summary_pdf:plot:pdf,cell_barcodes_csv:gene_report:csv,metrics_csv:gene_report:csv"
+    output_sample: "output_h5:gene_expression_matrix:h5,filtered_h5:gene_expression_matrix:h5,report_html:quality_control_report:html,summary_pdf:plot:pdf,log_file:report:textual_format,cell_barcodes_csv:gene_report:csv,metrics_csv:gene_report:csv,checkpoint_tar:mathematical_model:tar_format"
     output_reference: "none"
   }
 

--- a/modules/ww-cellbender/ww-cellbender.wdl
+++ b/modules/ww-cellbender/ww-cellbender.wdl
@@ -90,14 +90,14 @@ task remove_background {
   >>>
 
   output {
-    File output_h5             = "~{sample_name}_out.h5"
-    File filtered_h5           = "~{sample_name}_out_filtered.h5"
-    File report_html           = "~{sample_name}_out_report.html"
-    File summary_pdf           = "~{sample_name}_out.pdf"
-    File log_file              = "~{sample_name}_out.log"
-    File cell_barcodes_csv     = "~{sample_name}_out_cell_barcodes.csv"
-    File metrics_csv           = "~{sample_name}_out_metrics.csv"
-    File checkpoint_tar        = "ckpt.tar.gz"
+    File output_h5 = "~{sample_name}_out.h5"
+    File filtered_h5 = "~{sample_name}_out_filtered.h5"
+    File report_html = "~{sample_name}_out_report.html"
+    File summary_pdf = "~{sample_name}_out.pdf"
+    File log_file = "~{sample_name}_out.log"
+    File cell_barcodes_csv = "~{sample_name}_out_cell_barcodes.csv"
+    File metrics_csv = "~{sample_name}_out_metrics.csv"
+    File checkpoint_tar = "ckpt.tar.gz"
   }
 
   runtime {

--- a/modules/ww-cellbender/ww-cellbender.wdl
+++ b/modules/ww-cellbender/ww-cellbender.wdl
@@ -46,9 +46,6 @@ task remove_background {
     low_count_threshold: "Droplets with total UMI count below this value are excluded from analysis"
     exclude_feature_types: "Optional space-separated list of feature types to exclude (e.g. 'Antibody Capture')"
     checkpoint_mins: "How frequently (in minutes) to save a training checkpoint; default matches CellBender's built-in default of 7 minutes"
-    epoch_elbo_fail_fraction: "Optional fraction of initial ELBO loss at which a per-epoch ELBO is considered a failure and triggers a training retry; set to 1.0 to disable per-epoch early stopping"
-    final_elbo_fail_fraction: "Optional fraction of initial ELBO loss at which the final ELBO is considered a failure and triggers a training retry; set to 1.0 to disable final-ELBO early stopping"
-    num_training_tries: "Number of times to attempt training if ELBO failures occur (default: CellBender uses 1)"
     gpu_enabled: "Enable GPU acceleration (adds --cuda flag and requests 1 GPU in runtime); set to false for CPU-only execution"
     cpu_cores: "Number of CPU cores allocated for the task"
     memory_gb: "Memory allocated for the task in GB"
@@ -67,9 +64,6 @@ task remove_background {
     Int low_count_threshold = 5
     String? exclude_feature_types
     Float checkpoint_mins = 7.0
-    Float? epoch_elbo_fail_fraction
-    Float? final_elbo_fail_fraction
-    Int? num_training_tries
     Boolean gpu_enabled = true
     Int cpu_cores = 4
     Int memory_gb = 32
@@ -91,9 +85,6 @@ task remove_background {
       ~{"--total-droplets-included " + total_droplets_included} \
       ~{"--exclude-feature-types " + exclude_feature_types} \
       --checkpoint-mins ~{checkpoint_mins} \
-      ~{"--epoch-elbo-fail-fraction " + epoch_elbo_fail_fraction} \
-      ~{"--final-elbo-fail-fraction " + final_elbo_fail_fraction} \
-      ~{"--num-training-tries " + num_training_tries} \
       ~{if gpu_enabled then "--cuda" else ""} \
       --cpu-threads ~{cpu_cores}
   >>>

--- a/modules/ww-cellbender/ww-cellbender.wdl
+++ b/modules/ww-cellbender/ww-cellbender.wdl
@@ -1,0 +1,106 @@
+## WILDS WDL Module: ww-cellbender
+## Description: Module for removing ambient RNA and barcode swapping from single-cell RNA-seq data using CellBender.
+## CellBender's remove-background command uses a deep generative model to separate
+## real cell signal from technical artifacts in UMI-based scRNA-seq, snRNA-seq, and CITE-seq data.
+
+version 1.0
+
+#### TASK DEFINITIONS ####
+
+task remove_background {
+  meta {
+    author: "WILDS Team"
+    email: "wilds@fredhutch.org"
+    description: "Remove ambient RNA contamination and barcode swapping artifacts from a 10x Genomics raw feature-barcode matrix using CellBender remove-background"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellbender/ww-cellbender.wdl"
+    outputs: {
+        output_h5: "Full cleaned count matrix in H5 format (all input barcodes retained)",
+        filtered_h5: "Filtered cleaned count matrix containing only barcodes with >50% cell probability",
+        report_html: "Interactive HTML report with training diagnostics and quality plots",
+        summary_pdf: "PDF summary of the inference procedure",
+        log_file: "Run log with diagnostics and parameter summary",
+        cell_barcodes_csv: "Plain-text list of cell barcodes exceeding 50% cell probability threshold",
+        metrics_csv: "Run metrics CSV (one row per FPR value)",
+        checkpoint_tar: "Trained model checkpoint tarball (can be used to resume or inspect training)"
+    }
+    topic: "transcriptomics,single_cell"
+    species: "human,mouse,eukaryote"
+    operation: "data_handling"
+    input_sample_required: "input_h5:gene_expression_matrix:h5"
+    input_sample_optional: "none"
+    input_reference_required: "none"
+    input_reference_optional: "none"
+    output_sample: "output_h5:gene_expression_matrix:h5,filtered_h5:gene_expression_matrix:h5,report_html:quality_control_report:html,summary_pdf:plot:pdf,cell_barcodes_csv:gene_report:csv,metrics_csv:gene_report:csv"
+    output_reference: "none"
+  }
+
+  parameter_meta {
+    input_h5: "Raw feature-barcode matrix HDF5 file from Cell Ranger (raw_feature_bc_matrix.h5)"
+    sample_name: "Sample name used as output file prefix"
+    expected_cells: "Optional estimated number of real cells in the sample; helps CellBender set priors"
+    total_droplets_included: "Optional total number of droplets to include in the analysis (raw barcodes ranked by UMI count); defaults to CellBender auto-selection"
+    fpr: "False positive rate target(s) for the output matrix, space-separated if multiple (e.g. '0.01 0.05')"
+    epochs: "Number of training epochs"
+    learning_rate: "Base learning rate for the variational inference optimizer"
+    model: "CellBender model variant: naive, simple, ambient, swapping, or full"
+    low_count_threshold: "Droplets with total UMI count below this value are excluded from analysis"
+    exclude_feature_types: "Optional space-separated list of feature types to exclude (e.g. 'Antibody Capture')"
+    gpu_enabled: "Enable GPU acceleration (adds --cuda flag and requests 1 GPU in runtime); set to false for CPU-only execution"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    File input_h5
+    String sample_name
+    Int? expected_cells
+    Int? total_droplets_included
+    String fpr = "0.01"
+    Int epochs = 150
+    Float learning_rate = 0.0001
+    String model = "full"
+    Int low_count_threshold = 5
+    String? exclude_feature_types
+    Boolean gpu_enabled = true
+    Int cpu_cores = 4
+    Int memory_gb = 32
+    String docker_image = "getwilds/cellbender:0.3.2"
+  }
+
+  command <<<
+    set -eo pipefail
+
+    cellbender remove-background \
+      --input "~{input_h5}" \
+      --output "~{sample_name}_out.h5" \
+      --model ~{model} \
+      --epochs ~{epochs} \
+      --learning-rate ~{learning_rate} \
+      --fpr ~{fpr} \
+      --low-count-threshold ~{low_count_threshold} \
+      ~{"--expected-cells " + expected_cells} \
+      ~{"--total-droplets-included " + total_droplets_included} \
+      ~{"--exclude-feature-types " + exclude_feature_types} \
+      ~{if gpu_enabled then "--cuda" else ""} \
+      --cpu-threads ~{cpu_cores}
+  >>>
+
+  output {
+    File output_h5             = "~{sample_name}_out.h5"
+    File filtered_h5           = "~{sample_name}_out_filtered.h5"
+    File report_html           = "~{sample_name}_out_report.html"
+    File summary_pdf           = "~{sample_name}_out.pdf"
+    File log_file              = "~{sample_name}_out.log"
+    File cell_barcodes_csv     = "~{sample_name}_out_cell_barcodes.csv"
+    File metrics_csv           = "~{sample_name}_out_metrics.csv"
+    File checkpoint_tar        = "ckpt.tar.gz"
+  }
+
+  runtime {
+    docker: docker_image
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+    gpus: if gpu_enabled then "1" else "0"
+  }
+}

--- a/modules/ww-cellranger/README.md
+++ b/modules/ww-cellranger/README.md
@@ -87,6 +87,7 @@ Run `cellranger count` on gene expression reads from one GEM well using a privat
 - `web_summary` (File?): Web summary HTML file with QC metrics. Absent when the sample was skipped.
 - `metrics_summary` (File?): Metrics summary CSV file with key statistics. Absent when the sample was skipped.
 - `filtered_h5` (File?): Filtered feature-barcode matrix HDF5 file. Absent when the sample was skipped.
+- `raw_h5` (File?): Raw feature-barcode matrix HDF5 file. Absent when the sample was skipped.
 
 ### Graceful chemistry-detection skip
 
@@ -181,6 +182,7 @@ workflow my_single_cell_pipeline {
     File web_summary = run_count.web_summary
     File metrics = run_count.metrics_summary
     File filtered_h5 = run_count.filtered_h5
+    File raw_h5 = run_count.raw_h5
   }
 }
 ```

--- a/modules/ww-cellranger/testrun.wdl
+++ b/modules/ww-cellranger/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/run-selector-input/modules/ww-cellranger/ww-cellranger.wdl" as ww_cellranger
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-cellranger/ww-cellranger.wdl" as ww_cellranger
 
 workflow cellranger_example {
 

--- a/modules/ww-cellranger/ww-cellranger.wdl
+++ b/modules/ww-cellranger/ww-cellranger.wdl
@@ -14,7 +14,8 @@ task run_count {
         results_tar: "Compressed tarball of Cell Ranger count output directory (absent if skipped)",
         web_summary: "Web summary HTML file (absent if skipped)",
         metrics_summary: "Metrics summary CSV file (absent if skipped)",
-        filtered_h5: "Filtered feature-barcode matrix HDF5 file (absent if skipped)"
+        filtered_h5: "Filtered feature-barcode matrix HDF5 file (absent if skipped)",
+        raw_h5: "Raw feature-barcode matrix HDF5 file (absent if skipped)"
     }
     topic: "transcriptomics,gene_expression,single_cell_sequencing"
     species: "human,eukaryote,prokaryote,virus"
@@ -23,7 +24,7 @@ task run_count {
     input_sample_optional: "none"
     input_reference_required: "ref_gex:data_index:tar_format"
     input_reference_optional: "none"
-    output_sample: "results_tar:gene_expression_matrix:tar_format,web_summary:quality_control_report:html,metrics_summary:quality_control_report:csv,filtered_h5:gene_expression_matrix:h5"
+    output_sample: "results_tar:gene_expression_matrix:tar_format,web_summary:quality_control_report:html,metrics_summary:quality_control_report:csv,filtered_h5:gene_expression_matrix:h5,raw_h5:gene_expression_matrix:h5"
     output_reference: "none"
   }
 
@@ -160,6 +161,7 @@ task run_count {
     mv "~{sample_id}/outs/web_summary.html" "~{sample_id}_web_summary.html"
     mv "~{sample_id}/outs/metrics_summary.csv" "~{sample_id}_metrics_summary.csv"
     mv "~{sample_id}/outs/filtered_feature_bc_matrix.h5" "~{sample_id}_filtered_feature_bc_matrix.h5"
+    mv "~{sample_id}/outs/raw_feature_bc_matrix.h5" "~{sample_id}_raw_feature_bc_matrix.h5"
 
     # Clean up Cell Ranger output directory for housekeeping
     # (and to avoid Sprocket symlink validation errors)
@@ -172,6 +174,7 @@ task run_count {
     File? web_summary = "~{sample_id}_web_summary.html"
     File? metrics_summary = "~{sample_id}_metrics_summary.csv"
     File? filtered_h5 = "~{sample_id}_filtered_feature_bc_matrix.h5"
+    File? raw_h5 = "~{sample_id}_raw_feature_bc_matrix.h5"
   }
 
   runtime {
@@ -192,7 +195,8 @@ task run_count_hpc_cromwell {
         results_tar: "Compressed tarball of Cell Ranger count output directory (absent if skipped)",
         web_summary: "Web summary HTML file (absent if skipped)",
         metrics_summary: "Metrics summary CSV file (absent if skipped)",
-        filtered_h5: "Filtered feature-barcode matrix HDF5 file (absent if skipped)"
+        filtered_h5: "Filtered feature-barcode matrix HDF5 file (absent if skipped)",
+        raw_h5: "Raw feature-barcode matrix HDF5 file (absent if skipped)"
     }
   }
 
@@ -333,6 +337,7 @@ task run_count_hpc_cromwell {
     mv "~{sample_id}/outs/web_summary.html" "~{sample_id}_web_summary.html"
     mv "~{sample_id}/outs/metrics_summary.csv" "~{sample_id}_metrics_summary.csv"
     mv "~{sample_id}/outs/filtered_feature_bc_matrix.h5" "~{sample_id}_filtered_feature_bc_matrix.h5"
+    mv "~{sample_id}/outs/raw_feature_bc_matrix.h5" "~{sample_id}_raw_feature_bc_matrix.h5"
 
     # Clean up Cell Ranger output directory for housekeeping
     # (and to avoid Sprocket symlink validation errors)
@@ -345,6 +350,7 @@ task run_count_hpc_cromwell {
     File? web_summary = "~{sample_id}_web_summary.html"
     File? metrics_summary = "~{sample_id}_metrics_summary.csv"
     File? filtered_h5 = "~{sample_id}_filtered_feature_bc_matrix.h5"
+    File? raw_h5 = "~{sample_id}_raw_feature_bc_matrix.h5"
   }
 
   # No docker/container runtime key: Cromwell's HPC backend runs this
@@ -367,7 +373,8 @@ task run_count_hpc_sprocket {
         results_tar: "Compressed tarball of Cell Ranger count output directory (absent if skipped)",
         web_summary: "Web summary HTML file (absent if skipped)",
         metrics_summary: "Metrics summary CSV file (absent if skipped)",
-        filtered_h5: "Filtered feature-barcode matrix HDF5 file (absent if skipped)"
+        filtered_h5: "Filtered feature-barcode matrix HDF5 file (absent if skipped)",
+        raw_h5: "Raw feature-barcode matrix HDF5 file (absent if skipped)"
     }
   }
 
@@ -512,6 +519,7 @@ task run_count_hpc_sprocket {
     mv "~{sample_id}/outs/web_summary.html" "~{sample_id}_web_summary.html"
     mv "~{sample_id}/outs/metrics_summary.csv" "~{sample_id}_metrics_summary.csv"
     mv "~{sample_id}/outs/filtered_feature_bc_matrix.h5" "~{sample_id}_filtered_feature_bc_matrix.h5"
+    mv "~{sample_id}/outs/raw_feature_bc_matrix.h5" "~{sample_id}_raw_feature_bc_matrix.h5"
 
     # Clean up Cell Ranger output directory for housekeeping
     # (and to avoid Sprocket symlink validation errors)
@@ -524,6 +532,7 @@ task run_count_hpc_sprocket {
     File? web_summary = "~{sample_id}_web_summary.html"
     File? metrics_summary = "~{sample_id}_metrics_summary.csv"
     File? filtered_h5 = "~{sample_id}_filtered_feature_bc_matrix.h5"
+    File? raw_h5 = "~{sample_id}_raw_feature_bc_matrix.h5"
   }
 
   # Minimal Lua-having container so the host's bind-mounted Lmod can

--- a/modules/ww-testdata/README.md
+++ b/modules/ww-testdata/README.md
@@ -21,7 +21,7 @@ Rather than maintaining large static test datasets, `ww-testdata` enables:
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
 
-- **Tasks**: `download_ref_data`, `merge_fastas_with_prefix`, `download_rrna_reference`, `download_fastq_data`, `download_test_transcriptome`, `interleave_fastq`, `download_cram_data`, `download_bam_data`, `inject_synthetic_umis`, `download_ichor_data`, `download_tritonnp_data`, `download_dbsnp_vcf`, `download_known_indels_vcf`, `download_gnomad_vcf`, `download_annotsv_vcf`, `generate_pasilla_counts`, `create_clean_amplicon_reference`, `create_gdc_manifest`, `download_shapemapper_data`, `download_test_cellranger_ref`, `download_10x_h5_data`, `create_diamond_data`, `create_test_protein_fasta`, `create_test_idp_fasta`, `download_glimpse2_genetic_map`, `download_glimpse2_reference_panel`, `download_glimpse2_test_gl_vcf`, `download_glimpse2_truth_vcf`, `generate_sjl_data`, `download_jcast_test_data`, `download_pao1_ref`
+- **Tasks**: `download_ref_data`, `merge_fastas_with_prefix`, `download_rrna_reference`, `download_fastq_data`, `download_test_transcriptome`, `interleave_fastq`, `download_cram_data`, `download_bam_data`, `inject_synthetic_umis`, `download_ichor_data`, `download_tritonnp_data`, `download_dbsnp_vcf`, `download_known_indels_vcf`, `download_gnomad_vcf`, `download_annotsv_vcf`, `generate_pasilla_counts`, `create_clean_amplicon_reference`, `create_gdc_manifest`, `download_shapemapper_data`, `download_test_cellranger_ref`, `download_10x_h5_data`, `download_10x_raw_h5_data`, `create_diamond_data`, `create_test_protein_fasta`, `create_test_idp_fasta`, `download_glimpse2_genetic_map`, `download_glimpse2_reference_panel`, `download_glimpse2_test_gl_vcf`, `download_glimpse2_truth_vcf`, `generate_sjl_data`, `download_jcast_test_data`, `download_pao1_ref`
 - **Test workflow**: `testrun.wdl` (demonstration workflow that executes all tasks)
 
 ## Usage
@@ -57,7 +57,7 @@ The `testrun.wdl` workflow requires no input parameters and automatically downlo
 
 - **Chromosome**: chr1 only (for efficient testing)
 - **Reference version**: hg38 (latest standard)
-- **All test data types**: Reference genome, transcriptome, FASTQ, interleaved FASTQ, CRAM, BAM, ichorCNA files, VCF files (dbSNP, known indels, gnomAD, AnnotSV), Pasilla counts, ShapeMapper data, Cell Ranger reference, 10X H5 matrix, DIAMOND data, test protein FASTA, GLIMPSE2 imputation data, and JCAST rMATS test data
+- **All test data types**: Reference genome, transcriptome, FASTQ, interleaved FASTQ, CRAM, BAM, ichorCNA files, VCF files (dbSNP, known indels, gnomAD, AnnotSV), Pasilla counts, ShapeMapper data, Cell Ranger reference, 10X filtered and raw H5 matrices, DIAMOND data, test protein FASTA, GLIMPSE2 imputation data, and JCAST rMATS test data
 
 ### Running the Test Workflow
 
@@ -621,6 +621,34 @@ call seurat_tasks.seurat_analysis {
 }
 ```
 
+### download_10x_raw_h5_data
+
+Downloads a 10X Genomics example raw (unfiltered) feature-barcode matrix in HDF5 format (2,500 Wistar Rat PBMCs, Singleplex, Cell Ranger 9.0.0).
+
+**Use Case**: When testing ambient RNA removal tools (e.g., CellBender) that require the unfiltered Cell Ranger output, you need the raw matrix rather than the filtered one. The raw matrix includes all detected barcodes -- empty droplets and cells alike -- which is the input format these tools expect.
+
+**Inputs**:
+- `sample_name` (String): Output filename prefix (default: "2500_Wistar_Rat_PBMCs_Singleplex")
+- `cpu_cores` (Int): CPU allocation (default: 1)
+- `memory_gb` (Int): Memory allocation (default: 2)
+- `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
+
+**Outputs**:
+- `raw_h5_matrix` (File): Raw feature-barcode matrix in HDF5 format (`<sample_name>_raw_feature_bc_matrix.h5`)
+
+**Data Source**: https://www.10xgenomics.com/datasets/2500-wistar-rat-pbmcs-singleplex-3p-gem-x-universal-protocol
+
+**Example Usage**:
+```wdl
+call testdata.download_10x_raw_h5_data { }
+call cellbender_tasks.remove_background {
+  input:
+    input_h5 = download_10x_raw_h5_data.raw_h5_matrix,
+    sample_name = "rat_pbmcs",
+    expected_cells = 2500
+}
+```
+
 ### create_diamond_data
 
 Downloads E. coli Swiss-Prot reference proteome and creates a small subset for testing DIAMOND protein alignment workflows.
@@ -927,7 +955,8 @@ This module is specifically designed to support other WILDS modules:
 - **ww-sjl / ww-jetlag**: Solar Jetlag tile processing (uses synthetic tile and border points from `generate_sjl_data`)
 - **ww-jcast**: Alternative splicing proteomics (uses rMATS test data from `download_jcast_test_data`)
 - **ww-umi-tools**: UMI-aware deduplication (uses synthetic UMI-tagged BAMs from `inject_synthetic_umis` for zero-config testing)
-- **ww-seurat**: Single-cell RNA-seq analysis (uses 10X H5 matrix from `download_10x_h5_data`)
+- **ww-seurat**: Single-cell RNA-seq analysis (uses 10X filtered H5 matrix from `download_10x_h5_data`)
+- **ww-cellbender**: Ambient RNA removal from scRNA-seq data (uses 10X raw H5 matrix from `download_10x_raw_h5_data`)
 - **Variant calling workflows**: GATK best practices (requires dbSNP, known indels, gnomAD)
 
 By centralizing test data downloads, `ww-testdata` enables:

--- a/modules/ww-testdata/README.md
+++ b/modules/ww-testdata/README.md
@@ -623,12 +623,12 @@ call seurat_tasks.seurat_analysis {
 
 ### download_10x_raw_h5_data
 
-Downloads a 10X Genomics example raw (unfiltered) feature-barcode matrix in HDF5 format (2,500 Wistar Rat PBMCs, Singleplex, Cell Ranger 9.0.0).
+Downloads a 10X Genomics example raw (unfiltered) feature-barcode matrix in HDF5 format (10k human PBMCs, v3 chemistry, Cell Ranger 3.0.0, ~168 MB).
 
 **Use Case**: When testing ambient RNA removal tools (e.g., CellBender) that require the unfiltered Cell Ranger output, you need the raw matrix rather than the filtered one. The raw matrix includes all detected barcodes -- empty droplets and cells alike -- which is the input format these tools expect.
 
 **Inputs**:
-- `sample_name` (String): Output filename prefix (default: "2500_Wistar_Rat_PBMCs_Singleplex")
+- `sample_name` (String): Output filename prefix (default: "pbmc_10k_v3")
 - `cpu_cores` (Int): CPU allocation (default: 1)
 - `memory_gb` (Int): Memory allocation (default: 2)
 - `docker_image` (String): Docker image to use for this task (default: `getwilds/awscli:2.27.49`)
@@ -636,7 +636,7 @@ Downloads a 10X Genomics example raw (unfiltered) feature-barcode matrix in HDF5
 **Outputs**:
 - `raw_h5_matrix` (File): Raw feature-barcode matrix in HDF5 format (`<sample_name>_raw_feature_bc_matrix.h5`)
 
-**Data Source**: https://www.10xgenomics.com/datasets/2500-wistar-rat-pbmcs-singleplex-3p-gem-x-universal-protocol
+**Data Source**: https://www.10xgenomics.com/datasets/10-k-pbm-cs-from-a-healthy-donor-v-3-chemistry-3-0-0
 
 **Example Usage**:
 ```wdl
@@ -644,8 +644,8 @@ call testdata.download_10x_raw_h5_data { }
 call cellbender_tasks.remove_background {
   input:
     input_h5 = download_10x_raw_h5_data.raw_h5_matrix,
-    sample_name = "rat_pbmcs",
-    expected_cells = 2500
+    sample_name = "pbmc_10k_v3",
+    expected_cells = 10000
 }
 ```
 

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -1998,9 +1998,9 @@ task download_10x_h5_data {
 
 task download_10x_raw_h5_data {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
-    description: "Downloads a 10X example raw feature-barcode matrix H5 file (2500 rat PBMCs). The raw matrix includes all barcodes detected, making it suitable as input to ambient RNA removal tools like CellBender."
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Downloads a 10X example raw feature-barcode matrix H5 file (10k human PBMCs, v3 chemistry, Cell Ranger 3.0.0). The raw matrix includes all detected barcodes, making it suitable as input to ambient RNA removal tools like CellBender."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
         raw_h5_matrix: "Raw feature-barcode matrix in HDF5 format (all detected barcodes, pre-filtering)"
@@ -2015,7 +2015,7 @@ task download_10x_raw_h5_data {
   }
 
   input {
-    String sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+    String sample_name = "pbmc_10k_v3"
     Int cpu_cores = 1
     Int memory_gb = 2
     String docker_image = "getwilds/awscli:2.27.49"
@@ -2025,7 +2025,7 @@ task download_10x_raw_h5_data {
     set -eo pipefail
 
     curl -L -o "~{sample_name}_raw_feature_bc_matrix.h5" \
-      "https://cf.10xgenomics.com/samples/cell-exp/9.0.0/2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal_2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal/2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal_2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal_count_sample_raw_feature_bc_matrix.h5"
+      "https://cf.10xgenomics.com/samples/cell-exp/3.0.0/pbmc_10k_v3/pbmc_10k_v3_raw_feature_bc_matrix.h5"
   >>>
 
   output {

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -1995,3 +1995,46 @@ task download_10x_h5_data {
     memory: "~{memory_gb} GB"
   }
 }
+
+task download_10x_raw_h5_data {
+  meta {
+    author: "WILDS Team"
+    email: "wilds@fredhutch.org"
+    description: "Downloads a 10X example raw feature-barcode matrix H5 file (2500 rat PBMCs). The raw matrix includes all barcodes detected, making it suitable as input to ambient RNA removal tools like CellBender."
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
+    outputs: {
+        raw_h5_matrix: "Raw feature-barcode matrix in HDF5 format (all detected barcodes, pre-filtering)"
+    }
+  }
+
+  parameter_meta {
+    sample_name: "Sample name used as the output filename prefix"
+    cpu_cores: "Number of CPU cores to use for downloading"
+    memory_gb: "Memory allocation in GB for the task"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    String sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+    Int cpu_cores = 1
+    Int memory_gb = 2
+    String docker_image = "getwilds/awscli:2.27.49"
+  }
+
+  command <<<
+    set -eo pipefail
+
+    curl -L -o "~{sample_name}_raw_feature_bc_matrix.h5" \
+      "https://cf.10xgenomics.com/samples/cell-exp/9.0.0/2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal_2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal/2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal_2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal_count_sample_raw_feature_bc_matrix.h5"
+  >>>
+
+  output {
+    File raw_h5_matrix = "~{sample_name}_raw_feature_bc_matrix.h5"
+  }
+
+  runtime {
+    docker: docker_image
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -136,6 +136,8 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `execution_mode` | Which Cell Ranger task to dispatch to: `"docker"`, `"hpc_cromwell"`, or `"hpc_sprocket"`. See [Cell Ranger Software Environment](#cell-ranger-software-environment). | String | No | `"docker"` |
 | `docker_image` | Private Cell Ranger Docker image used by `run_count`. Ignored unless `execution_mode = "docker"`. | String | No | `ghcr.io/getwilds/cellranger:10.0.0` |
 | `cellranger_module` | HPC environment module used by the `run_count_hpc_*` tasks. Ignored unless `execution_mode` starts with `hpc_`. | String | No | `CellRanger/10.0.0` |
+| `organize_results` | When true, package all Cell Ranger outputs into a ZIP archive organized by sample subdirectory. | Boolean | No | `false` |
+| `output_prefix` | Prefix for the organized results ZIP filename. | String | No | `cellranger_results` |
 
 ### Cell Ranger Reference
 
@@ -154,6 +156,7 @@ Cell Ranger requires a pre-built reference transcriptome tarball. You can:
 | `cellranger_metrics` | Metrics summary CSV files | ww-cellranger |
 | `cellranger_filtered_h5s` | Filtered feature-barcode matrix HDF5 files | ww-cellranger |
 | `cellranger_raw_h5s` | Raw feature-barcode matrix HDF5 files | ww-cellranger |
+| `organized_results` | ZIP archive of all outputs organized into per-sample subdirectories (absent unless `organize_results = true`) | pipeline |
 
 ### Mixed single-cell / non-single-cell input
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -71,7 +71,7 @@ Unused inputs are ignored — e.g., `docker_image` has no effect when `execution
 - WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
 - One of: Docker/Apptainer support with a private Cell Ranger image (default `execution_mode = "docker"`), a Cromwell-on-HPC backend that runs tasks directly on the compute node and provides Cell Ranger via Lmod (`execution_mode = "hpc_cromwell"`), or a Sprocket-on-HPC config that bind-mounts the host's Lmod and Cell Ranger software trees into the container (`execution_mode = "hpc_sprocket"`)
 - Internet access for SRA downloads
-- Sufficient compute resources for Cell Ranger (64GB+ RAM recommended)
+- Sufficient compute resources for Cell Ranger (64GB+ RAM recommended) and CellBender (32GB+ RAM; GPU strongly recommended, set `cellbender_gpu_enabled = false` for CPU-only)
 - **Platform**: Cell Ranger requires Linux x86_64 with AVX support (not compatible with Apple Silicon)
 
 ### Input Configuration
@@ -86,7 +86,9 @@ Create an inputs JSON file with your SRA accessions and Cell Ranger reference. P
   "sra_cellranger.memory_gb": 64,
   "sra_cellranger.execution_mode": "hpc_cromwell",
   "sra_cellranger.docker_image": "ghcr.io/getwilds/cellranger:10.0.0",
-  "sra_cellranger.cellranger_module": "CellRanger/10.0.0"
+  "sra_cellranger.cellranger_module": "CellRanger/10.0.0",
+  "sra_cellranger.cellbender_gpu_enabled": true,
+  "sra_cellranger.cellbender_expected_cells": 5000
 }
 ```
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -2,11 +2,11 @@
 [![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A WILDS WDL pipeline for downloading single-cell RNA-seq data from SRA and processing with Cell Ranger count.
+A WILDS WDL pipeline for downloading single-cell RNA-seq data from SRA, processing with Cell Ranger count, and removing ambient RNA with CellBender.
 
 ## Overview
 
-This pipeline combines the `ww-sra` and `ww-cellranger` modules to download scRNA-seq FASTQ data from NCBI's Sequence Read Archive and run Cell Ranger `count` for gene expression quantification. It supports both public SRA data and controlled-access dbGaP data via optional NGC authentication.
+This pipeline combines the `ww-sra`, `ww-cellranger`, and `ww-cellbender` modules to download scRNA-seq FASTQ data from NCBI's Sequence Read Archive, run Cell Ranger `count` for gene expression quantification, and remove ambient RNA contamination from the resulting count matrices. It supports both public SRA data and controlled-access dbGaP data via optional NGC authentication.
 
 The pipeline automatically handles FASTQ renaming to satisfy Cell Ranger's strict naming convention, so users only need to provide SRA accession IDs and a reference transcriptome.
 
@@ -22,9 +22,9 @@ When pulling controlled-access data from dbGaP via the `ngc_file` input, you are
 
 This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and demonstrates:
 
-- **Module Integration**: Combining `ww-sra` and `ww-cellranger` modules
-- **Data Flow**: SRA download, FASTQ renaming, and Cell Ranger processing
-- **Complexity Level**: Basic (2 modules)
+- **Module Integration**: Combining `ww-sra`, `ww-cellranger`, and `ww-cellbender` modules
+- **Data Flow**: SRA download, FASTQ renaming, Cell Ranger processing, and ambient RNA removal
+- **Complexity Level**: Basic (3 modules)
 
 ## Pipeline Steps
 
@@ -40,11 +40,17 @@ This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wil
    - Runs `cellranger count` on each sample via one of `run_count` (private Docker image), `run_count_hpc_cromwell` (HPC environment module on a Cromwell-on-HPC backend), or `run_count_hpc_sprocket` (HPC environment module inside a Sprocket-managed Lua container), selected by the `execution_mode` input
    - Generates gene expression matrices, web summaries, and metrics
 
+4. **Ambient RNA Removal** (using `ww-cellbender` module):
+   - Runs CellBender `remove-background` on each sample that produced a raw feature-barcode matrix
+   - Samples skipped by Cell Ranger (chemistry detection failure) are automatically excluded
+   - GPU acceleration is enabled by default; set `cellbender_gpu_enabled = false` for CPU-only execution
+
 ## Module Dependencies
 
 This pipeline imports and uses:
 - **ww-sra module**: For SRA data download (`fastqdump` task, with optional dbGaP/NGC support)
 - **ww-cellranger module**: For FASTQ renaming (`rename_fastqs` task) and gene expression quantification (one of `run_count`, `run_count_hpc_cromwell`, or `run_count_hpc_sprocket`, selected per run via the `execution_mode` input)
+- **ww-cellbender module**: For ambient RNA removal (`remove_background` task), run on each sample that produced a raw feature-barcode matrix
 
 ## Cell Ranger Software Environment
 
@@ -138,6 +144,12 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `cellranger_module` | HPC environment module used by the `run_count_hpc_*` tasks. Ignored unless `execution_mode` starts with `hpc_`. | String | No | `CellRanger/10.0.0` |
 | `organize_results` | When true, package all Cell Ranger outputs into a tarball organized by sample subdirectory. | Boolean | No | `false` |
 | `output_prefix` | Prefix for the organized results tarball filename. | String | No | `cellranger_results` |
+| `cellbender_gpu_enabled` | Enable GPU acceleration for CellBender. Set to `false` for CPU-only execution. | Boolean | No | `true` |
+| `cellbender_expected_cells` | Expected number of real cells per sample passed to CellBender. | Int | No | auto |
+| `cellbender_total_droplets_included` | Total number of droplets for CellBender to analyze per sample. | Int | No | auto |
+| `cellbender_epochs` | Number of CellBender training epochs. | Int | No | `150` |
+| `cellbender_cpu_cores` | Number of CPU cores for CellBender. | Int | No | `4` |
+| `cellbender_memory_gb` | Memory in GB for CellBender. | Int | No | `32` |
 
 ### Cell Ranger Reference
 
@@ -156,6 +168,8 @@ Cell Ranger requires a pre-built reference transcriptome tarball. You can:
 | `cellranger_metrics` | Metrics summary CSV files | ww-cellranger |
 | `cellranger_filtered_h5s` | Filtered feature-barcode matrix HDF5 files | ww-cellranger |
 | `cellranger_raw_h5s` | Raw feature-barcode matrix HDF5 files | ww-cellranger |
+| `cellbender_output_h5s` | CellBender cleaned count matrices (all barcodes retained), one per successful sample | ww-cellbender |
+| `cellbender_filtered_h5s` | CellBender filtered count matrices (barcodes with >50% cell probability), one per successful sample | ww-cellbender |
 | `organized_results` | Tarball of all outputs organized into per-sample subdirectories (absent unless `organize_results = true`) | pipeline |
 
 ### Mixed single-cell / non-single-cell input
@@ -198,7 +212,8 @@ The test workflow automatically:
 2. Downloads two SRA datasets, limited to 1M reads each: SRR7722937 (10x Chromium 3' v3 scRNA-seq demo dataset, expected to run successfully) and SRR1039508 (bulk RNA-seq, expected to trigger the `skip_on_chemistry_failure` path)
 3. Renames FASTQs for Cell Ranger compatibility
 4. Runs Cell Ranger count
-5. Outputs results, web summary, and metrics
+5. Runs CellBender `remove-background` on the successful sample (CPU-only with reduced epochs and droplets for CI speed)
+6. Validates that CellBender produced output for the single-cell sample and was correctly skipped for the bulk sample
 
 ### HPC Test Workflow
 
@@ -208,6 +223,7 @@ The test workflow automatically:
 
 - **ww-sra module**: SRA download functionality
 - **ww-cellranger module**: Cell Ranger processing functionality
+- **ww-cellbender module**: Ambient RNA removal functionality
 - **ww-sra-star pipeline**: Alternative pipeline for bulk RNA-seq alignment
 - **ww-sra-salmon pipeline**: Alternative pipeline for bulk RNA-seq quantification
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -153,6 +153,7 @@ Cell Ranger requires a pre-built reference transcriptome tarball. You can:
 | `cellranger_web_summaries` | Web summary HTML files | ww-cellranger |
 | `cellranger_metrics` | Metrics summary CSV files | ww-cellranger |
 | `cellranger_filtered_h5s` | Filtered feature-barcode matrix HDF5 files | ww-cellranger |
+| `cellranger_raw_h5s` | Raw feature-barcode matrix HDF5 files | ww-cellranger |
 
 ### Mixed single-cell / non-single-cell input
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -150,6 +150,7 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `cellbender_expected_cells` | Expected number of real cells per sample passed to CellBender. | Int | No | auto |
 | `cellbender_total_droplets_included` | Total number of droplets for CellBender to analyze per sample. | Int | No | auto |
 | `cellbender_epochs` | Number of CellBender training epochs. | Int | No | `150` |
+| `cellbender_low_count_threshold` | Droplets with total UMI count below this value are excluded from CellBender analysis. | Int | No | `5` |
 | `cellbender_cpu_cores` | Number of CPU cores for CellBender. | Int | No | `4` |
 | `cellbender_memory_gb` | Memory in GB for CellBender. | Int | No | `32` |
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -170,7 +170,7 @@ Cell Ranger requires a pre-built reference transcriptome tarball. You can:
 | `cellranger_raw_h5s` | Raw feature-barcode matrix HDF5 files | ww-cellranger |
 | `cellbender_output_h5s` | CellBender cleaned count matrices (all barcodes retained), one per successful sample | ww-cellbender |
 | `cellbender_filtered_h5s` | CellBender filtered count matrices (barcodes with >50% cell probability), one per successful sample | ww-cellbender |
-| `organized_results` | Tarball of all outputs organized into per-sample subdirectories (absent unless `organize_results = true`) | pipeline |
+| `organized_results` | Tarball of all Cell Ranger and CellBender outputs organized into per-sample subdirectories (absent unless `organize_results = true`) | pipeline |
 
 ### Mixed single-cell / non-single-cell input
 

--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -136,8 +136,8 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `execution_mode` | Which Cell Ranger task to dispatch to: `"docker"`, `"hpc_cromwell"`, or `"hpc_sprocket"`. See [Cell Ranger Software Environment](#cell-ranger-software-environment). | String | No | `"docker"` |
 | `docker_image` | Private Cell Ranger Docker image used by `run_count`. Ignored unless `execution_mode = "docker"`. | String | No | `ghcr.io/getwilds/cellranger:10.0.0` |
 | `cellranger_module` | HPC environment module used by the `run_count_hpc_*` tasks. Ignored unless `execution_mode` starts with `hpc_`. | String | No | `CellRanger/10.0.0` |
-| `organize_results` | When true, package all Cell Ranger outputs into a ZIP archive organized by sample subdirectory. | Boolean | No | `false` |
-| `output_prefix` | Prefix for the organized results ZIP filename. | String | No | `cellranger_results` |
+| `organize_results` | When true, package all Cell Ranger outputs into a tarball organized by sample subdirectory. | Boolean | No | `false` |
+| `output_prefix` | Prefix for the organized results tarball filename. | String | No | `cellranger_results` |
 
 ### Cell Ranger Reference
 
@@ -156,7 +156,7 @@ Cell Ranger requires a pre-built reference transcriptome tarball. You can:
 | `cellranger_metrics` | Metrics summary CSV files | ww-cellranger |
 | `cellranger_filtered_h5s` | Filtered feature-barcode matrix HDF5 files | ww-cellranger |
 | `cellranger_raw_h5s` | Raw feature-barcode matrix HDF5 files | ww-cellranger |
-| `organized_results` | ZIP archive of all outputs organized into per-sample subdirectories (absent unless `organize_results = true`) | pipeline |
+| `organized_results` | Tarball of all outputs organized into per-sample subdirectories (absent unless `organize_results = true`) | pipeline |
 
 ### Mixed single-cell / non-single-cell input
 

--- a/pipelines/ww-sra-cellranger/inputs.json
+++ b/pipelines/ww-sra-cellranger/inputs.json
@@ -8,5 +8,6 @@
   "sra_cellranger.docker_image": "ghcr.io/getwilds/cellranger:10.0.0",
   "sra_cellranger.cellranger_module": "CellRanger/10.0.0",
   "sra_cellranger.cellbender_gpu_enabled": true,
-  "sra_cellranger.cellbender_expected_cells": 5000
+  "sra_cellranger.cellbender_expected_cells": 5000,
+  "sra_cellranger.cellbender_low_count_threshold": 5
 }

--- a/pipelines/ww-sra-cellranger/inputs.json
+++ b/pipelines/ww-sra-cellranger/inputs.json
@@ -6,5 +6,7 @@
   "sra_cellranger.skip_on_chemistry_failure": true,
   "sra_cellranger.execution_mode": "hpc_cromwell",
   "sra_cellranger.docker_image": "ghcr.io/getwilds/cellranger:10.0.0",
-  "sra_cellranger.cellranger_module": "CellRanger/10.0.0"
+  "sra_cellranger.cellranger_module": "CellRanger/10.0.0",
+  "sra_cellranger.cellbender_gpu_enabled": true,
+  "sra_cellranger.cellbender_expected_cells": 5000
 }

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -21,8 +21,6 @@ workflow sra_cellranger_example {
     skip_on_chemistry_failure = true,
     organize_results = true,
     cellbender_gpu_enabled = false,
-    cellbender_total_droplets_included = 5000,
-    cellbender_epochs = 10,
     cellbender_memory_gb = 8
   }
 

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -133,13 +133,17 @@ task validate_outputs {
     fi
 
     if [ -n "~{organized_results}" ]; then
-      if tar -tf "~{organized_results}" | grep -q "$expected_single_cell"; then
+      tar_listing=$(tar -tf "~{organized_results}")
+      echo "=== organized_results tar listing ===" >> validation_report.txt
+      echo "$tar_listing" >> validation_report.txt
+      echo "=====================================" >> validation_report.txt
+      if echo "$tar_listing" | grep -q "/$expected_single_cell/"; then
         echo "organized_results contains $expected_single_cell subdirectory - PASSED" >> validation_report.txt
       else
         echo "organized_results missing $expected_single_cell subdirectory" >> validation_report.txt
         status=FAILED
       fi
-      if tar -tf "~{organized_results}" | grep -q "$expected_skipped"; then
+      if echo "$tar_listing" | grep -q "/$expected_skipped/"; then
         echo "organized_results contains $expected_skipped subdirectory (skipped sample should be absent) - FAILED" >> validation_report.txt
         status=FAILED
       else

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 workflow sra_cellranger_example {
   # Download a small GEX reference for Cell Ranger

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -18,7 +18,8 @@ workflow sra_cellranger_example {
     ncpu = 2,
     memory_gb = 6,
     max_reads = 1000000,
-    skip_on_chemistry_failure = true
+    skip_on_chemistry_failure = true,
+    organize_results = true
   }
 
   Int n_results = length(sra_cellranger.cellranger_results)
@@ -28,7 +29,8 @@ workflow sra_cellranger_example {
     skipped_sample_list = sra_cellranger.skipped_sample_list,
     n_results = n_results,
     expected_single_cell_id = "SRR7722937",
-    expected_skipped_id = "SRR1039508"
+    expected_skipped_id = "SRR1039508",
+    organized_results = sra_cellranger.organized_results
   }
 
   output {
@@ -38,13 +40,15 @@ workflow sra_cellranger_example {
     Array[File] cellranger_web_summaries = sra_cellranger.cellranger_web_summaries
     Array[File] cellranger_metrics = sra_cellranger.cellranger_metrics
     Array[File] cellranger_filtered_h5s = sra_cellranger.cellranger_filtered_h5s
+    Array[File] cellranger_raw_h5s = sra_cellranger.cellranger_raw_h5s
+    File? organized_results = sra_cellranger.organized_results
     File validation_report = validate_outputs.report
   }
 }
 
 task validate_outputs {
   meta {
-    description: "Assert that the skip_on_chemistry_failure=true scatter correctly partitioned the single-cell and non-single-cell samples."
+    description: "Assert that the skip_on_chemistry_failure=true scatter correctly partitioned the single-cell and non-single-cell samples, and that the organized results ZIP contains the expected per-sample subdirectory."
     outputs: {
         report: "Validation report"
     }
@@ -56,6 +60,7 @@ task validate_outputs {
     n_results: "Length of the filtered cellranger_results array (should be 1)"
     expected_single_cell_id: "Sample ID expected in single_cell_sample_list"
     expected_skipped_id: "Sample ID expected in skipped_sample_list"
+    organized_results: "ZIP archive produced by organize_outputs (optional; checked when present)"
   }
 
   input {
@@ -64,6 +69,7 @@ task validate_outputs {
     Int n_results
     String expected_single_cell_id
     String expected_skipped_id
+    File? organized_results
   }
 
   command <<<
@@ -98,6 +104,21 @@ task validate_outputs {
       status=FAILED
     else
       echo "cellranger_results length = 1 - PASSED" >> validation_report.txt
+    fi
+
+    if [ -n "~{organized_results}" ]; then
+      if unzip -l "~{organized_results}" | grep -q "$expected_single_cell/"; then
+        echo "organized_results contains $expected_single_cell/ subdirectory - PASSED" >> validation_report.txt
+      else
+        echo "organized_results missing $expected_single_cell/ subdirectory" >> validation_report.txt
+        status=FAILED
+      fi
+      if unzip -l "~{organized_results}" | grep -q "$expected_skipped/"; then
+        echo "organized_results contains $expected_skipped/ subdirectory (skipped sample should be absent) - FAILED" >> validation_report.txt
+        status=FAILED
+      else
+        echo "organized_results does not contain $expected_skipped/ subdirectory (skipped sample correctly absent) - PASSED" >> validation_report.txt
+      fi
     fi
 
     echo "" >> validation_report.txt

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -133,17 +133,17 @@ task validate_outputs {
     fi
 
     if [ -n "~{organized_results}" ]; then
-      if tar -tf "~{organized_results}" | grep -q "$expected_single_cell/"; then
-        echo "organized_results contains $expected_single_cell/ subdirectory - PASSED" >> validation_report.txt
+      if tar -tf "~{organized_results}" | grep -q "$expected_single_cell"; then
+        echo "organized_results contains $expected_single_cell subdirectory - PASSED" >> validation_report.txt
       else
-        echo "organized_results missing $expected_single_cell/ subdirectory" >> validation_report.txt
+        echo "organized_results missing $expected_single_cell subdirectory" >> validation_report.txt
         status=FAILED
       fi
-      if tar -tf "~{organized_results}" | grep -q "$expected_skipped/"; then
-        echo "organized_results contains $expected_skipped/ subdirectory (skipped sample should be absent) - FAILED" >> validation_report.txt
+      if tar -tf "~{organized_results}" | grep -q "$expected_skipped"; then
+        echo "organized_results contains $expected_skipped subdirectory (skipped sample should be absent) - FAILED" >> validation_report.txt
         status=FAILED
       else
-        echo "organized_results does not contain $expected_skipped/ subdirectory (skipped sample correctly absent) - PASSED" >> validation_report.txt
+        echo "organized_results does not contain $expected_skipped subdirectory (skipped sample correctly absent) - PASSED" >> validation_report.txt
       fi
     fi
 

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -21,7 +21,6 @@ workflow sra_cellranger_example {
     skip_on_chemistry_failure = true,
     organize_results = true,
     cellbender_gpu_enabled = false,
-    cellbender_expected_cells = 500,
     cellbender_total_droplets_included = 5000,
     cellbender_epochs = 10,
     cellbender_memory_gb = 8

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -17,7 +17,7 @@ workflow sra_cellranger_example {
     ref_gex = download_test_cellranger_ref.ref_tar,
     ncpu = 2,
     memory_gb = 6,
-    max_reads = 1000000,
+    max_reads = 5000000,
     skip_on_chemistry_failure = true,
     organize_results = true,
     cellbender_gpu_enabled = false,

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 workflow sra_cellranger_example {
   # Download a small GEX reference for Cell Ranger
@@ -19,7 +19,11 @@ workflow sra_cellranger_example {
     memory_gb = 6,
     max_reads = 1000000,
     skip_on_chemistry_failure = true,
-    organize_results = true
+    organize_results = true,
+    cellbender_gpu_enabled = false,
+    cellbender_expected_cells = 500,
+    cellbender_total_droplets_included = 5000,
+    cellbender_epochs = 10
   }
 
   Int n_results = length(sra_cellranger.cellranger_results)
@@ -30,7 +34,9 @@ workflow sra_cellranger_example {
     n_results = n_results,
     expected_single_cell_id = "SRR7722937",
     expected_skipped_id = "SRR1039508",
-    organized_results = sra_cellranger.organized_results
+    organized_results = sra_cellranger.organized_results,
+    cellbender_output_h5s = sra_cellranger.cellbender_output_h5s,
+    cellbender_filtered_h5s = sra_cellranger.cellbender_filtered_h5s
   }
 
   output {
@@ -41,6 +47,8 @@ workflow sra_cellranger_example {
     Array[File] cellranger_metrics = sra_cellranger.cellranger_metrics
     Array[File] cellranger_filtered_h5s = sra_cellranger.cellranger_filtered_h5s
     Array[File] cellranger_raw_h5s = sra_cellranger.cellranger_raw_h5s
+    Array[File] cellbender_output_h5s = sra_cellranger.cellbender_output_h5s
+    Array[File] cellbender_filtered_h5s = sra_cellranger.cellbender_filtered_h5s
     File? organized_results = sra_cellranger.organized_results
     File validation_report = validate_outputs.report
   }
@@ -61,6 +69,8 @@ task validate_outputs {
     expected_single_cell_id: "Sample ID expected in single_cell_sample_list"
     expected_skipped_id: "Sample ID expected in skipped_sample_list"
     organized_results: "ZIP archive produced by organize_outputs (optional; checked when present)"
+    cellbender_output_h5s: "CellBender cleaned H5 files (one per successful sample)"
+    cellbender_filtered_h5s: "CellBender filtered H5 files (one per successful sample)"
   }
 
   input {
@@ -70,6 +80,8 @@ task validate_outputs {
     String expected_single_cell_id
     String expected_skipped_id
     File? organized_results
+    Array[File] cellbender_output_h5s
+    Array[File] cellbender_filtered_h5s
   }
 
   command <<<
@@ -104,6 +116,22 @@ task validate_outputs {
       status=FAILED
     else
       echo "cellranger_results length = 1 - PASSED" >> validation_report.txt
+    fi
+
+    n_cellbender_output=~{length(cellbender_output_h5s)}
+    if [ "$n_cellbender_output" -ne 1 ]; then
+      echo "cellbender_output_h5s length: expected 1, got $n_cellbender_output" >> validation_report.txt
+      status=FAILED
+    else
+      echo "cellbender_output_h5s length = 1 - PASSED" >> validation_report.txt
+    fi
+
+    n_cellbender_filtered=~{length(cellbender_filtered_h5s)}
+    if [ "$n_cellbender_filtered" -ne 1 ]; then
+      echo "cellbender_filtered_h5s length: expected 1, got $n_cellbender_filtered" >> validation_report.txt
+      status=FAILED
+    else
+      echo "cellbender_filtered_h5s length = 1 - PASSED" >> validation_report.txt
     fi
 
     if [ -n "~{organized_results}" ]; then

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -107,13 +107,13 @@ task validate_outputs {
     fi
 
     if [ -n "~{organized_results}" ]; then
-      if unzip -l "~{organized_results}" | grep -q "$expected_single_cell/"; then
+      if tar -tf "~{organized_results}" | grep -q "$expected_single_cell/"; then
         echo "organized_results contains $expected_single_cell/ subdirectory - PASSED" >> validation_report.txt
       else
         echo "organized_results missing $expected_single_cell/ subdirectory" >> validation_report.txt
         status=FAILED
       fi
-      if unzip -l "~{organized_results}" | grep -q "$expected_skipped/"; then
+      if tar -tf "~{organized_results}" | grep -q "$expected_skipped/"; then
         echo "organized_results contains $expected_skipped/ subdirectory (skipped sample should be absent) - FAILED" >> validation_report.txt
         status=FAILED
       else

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/run-selector-input/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 workflow sra_cellranger_example {
   # Download a small GEX reference for Cell Ranger

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -23,7 +23,8 @@ workflow sra_cellranger_example {
     cellbender_gpu_enabled = false,
     cellbender_expected_cells = 500,
     cellbender_total_droplets_included = 5000,
-    cellbender_epochs = 10
+    cellbender_epochs = 10,
+    cellbender_memory_gb = 8
   }
 
   Int n_results = length(sra_cellranger.cellranger_results)

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -31,7 +31,9 @@ workflow sra_cellranger_example {
     skipped_sample_list = sra_cellranger.skipped_sample_list,
     n_results = n_results,
     expected_single_cell_id = "SRR7722937",
-    expected_skipped_id = "SRR1039508"
+    expected_skipped_id = "SRR1039508",
+    cellbender_output_h5s = sra_cellranger.cellbender_output_h5s,
+    cellbender_filtered_h5s = sra_cellranger.cellbender_filtered_h5s
   }
 
   output {
@@ -49,7 +51,7 @@ workflow sra_cellranger_example {
 
 task validate_outputs {
   meta {
-    description: "Assert that the skip_on_chemistry_failure=true scatter correctly partitioned the single-cell and non-single-cell samples."
+    description: "Assert that the skip_on_chemistry_failure=true scatter correctly partitioned the single-cell and non-single-cell samples, and that CellBender produced output for exactly the successful sample."
     outputs: {
         report: "Validation report"
     }
@@ -61,6 +63,8 @@ task validate_outputs {
     n_results: "Length of the filtered cellranger_results array (should be 1)"
     expected_single_cell_id: "Sample ID expected in single_cell_sample_list"
     expected_skipped_id: "Sample ID expected in skipped_sample_list"
+    cellbender_output_h5s: "CellBender cleaned H5 files (one per successful sample)"
+    cellbender_filtered_h5s: "CellBender filtered H5 files (one per successful sample)"
   }
 
   input {
@@ -69,6 +73,8 @@ task validate_outputs {
     Int n_results
     String expected_single_cell_id
     String expected_skipped_id
+    Array[File] cellbender_output_h5s
+    Array[File] cellbender_filtered_h5s
   }
 
   command <<<
@@ -103,6 +109,22 @@ task validate_outputs {
       status=FAILED
     else
       echo "cellranger_results length = 1 - PASSED" >> validation_report.txt
+    fi
+
+    n_cellbender_output=~{length(cellbender_output_h5s)}
+    if [ "$n_cellbender_output" -ne 1 ]; then
+      echo "cellbender_output_h5s length: expected 1, got $n_cellbender_output" >> validation_report.txt
+      status=FAILED
+    else
+      echo "cellbender_output_h5s length = 1 - PASSED" >> validation_report.txt
+    fi
+
+    n_cellbender_filtered=~{length(cellbender_filtered_h5s)}
+    if [ "$n_cellbender_filtered" -ne 1 ]; then
+      echo "cellbender_filtered_h5s length: expected 1, got $n_cellbender_filtered" >> validation_report.txt
+      status=FAILED
+    else
+      echo "cellbender_filtered_h5s length = 1 - PASSED" >> validation_report.txt
     fi
 
     echo "" >> validation_report.txt

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC variant of the ww-sra-cellranger pipeline testrun. Dispatches via

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -18,9 +18,9 @@ workflow sra_cellranger_example {
     ref_gex = download_test_cellranger_ref.ref_tar,
     ncpu = 2,
     memory_gb = 6,
-    max_reads = 1000000,
+    max_reads = 5000000,
     skip_on_chemistry_failure = true,
-    execution_mode = "hpc_sprocket",
+    execution_mode = "hpc_cromwell",
     cellbender_gpu_enabled = true
   }
 

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -20,7 +20,7 @@ workflow sra_cellranger_example {
     memory_gb = 6,
     max_reads = 5000000,
     skip_on_chemistry_failure = true,
-    execution_mode = "hpc_cromwell",
+    execution_mode = "hpc_sprocket",
     cellbender_gpu_enabled = true
   }
 

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC variant of the ww-sra-cellranger pipeline testrun. Dispatches via
@@ -20,7 +20,8 @@ workflow sra_cellranger_example {
     memory_gb = 6,
     max_reads = 1000000,
     skip_on_chemistry_failure = true,
-    execution_mode = "hpc_sprocket"
+    execution_mode = "hpc_sprocket",
+    cellbender_gpu_enabled = true
   }
 
   Int n_results = length(sra_cellranger.cellranger_results)
@@ -40,6 +41,8 @@ workflow sra_cellranger_example {
     Array[File] cellranger_web_summaries = sra_cellranger.cellranger_web_summaries
     Array[File] cellranger_metrics = sra_cellranger.cellranger_metrics
     Array[File] cellranger_filtered_h5s = sra_cellranger.cellranger_filtered_h5s
+    Array[File] cellbender_output_h5s = sra_cellranger.cellbender_output_h5s
+    Array[File] cellbender_filtered_h5s = sra_cellranger.cellbender_filtered_h5s
     File validation_report = validate_outputs.report
   }
 }

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/run-selector-input/modules/ww-cellranger/ww-cellranger.wdl" as cellranger_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-cellranger/ww-cellranger.wdl" as cellranger_tasks
 
 workflow sra_cellranger {
   meta {

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -25,7 +25,7 @@ workflow sra_cellranger {
         cellranger_metrics: "Cell Ranger metrics summary CSV files",
         cellranger_filtered_h5s: "Cell Ranger filtered feature-barcode matrix HDF5 files",
         cellranger_raw_h5s: "Cell Ranger raw feature-barcode matrix HDF5 files",
-        organized_results: "ZIP archive of all Cell Ranger outputs organized into per-sample subdirectories (absent when organize_results is false)"
+        organized_results: "Tarball of all Cell Ranger outputs organized into per-sample subdirectories (absent when organize_results is false)"
     }
   }
 
@@ -43,8 +43,8 @@ workflow sra_cellranger {
     execution_mode: "Which Cell Ranger task to dispatch to: 'docker' (default; private Cell Ranger image), 'hpc_cromwell' (loads Cell Ranger via host env-modules under Cromwell-on-HPC), or 'hpc_sprocket' (same module-load approach inside a Lua container under Sprocket-on-HPC). Any other value fails loudly via select_first."
     docker_image: "Private Cell Ranger Docker image used by run_count. Ignored unless execution_mode is 'docker'."
     cellranger_module: "HPC environment module used by the run_count_hpc_* tasks. Ignored unless execution_mode starts with 'hpc_'."
-    organize_results: "When true, package all Cell Ranger outputs into a ZIP archive organized by sample subdirectory."
-    output_prefix: "Prefix for the organized results ZIP filename (default: 'cellranger_results')."
+    organize_results: "When true, package all Cell Ranger outputs into a tarball organized by sample subdirectory."
+    output_prefix: "Prefix for the organized results tarball filename (default: 'cellranger_results')."
   }
 
   input {
@@ -273,9 +273,9 @@ task organize_outputs {
   meta {
     author: "Taylor Firman"
     email: "tfirman@fredhutch.org"
-    description: "Package Cell Ranger outputs into a ZIP archive organized by sample subdirectory."
+    description: "Package Cell Ranger outputs into a tarball organized by sample subdirectory."
     outputs: {
-        results_zip: "ZIP archive containing all Cell Ranger outputs organized into per-sample subdirectories"
+        results_zip: "Tarball containing all Cell Ranger outputs organized into per-sample subdirectories"
     }
   }
 
@@ -286,7 +286,7 @@ task organize_outputs {
     metrics_summaries: "Metrics summary CSV files, one per successful sample"
     filtered_h5s: "Filtered feature-barcode matrix HDF5 files, one per successful sample"
     raw_h5s: "Raw feature-barcode matrix HDF5 files, one per successful sample"
-    output_prefix: "Prefix for the output ZIP filename"
+    output_prefix: "Prefix for the output tarball filename"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
   }
@@ -324,11 +324,11 @@ task organize_outputs {
       cp "${RAW[$i]}"      "$OUTDIR/$SAMPLE/"
     done
 
-    zip -r "~{output_prefix}.zip" "$OUTDIR"
+    tar -czf "~{output_prefix}.tar.gz" "$OUTDIR"
   >>>
 
   output {
-    File results_zip = "~{output_prefix}.zip"
+    File results_zip = "~{output_prefix}.tar.gz"
   }
 
   runtime {

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -2,6 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-cellranger/ww-cellranger.wdl" as cellranger_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-cellbender/ww-cellbender.wdl" as cellbender_tasks
 
 workflow sra_cellranger {
   meta {
@@ -25,6 +26,8 @@ workflow sra_cellranger {
         cellranger_metrics: "Cell Ranger metrics summary CSV files",
         cellranger_filtered_h5s: "Cell Ranger filtered feature-barcode matrix HDF5 files",
         cellranger_raw_h5s: "Cell Ranger raw feature-barcode matrix HDF5 files",
+        cellbender_output_h5s: "CellBender cleaned count matrix H5 files (all barcodes retained), one per successful sample",
+        cellbender_filtered_h5s: "CellBender filtered count matrix H5 files (barcodes with >50% cell probability), one per successful sample",
         organized_results: "Tarball of all Cell Ranger outputs organized into per-sample subdirectories (absent when organize_results is false)"
     }
   }
@@ -45,6 +48,12 @@ workflow sra_cellranger {
     cellranger_module: "HPC environment module used by the run_count_hpc_* tasks. Ignored unless execution_mode starts with 'hpc_'."
     organize_results: "When true, package all Cell Ranger outputs into a tarball organized by sample subdirectory."
     output_prefix: "Prefix for the organized results tarball filename (default: 'cellranger_results')."
+    cellbender_gpu_enabled: "Enable GPU acceleration for CellBender (default: true); set to false for CPU-only execution."
+    cellbender_expected_cells: "Optional expected number of real cells per sample passed to CellBender."
+    cellbender_total_droplets_included: "Optional total number of droplets for CellBender to analyze per sample."
+    cellbender_epochs: "Number of CellBender training epochs (default: 150)."
+    cellbender_cpu_cores: "Number of CPU cores for CellBender (default: 4)."
+    cellbender_memory_gb: "Memory in GB for CellBender (default: 32)."
   }
 
   input {
@@ -63,6 +72,12 @@ workflow sra_cellranger {
     String cellranger_module = "CellRanger/10.0.0"
     Boolean organize_results = false
     String output_prefix = "cellranger_results"
+    Boolean cellbender_gpu_enabled = true
+    Int? cellbender_expected_cells
+    Int? cellbender_total_droplets_included
+    Int cellbender_epochs = 150
+    Int cellbender_cpu_cores = 4
+    Int cellbender_memory_gb = 32
   }
 
   # Resolve the sample list from whichever input was provided. A
@@ -168,6 +183,20 @@ workflow sra_cellranger {
     File? raw_h5 = if defined(run_count.raw_h5) then run_count.raw_h5
                   else if defined(run_count_hpc_cromwell.raw_h5) then run_count_hpc_cromwell.raw_h5
                   else run_count_hpc_sprocket.raw_h5
+
+    # Run CellBender on samples that produced a raw h5 (skipped samples won't have one)
+    if (defined(raw_h5)) {
+      call cellbender_tasks.remove_background { input:
+        input_h5 = select_first([raw_h5]),
+        sample_name = id,
+        expected_cells = cellbender_expected_cells,
+        total_droplets_included = cellbender_total_droplets_included,
+        epochs = cellbender_epochs,
+        gpu_enabled = cellbender_gpu_enabled,
+        cpu_cores = cellbender_cpu_cores,
+        memory_gb = cellbender_memory_gb
+      }
+    }
   }
 
   # Partition sample_ids into "ran" vs "skipped" based on each
@@ -201,6 +230,8 @@ workflow sra_cellranger {
     Array[File] cellranger_metrics = select_all(metrics_summary)
     Array[File] cellranger_filtered_h5s = select_all(filtered_h5)
     Array[File] cellranger_raw_h5s = select_all(raw_h5)
+    Array[File] cellbender_output_h5s = select_all(remove_background.output_h5)
+    Array[File] cellbender_filtered_h5s = select_all(remove_background.filtered_h5)
     File? organized_results = organize_outputs.results_zip
   }
 }

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -218,6 +218,8 @@ workflow sra_cellranger {
         metrics_summaries = select_all(metrics_summary),
         filtered_h5s = select_all(filtered_h5),
         raw_h5s = select_all(raw_h5),
+        cellbender_output_h5s = select_all(remove_background.output_h5),
+        cellbender_filtered_h5s = select_all(remove_background.filtered_h5),
         output_prefix = output_prefix
     }
   }
@@ -306,7 +308,7 @@ task organize_outputs {
     email: "tfirman@fredhutch.org"
     description: "Package Cell Ranger outputs into a tarball organized by sample subdirectory."
     outputs: {
-        results_zip: "Tarball containing all Cell Ranger outputs organized into per-sample subdirectories"
+        results_zip: "Tarball containing all Cell Ranger and CellBender outputs organized into per-sample subdirectories"
     }
   }
 
@@ -317,6 +319,8 @@ task organize_outputs {
     metrics_summaries: "Metrics summary CSV files, one per successful sample"
     filtered_h5s: "Filtered feature-barcode matrix HDF5 files, one per successful sample"
     raw_h5s: "Raw feature-barcode matrix HDF5 files, one per successful sample"
+    cellbender_output_h5s: "CellBender cleaned count matrix H5 files, one per successful sample"
+    cellbender_filtered_h5s: "CellBender filtered count matrix H5 files, one per successful sample"
     output_prefix: "Prefix for the output tarball filename"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
@@ -329,6 +333,8 @@ task organize_outputs {
     Array[File] metrics_summaries
     Array[File] filtered_h5s
     Array[File] raw_h5s
+    Array[File] cellbender_output_h5s
+    Array[File] cellbender_filtered_h5s
     String output_prefix = "cellranger_results"
     Int memory_gb = 4
     Int cpu_cores = 1
@@ -344,15 +350,19 @@ task organize_outputs {
     METRICS=(~{sep=' ' metrics_summaries})
     FILTERED=(~{sep=' ' filtered_h5s})
     RAW=(~{sep=' ' raw_h5s})
+    CB_OUTPUT=(~{sep=' ' cellbender_output_h5s})
+    CB_FILTERED=(~{sep=' ' cellbender_filtered_h5s})
 
     for i in "${!SAMPLE_IDS[@]}"; do
       SAMPLE="${SAMPLE_IDS[$i]}"
       mkdir -p "$OUTDIR/$SAMPLE"
-      cp "${TARS[$i]}"     "$OUTDIR/$SAMPLE/"
-      cp "${WEB[$i]}"      "$OUTDIR/$SAMPLE/"
-      cp "${METRICS[$i]}"  "$OUTDIR/$SAMPLE/"
-      cp "${FILTERED[$i]}" "$OUTDIR/$SAMPLE/"
-      cp "${RAW[$i]}"      "$OUTDIR/$SAMPLE/"
+      cp "${TARS[$i]}"        "$OUTDIR/$SAMPLE/"
+      cp "${WEB[$i]}"         "$OUTDIR/$SAMPLE/"
+      cp "${METRICS[$i]}"     "$OUTDIR/$SAMPLE/"
+      cp "${FILTERED[$i]}"    "$OUTDIR/$SAMPLE/"
+      cp "${RAW[$i]}"         "$OUTDIR/$SAMPLE/"
+      cp "${CB_OUTPUT[$i]}"   "$OUTDIR/$SAMPLE/"
+      cp "${CB_FILTERED[$i]}" "$OUTDIR/$SAMPLE/"
     done
 
     tar -czf "~{output_prefix}.tar.gz" "$OUTDIR"

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -23,7 +23,8 @@ workflow sra_cellranger {
         cellranger_results: "Cell Ranger count output tarballs",
         cellranger_web_summaries: "Cell Ranger web summary HTML files",
         cellranger_metrics: "Cell Ranger metrics summary CSV files",
-        cellranger_filtered_h5s: "Cell Ranger filtered feature-barcode matrix HDF5 files"
+        cellranger_filtered_h5s: "Cell Ranger filtered feature-barcode matrix HDF5 files",
+        cellranger_raw_h5s: "Cell Ranger raw feature-barcode matrix HDF5 files"
     }
   }
 
@@ -159,6 +160,9 @@ workflow sra_cellranger {
     File? filtered_h5 = if defined(run_count.filtered_h5) then run_count.filtered_h5
                        else if defined(run_count_hpc_cromwell.filtered_h5) then run_count_hpc_cromwell.filtered_h5
                        else run_count_hpc_sprocket.filtered_h5
+    File? raw_h5 = if defined(run_count.raw_h5) then run_count.raw_h5
+                  else if defined(run_count_hpc_cromwell.raw_h5) then run_count_hpc_cromwell.raw_h5
+                  else run_count_hpc_sprocket.raw_h5
   }
 
   # Partition sample_ids into "ran" vs "skipped" based on each
@@ -175,6 +179,7 @@ workflow sra_cellranger {
     Array[File] cellranger_web_summaries = select_all(web_summary)
     Array[File] cellranger_metrics = select_all(metrics_summary)
     Array[File] cellranger_filtered_h5s = select_all(filtered_h5)
+    Array[File] cellranger_raw_h5s = select_all(raw_h5)
   }
 }
 

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -359,12 +359,12 @@ task organize_outputs {
     for i in "${!SAMPLE_IDS[@]}"; do
       SAMPLE="${SAMPLE_IDS[$i]}"
       mkdir -p "$OUTDIR/$SAMPLE"
-      cp "${TARS[$i]}"        "$OUTDIR/$SAMPLE/"
-      cp "${WEB[$i]}"         "$OUTDIR/$SAMPLE/"
-      cp "${METRICS[$i]}"     "$OUTDIR/$SAMPLE/"
-      cp "${FILTERED[$i]}"    "$OUTDIR/$SAMPLE/"
-      cp "${RAW[$i]}"         "$OUTDIR/$SAMPLE/"
-      cp "${CB_OUTPUT[$i]}"   "$OUTDIR/$SAMPLE/"
+      cp "${TARS[$i]}" "$OUTDIR/$SAMPLE/"
+      cp "${WEB[$i]}" "$OUTDIR/$SAMPLE/"
+      cp "${METRICS[$i]}" "$OUTDIR/$SAMPLE/"
+      cp "${FILTERED[$i]}" "$OUTDIR/$SAMPLE/"
+      cp "${RAW[$i]}" "$OUTDIR/$SAMPLE/"
+      cp "${CB_OUTPUT[$i]}" "$OUTDIR/$SAMPLE/"
       cp "${CB_FILTERED[$i]}" "$OUTDIR/$SAMPLE/"
     done
 

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -24,7 +24,8 @@ workflow sra_cellranger {
         cellranger_web_summaries: "Cell Ranger web summary HTML files",
         cellranger_metrics: "Cell Ranger metrics summary CSV files",
         cellranger_filtered_h5s: "Cell Ranger filtered feature-barcode matrix HDF5 files",
-        cellranger_raw_h5s: "Cell Ranger raw feature-barcode matrix HDF5 files"
+        cellranger_raw_h5s: "Cell Ranger raw feature-barcode matrix HDF5 files",
+        organized_results: "ZIP archive of all Cell Ranger outputs organized into per-sample subdirectories (absent when organize_results is false)"
     }
   }
 
@@ -42,6 +43,8 @@ workflow sra_cellranger {
     execution_mode: "Which Cell Ranger task to dispatch to: 'docker' (default; private Cell Ranger image), 'hpc_cromwell' (loads Cell Ranger via host env-modules under Cromwell-on-HPC), or 'hpc_sprocket' (same module-load approach inside a Lua container under Sprocket-on-HPC). Any other value fails loudly via select_first."
     docker_image: "Private Cell Ranger Docker image used by run_count. Ignored unless execution_mode is 'docker'."
     cellranger_module: "HPC environment module used by the run_count_hpc_* tasks. Ignored unless execution_mode starts with 'hpc_'."
+    organize_results: "When true, package all Cell Ranger outputs into a ZIP archive organized by sample subdirectory."
+    output_prefix: "Prefix for the organized results ZIP filename (default: 'cellranger_results')."
   }
 
   input {
@@ -58,6 +61,8 @@ workflow sra_cellranger {
     String execution_mode = "docker"
     String docker_image = "ghcr.io/getwilds/cellranger:10.0.0"
     String cellranger_module = "CellRanger/10.0.0"
+    Boolean organize_results = false
+    String output_prefix = "cellranger_results"
   }
 
   # Resolve the sample list from whichever input was provided. A
@@ -172,6 +177,22 @@ workflow sra_cellranger {
       chemistry_status_files = chemistry_status_file
   }
 
+  # Optional: package all outputs into per-sample subdirectories. Uses
+  # read_lines on the single_cell_sample_list so the sample IDs are in
+  # the same order as the select_all'd file arrays (skipped samples are
+  # absent from both).
+  if (organize_results) {
+    call organize_outputs { input:
+        sample_ids = read_lines(summarize_chemistry_status.single_cell_sample_list),
+        results_tars = select_all(results_tar),
+        web_summaries = select_all(web_summary),
+        metrics_summaries = select_all(metrics_summary),
+        filtered_h5s = select_all(filtered_h5),
+        raw_h5s = select_all(raw_h5),
+        output_prefix = output_prefix
+    }
+  }
+
   output {
     File single_cell_sample_list = summarize_chemistry_status.single_cell_sample_list
     File skipped_sample_list = summarize_chemistry_status.skipped_sample_list
@@ -180,6 +201,7 @@ workflow sra_cellranger {
     Array[File] cellranger_metrics = select_all(metrics_summary)
     Array[File] cellranger_filtered_h5s = select_all(filtered_h5)
     Array[File] cellranger_raw_h5s = select_all(raw_h5)
+    File? organized_results = organize_outputs.results_zip
   }
 }
 
@@ -244,5 +266,74 @@ task summarize_chemistry_status {
     docker: "ubuntu:22.04"
     cpu: 1
     memory: "2 GB"
+  }
+}
+
+task organize_outputs {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Package Cell Ranger outputs into a ZIP archive organized by sample subdirectory."
+    outputs: {
+        results_zip: "ZIP archive containing all Cell Ranger outputs organized into per-sample subdirectories"
+    }
+  }
+
+  parameter_meta {
+    sample_ids: "Sample IDs in the same order as the file arrays (skipped samples must be excluded)"
+    results_tars: "Cell Ranger output tarballs, one per successful sample"
+    web_summaries: "Web summary HTML files, one per successful sample"
+    metrics_summaries: "Metrics summary CSV files, one per successful sample"
+    filtered_h5s: "Filtered feature-barcode matrix HDF5 files, one per successful sample"
+    raw_h5s: "Raw feature-barcode matrix HDF5 files, one per successful sample"
+    output_prefix: "Prefix for the output ZIP filename"
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
+  }
+
+  input {
+    Array[String] sample_ids
+    Array[File] results_tars
+    Array[File] web_summaries
+    Array[File] metrics_summaries
+    Array[File] filtered_h5s
+    Array[File] raw_h5s
+    String output_prefix = "cellranger_results"
+    Int memory_gb = 4
+    Int cpu_cores = 1
+  }
+
+  command <<<
+    set -eo pipefail
+
+    OUTDIR="~{output_prefix}"
+    SAMPLE_IDS=(~{sep=' ' sample_ids})
+    TARS=(~{sep=' ' results_tars})
+    WEB=(~{sep=' ' web_summaries})
+    METRICS=(~{sep=' ' metrics_summaries})
+    FILTERED=(~{sep=' ' filtered_h5s})
+    RAW=(~{sep=' ' raw_h5s})
+
+    for i in "${!SAMPLE_IDS[@]}"; do
+      SAMPLE="${SAMPLE_IDS[$i]}"
+      mkdir -p "$OUTDIR/$SAMPLE"
+      cp "${TARS[$i]}"     "$OUTDIR/$SAMPLE/"
+      cp "${WEB[$i]}"      "$OUTDIR/$SAMPLE/"
+      cp "${METRICS[$i]}"  "$OUTDIR/$SAMPLE/"
+      cp "${FILTERED[$i]}" "$OUTDIR/$SAMPLE/"
+      cp "${RAW[$i]}"      "$OUTDIR/$SAMPLE/"
+    done
+
+    zip -r "~{output_prefix}.zip" "$OUTDIR"
+  >>>
+
+  output {
+    File results_zip = "~{output_prefix}.zip"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
   }
 }

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as sra_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-cellranger/ww-cellranger.wdl" as cellranger_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-cellbender/modules/ww-cellbender/ww-cellbender.wdl" as cellbender_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/organize-sra-cellranger-outputs/modules/ww-cellbender/ww-cellbender.wdl" as cellbender_tasks
 
 workflow sra_cellranger {
   meta {

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -52,6 +52,7 @@ workflow sra_cellranger {
     cellbender_expected_cells: "Optional expected number of real cells per sample passed to CellBender."
     cellbender_total_droplets_included: "Optional total number of droplets for CellBender to analyze per sample."
     cellbender_epochs: "Number of CellBender training epochs (default: 150)."
+    cellbender_low_count_threshold: "Droplets with total UMI count below this value are excluded from CellBender analysis (default: 5)."
     cellbender_cpu_cores: "Number of CPU cores for CellBender (default: 4)."
     cellbender_memory_gb: "Memory in GB for CellBender (default: 32)."
   }
@@ -76,6 +77,7 @@ workflow sra_cellranger {
     Int? cellbender_expected_cells
     Int? cellbender_total_droplets_included
     Int cellbender_epochs = 150
+    Int cellbender_low_count_threshold = 5
     Int cellbender_cpu_cores = 4
     Int cellbender_memory_gb = 32
   }
@@ -192,6 +194,7 @@ workflow sra_cellranger {
         expected_cells = cellbender_expected_cells,
         total_droplets_included = cellbender_total_droplets_included,
         epochs = cellbender_epochs,
+        low_count_threshold = cellbender_low_count_threshold,
         gpu_enabled = cellbender_gpu_enabled,
         cpu_cores = cellbender_cpu_cores,
         memory_gb = cellbender_memory_gb


### PR DESCRIPTION
## Type of Change

- New module
- Documentation update

## Description

This PR combines two related sets of changes: enhancements to `ww-cellranger` and `ww-sra-cellranger` output organization, and the new `ww-cellbender` module for ambient RNA removal, which is now integrated as a post-processing step at the end of `ww-sra-cellranger`.

### `ww-cellranger` updates

- Added `raw_h5` (`raw_feature_bc_matrix.h5`) to the outputs of all three `run_count` task variants (`run_count`, `run_count_hpc_cromwell`, `run_count_hpc_sprocket`); the raw (unfiltered) matrix is required by downstream tools like CellBender

### `ww-sra-cellranger` pipeline updates

- Added `raw_h5` to pipeline outputs
- New `organize_outputs` task packages all per-sample Cell Ranger and CellBender outputs into a single tarball organized by sample subdirectory, enabled via `organize_results = true` (default `false`) and `output_prefix` inputs
- Output format changed from zip to tarball (`.tar.gz`)
- `testrun.wdl` updated to exercise `organize_results = true` and validate the per-sample subdirectory structure
- Integrated `remove_background` (CellBender) inside the scatter after Cell Ranger, gated on `defined(raw_h5)` so chemistry-skipped samples are automatically excluded
- New pipeline inputs: `cellbender_gpu_enabled`, `cellbender_expected_cells`, `cellbender_total_droplets_included`, `cellbender_epochs`, `cellbender_cpu_cores`, `cellbender_memory_gb`
- New pipeline outputs: `cellbender_output_h5s`, `cellbender_filtered_h5s`
- `organize_outputs` updated to include CellBender h5s alongside Cell Ranger outputs in the per-sample tarball
- `testrun.wdl`: CPU-only CellBender (`cellbender_gpu_enabled = false`), 8 GB memory, `max_reads = 5000000` (required for sufficient barcode depth); validates CellBender output file counts in `validate_outputs`
- `testrun_hpc.wdl`: GPU-enabled CellBender, full defaults, same validation coverage

### New module: `ww-cellbender`

Wraps [CellBender](https://cellbender.readthedocs.io/) `remove-background`, which removes ambient RNA contamination and barcode swapping artifacts from 10x Genomics raw feature-barcode matrices.

- Single task: `remove_background`, taking `raw_feature_bc_matrix.h5` from Cell Ranger as input and producing a cleaned count matrix, filtered matrix, QC report, run log, cell barcodes CSV, metrics CSV, and checkpoint tarball
- `gpu_enabled` boolean (default `true`) toggles GPU acceleration via `--cuda` and the `gpus` runtime key; set to `false` for CPU-only execution (same pattern as `ww-starling` and `ww-esmfold`)
- `checkpoint_mins` input exposes CellBender's checkpoint frequency (useful for preemptible HPC instances)
- `testrun.wdl`: CPU-only, 10 epochs, 5000 total droplets for CI speed; uses the 10k PBMC v3 raw h5 from 10x Genomics (~168 MB)
- `testrun_hpc.wdl`: GPU-enabled, full production defaults
- Registered in `.dockstore.yml` under `tools:`, alphabetically between `ww-bwa` and `ww-cellranger`

### New testdata task: `download_10x_raw_h5_data` (in `ww-testdata`)

Downloads the 10k PBMC v3 raw feature-barcode matrix from 10x Genomics. CellBender requires the unfiltered matrix; the existing `download_10x_h5_data` task only provides the filtered one.

## Testing

**How did you test these changes?**
Ran `make lint` for all updated resources. Ran `testrun.wdl` (CPU) and `testrun_hpc.wdl` (GPU) for both `ww-cellbender` and the updated `ww-sra-cellranger` pipeline on GitHub Action CI/CD and Fred Hutch HPC via PROOF.

**What workflow engine did you use?**
Cromwell, miniWDL, and Sprocket (GitHub Actions CI); PROOF (Cromwell) on Fred Hutch HPC

**Did the tests pass?**
Yes -- all three executors pass for both `ww-cellbender` and `ww-sra-cellranger`.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- The `ww-cellbender` module defaults `gpu_enabled = true` for production HPC use; testruns override to `false` for CPU-only CI -- consistent with `ww-starling` and `ww-esmfold`