### PR TITLE
Switching `testrun.wdl` imports from URL's to relative paths

### DIFF
--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -53,7 +53,7 @@ Create three files in `modules/ww-$ARGUMENTS/`:
 - `version 1.0`
 - Import the module using a **relative file path**: `import "ww-$ARGUMENTS.wdl" as ww_$ARGUMENTS_UNDERSCORE`
 - Import testdata using a **relative file path**: `import "../ww-testdata/ww-testdata.wdl" as ww_testdata`
-- **IMPORTANT**: Use relative imports so the module can be linted and tested locally before being committed. The CI/CD pipeline or the user will update these to GitHub raw URLs when ready.
+- **IMPORTANT**: Always use relative imports in `testrun.wdl`. This ensures that linting and test runs (both locally and in CI/CD) use the local version of the WDL being developed, not a stale copy on a remote branch.
 - Workflow name: `$ARGUMENTS_example` (with hyphens converted to underscores)
 - Must run with zero configuration (no input files needed)
 - Use appropriate `ww_testdata` tasks to provision test data

--- a/.agents/skills/create-pipeline/SKILL.md
+++ b/.agents/skills/create-pipeline/SKILL.md
@@ -61,7 +61,7 @@ Create four files in `pipelines/ww-$0/`:
 
 #### `testrun.wdl`
 - `version 1.0`
-- Import the pipeline WDL and `ww-testdata`
+- Import the pipeline WDL and `ww-testdata` using **relative paths** (e.g. `"./ww-$0.wdl"` and `"../../modules/ww-testdata/ww-testdata.wdl"`). This ensures linting and test runs use the local version being developed, not a stale copy on a remote branch.
 - Workflow name: `{pipeline_name}_example` (underscored)
 - Must run with zero configuration
 - Use `ww-testdata` tasks for all test data — check what's available:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -132,11 +132,13 @@ For modules where CI execution is impractical (GPU-only tools, license-gated too
 **Your test workflow file (`testrun.wdl` or `testrun_hpc.wdl`) must include:**
 
 - **Version declaration**: Use WDL version 1.0
-- **Module imports**: Import the module being tested and the `ww-testdata` module using GitHub URLs
+- **Module imports**: Import the module being tested and the `ww-testdata` module using relative paths (e.g. `"./ww-toolname.wdl"` for the own module and `"../ww-testdata/ww-testdata.wdl"` for test data)
 - **Sample struct definition**: Define a struct for organizing sample inputs if needed
 - **Test workflow**: A `toolname_example` workflow that demonstrates all tasks (must follow the naming convention `{module}_example` where `{module}` is the tool name, e.g., `star_example` for `ww-star`)
 - **Auto-downloading of test data**: Use the `ww-testdata` module to automatically provision test data
 - **Validation task (optional)**: Consider including a validation task to verify output correctness
+
+Note: `testrun.wdl` files use relative path imports (unlike the pipeline source WDL files, which use GitHub raw URLs for end-user convenience). Relative imports ensure that CI/CD and local test runs always exercise the local version of the WDL under development, rather than fetching a stale copy from a remote branch.
 
 **Parameter preferences:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ pipelines/ww-pipeline-name/
 - Command blocks: start with `set -eo pipefail`, use `<<<...>>>` heredoc syntax
 - Docker images: always from `getwilds/` with exact version pins (never `latest`); declared as `String docker_image = "getwilds/tool:version"` in the `input` block and referenced via `docker: docker_image` in `runtime`
 - Resource params: `cpu_cores` and `memory_gb` with sensible defaults
-- Imports use GitHub raw URLs: `https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-*/ww-*.wdl`
+- Pipeline and module source WDL files (`ww-*.wdl`) use GitHub raw URL imports: `https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-*/ww-*.wdl`
+- `testrun.wdl` and `testrun_hpc.wdl` use relative path imports (e.g. `"./ww-toolname.wdl"`, `"../ww-testdata/ww-testdata.wdl"`)
 - Modules are self-contained: `ww-<toolname>.wdl` files never import other modules. Cross-module composition happens only in `testrun.wdl` (for test fixtures) and in pipelines. If a task needs another tool's output, add it to the existing module rather than introducing a cross-module import in the source WDL.
 
 ## Test Workflows (testrun.wdl)
@@ -50,7 +51,6 @@ make run_cromwell NAME=ww-toolname  # Run testrun.wdl with Cromwell
 Sprocket exceptions (from sprocket.toml): TodoComment, ContainerUri, UnusedInput
 
 ## Common Development Pitfalls
-- Import URLs must point to the correct branch during development; switch to `main` before merging
 - Docker image version conflicts (especially with complex tools like ColabFold) - always pin versions
 - Test data changes go in the `ww-testdata` module, not individual modules
 - All modules/pipelines must pass CI on three executors: Cromwell, miniWDL, and Sprocket

--- a/modules/ww-annotsv/testrun.wdl
+++ b/modules/ww-annotsv/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-annotsv/ww-annotsv.wdl" as ww_annotsv
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-annotsv.wdl" as ww_annotsv
 
 workflow annotsv_example {
   # Download test data for annotation

--- a/modules/ww-annovar/testrun.wdl
+++ b/modules/ww-annovar/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-annovar/ww-annovar.wdl" as ww_annovar
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-annovar.wdl" as ww_annovar
 
 workflow annovar_example {
   # Download test data for annotation

--- a/modules/ww-aws-sso/testrun.wdl
+++ b/modules/ww-aws-sso/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-aws-sso/ww-aws-sso.wdl" as ww_aws_sso
+import "./ww-aws-sso.wdl" as ww_aws_sso
 
 workflow aws_sso_example {
   # Test listing bucket contents

--- a/modules/ww-bcftools/testrun.wdl
+++ b/modules/ww-bcftools/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bcftools/ww-bcftools.wdl" as ww_bcftools
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bcftools.wdl" as ww_bcftools
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow bcftools_example {
   # Download test data

--- a/modules/ww-bedparse/testrun.wdl
+++ b/modules/ww-bedparse/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bedparse/ww-bedparse.wdl" as ww_bedparse
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bedparse.wdl" as ww_bedparse
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow bedparse_example {
   # Auto-download test reference data for testing purposes

--- a/modules/ww-bedtools/testrun.wdl
+++ b/modules/ww-bedtools/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bedtools/ww-bedtools.wdl" as ww_bedtools
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bedtools.wdl" as ww_bedtools
 
 workflow bedtools_example {
   # Hard-coded configuration for testing

--- a/modules/ww-bowtie/testrun.wdl
+++ b/modules/ww-bowtie/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bowtie/ww-bowtie.wdl" as ww_bowtie
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bowtie.wdl" as ww_bowtie
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 struct BowtieSample {
     String name

--- a/modules/ww-bowtie2/testrun.wdl
+++ b/modules/ww-bowtie2/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bowtie2/ww-bowtie2.wdl" as ww_bowtie2
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bowtie2.wdl" as ww_bowtie2
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 struct Bowtie2Sample {
     String name

--- a/modules/ww-bwa/testrun.wdl
+++ b/modules/ww-bwa/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as ww_bwa
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bwa.wdl" as ww_bwa
 
 struct BwaSample {
     String name

--- a/modules/ww-cellbender/testrun.wdl
+++ b/modules/ww-cellbender/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module under test and testdata module using relative paths for local linting/testing
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellbender/ww-cellbender.wdl" as ww_cellbender
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-cellbender.wdl" as ww_cellbender
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-cellbender/testrun_hpc.wdl
+++ b/modules/ww-cellbender/testrun_hpc.wdl
@@ -3,8 +3,8 @@ version 1.0
 # HPC variant of the CellBender testrun. Runs remove-background with GPU enabled.
 # Uses the same test data as testrun.wdl; the only difference is gpu_enabled = true,
 # which adds --cuda to the CellBender command and requests 1 GPU in the runtime block.
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellbender/ww-cellbender.wdl" as ww_cellbender
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-cellbender.wdl" as ww_cellbender
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-cellranger/testrun.wdl
+++ b/modules/ww-cellranger/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellranger/ww-cellranger.wdl" as ww_cellranger
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-cellranger.wdl" as ww_cellranger
 
 workflow cellranger_example {
 

--- a/modules/ww-cellranger/testrun_hpc.wdl
+++ b/modules/ww-cellranger/testrun_hpc.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cellranger/ww-cellranger.wdl" as ww_cellranger
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-cellranger.wdl" as ww_cellranger
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC variant of the Cell Ranger testrun. Calls run_count_hpc_sprocket

--- a/modules/ww-clair3/testrun.wdl
+++ b/modules/ww-clair3/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module in question as well as the testdata module for automatic demo functionality
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-clair3/ww-clair3.wdl" as ww_clair3
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-clair3.wdl" as ww_clair3
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-cnvkit/testrun.wdl
+++ b/modules/ww-cnvkit/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-cnvkit/ww-cnvkit.wdl" as ww_cnvkit
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-cnvkit.wdl" as ww_cnvkit
 
 workflow cnvkit_example {
   # Auto-download test data for testing purposes (multiple samples for reference)

--- a/modules/ww-colabfold/testrun.wdl
+++ b/modules/ww-colabfold/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-colabfold/ww-colabfold.wdl" as ww_colabfold
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-colabfold.wdl" as ww_colabfold
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 # Tests ColabFold prediction with a tiny protein sequence on CPU.

--- a/modules/ww-consensus/testrun.wdl
+++ b/modules/ww-consensus/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-annovar/ww-annovar.wdl" as ww_annovar
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-consensus/ww-consensus.wdl" as ww_consensus
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../ww-annovar/ww-annovar.wdl" as ww_annovar
+import "./ww-consensus.wdl" as ww_consensus
 
 workflow consensus_example {
   # Download a small gnomAD VCF subset to use as test data

--- a/modules/ww-deeptools/testrun.wdl
+++ b/modules/ww-deeptools/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deeptools/ww-deeptools.wdl" as ww_deeptools
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-deeptools.wdl" as ww_deeptools
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 struct DeeptoolsSample {
     String name

--- a/modules/ww-deepvariant/testrun.wdl
+++ b/modules/ww-deepvariant/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deepvariant/ww-deepvariant.wdl" as ww_deepvariant
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-deepvariant.wdl" as ww_deepvariant
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 struct DeepVariantSample {
     String name

--- a/modules/ww-delly/testrun.wdl
+++ b/modules/ww-delly/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-delly/ww-delly.wdl" as ww_delly
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-delly.wdl" as ww_delly
 
 workflow delly_example {
   # Download test data

--- a/modules/ww-deseq2/testrun.wdl
+++ b/modules/ww-deseq2/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as ww_deseq2
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-deseq2.wdl" as ww_deseq2
 
 workflow deseq2_example {
   # Generate test data

--- a/modules/ww-diamond/testrun.wdl
+++ b/modules/ww-diamond/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-diamond/ww-diamond.wdl" as ww_diamond
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-diamond.wdl" as ww_diamond
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow diamond_example {
   call ww_testdata.create_diamond_data { }

--- a/modules/ww-ena/testrun.wdl
+++ b/modules/ww-ena/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-ena/ww-ena.wdl" as ww_ena
+import "./ww-ena.wdl" as ww_ena
 
 workflow ena_example {
   meta {

--- a/modules/ww-esmfold/testrun_hpc.wdl
+++ b/modules/ww-esmfold/testrun_hpc.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-esmfold/ww-esmfold.wdl" as ww_esmfold
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-esmfold.wdl" as ww_esmfold
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC-only ESMFold test: predicts the structure of a small test protein.

--- a/modules/ww-fastp/testrun.wdl
+++ b/modules/ww-fastp/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module in question as well as the testdata module for automatic demo functionality
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-fastp/ww-fastp.wdl" as ww_fastp
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-fastp.wdl" as ww_fastp
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 # Define data structure for paired-end sample inputs
 struct FastpSample {

--- a/modules/ww-fastqc/testrun.wdl
+++ b/modules/ww-fastqc/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-fastqc/ww-fastqc.wdl" as ww_fastqc
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-fastqc.wdl" as ww_fastqc
 
 workflow fastqc_example {
   # Auto-download test data for testing purposes

--- a/modules/ww-gatk/testrun.wdl
+++ b/modules/ww-gatk/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gatk/ww-gatk.wdl" as ww_gatk
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bwa/ww-bwa.wdl" as ww_bwa
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-gatk.wdl" as ww_gatk
+import "../ww-bwa/ww-bwa.wdl" as ww_bwa
 
 struct GatkSample {
     String name

--- a/modules/ww-gdc/testrun.wdl
+++ b/modules/ww-gdc/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gdc/ww-gdc.wdl" as ww_gdc
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-gdc.wdl" as ww_gdc
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow gdc_client_example {
   meta {

--- a/modules/ww-gffread/testrun.wdl
+++ b/modules/ww-gffread/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl" as ww_gffread
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-gffread.wdl" as ww_gffread
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow gffread_example {
   # Case 1: Bacterial NCBI GTF (the primary use case for this module)

--- a/modules/ww-glimpse2/testrun.wdl
+++ b/modules/ww-glimpse2/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-glimpse2/ww-glimpse2.wdl" as ww_glimpse2
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-glimpse2.wdl" as ww_glimpse2
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow glimpse2_example {
   # Test region on chr1 - small enough for CI/CD but large enough for meaningful testing

--- a/modules/ww-ichorcna/testrun.wdl
+++ b/modules/ww-ichorcna/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-ichorcna/ww-ichorcna.wdl" as ww_ichorcna
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-ichorcna.wdl" as ww_ichorcna
 
 struct IchorSample {
     String name

--- a/modules/ww-jcast/testrun.wdl
+++ b/modules/ww-jcast/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-jcast/ww-jcast.wdl" as ww_jcast
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-jcast.wdl" as ww_jcast
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow jcast_example {
   # Download rMATS test data, Ensembl GTF, and genome FASTA from the JCAST repository

--- a/modules/ww-manta/testrun.wdl
+++ b/modules/ww-manta/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-manta/ww-manta.wdl" as ww_manta
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-manta.wdl" as ww_manta
 
 workflow manta_example {
   # Download test data

--- a/modules/ww-megahit/testrun.wdl
+++ b/modules/ww-megahit/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-megahit/ww-megahit.wdl" as ww_megahit
+import "../ww-sra/ww-sra.wdl" as ww_sra
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-megahit.wdl" as ww_megahit
 
 workflow megahit_example {
   # Download test data from SRA

--- a/modules/ww-multiqc/testrun.wdl
+++ b/modules/ww-multiqc/testrun.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
 # Import module under test and dependencies
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as ww_multiqc
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-fastqc/ww-fastqc.wdl" as ww_fastqc
+import "./ww-multiqc.wdl" as ww_multiqc
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../ww-fastqc/ww-fastqc.wdl" as ww_fastqc
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-rmats-turbo/testrun.wdl
+++ b/modules/ww-rmats-turbo/testrun.wdl
@@ -6,8 +6,8 @@ version 1.0
 ## results will not be biologically meaningful but serve to validate the module
 ## executes correctly.
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rmats-turbo/ww-rmats-turbo.wdl" as ww_rmats_turbo
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-rmats-turbo.wdl" as ww_rmats_turbo
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow rmats_turbo_example {
   # Download reference GTF annotation

--- a/modules/ww-rseqc/testrun.wdl
+++ b/modules/ww-rseqc/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rseqc/ww-rseqc.wdl" as ww_rseqc
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bedparse/ww-bedparse.wdl" as ww_bedparse
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-rseqc.wdl" as ww_rseqc
+import "../ww-bedparse/ww-bedparse.wdl" as ww_bedparse
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow rseqc_example {
   # Auto-download test reference data for testing purposes

--- a/modules/ww-salmon/testrun.wdl
+++ b/modules/ww-salmon/testrun.wdl
@@ -3,8 +3,8 @@ version 1.0
 # Import module in question as well as the testdata module for automatic demo functionality
 
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-salmon/ww-salmon.wdl" as ww_salmon
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-salmon.wdl" as ww_salmon
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 
 #### TEST WORKFLOW DEFINITION ####

--- a/modules/ww-samtools/testrun.wdl
+++ b/modules/ww-samtools/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-samtools.wdl" as ww_samtools
 
 workflow samtools_example {
   # Download test data

--- a/modules/ww-seurat/testrun.wdl
+++ b/modules/ww-seurat/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-seurat/ww-seurat.wdl" as ww_seurat
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-seurat.wdl" as ww_seurat
 
 workflow seurat_example {
   # Download 10x Genomics H5 test data

--- a/modules/ww-shapemapper/testrun.wdl
+++ b/modules/ww-shapemapper/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-shapemapper/ww-shapemapper.wdl" as ww_shapemapper
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-shapemapper.wdl" as ww_shapemapper
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 struct ShapeMapperSample {
     String name

--- a/modules/ww-sjl/testrun.wdl
+++ b/modules/ww-sjl/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sjl/ww-sjl.wdl" as ww_sjl
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-sjl.wdl" as ww_sjl
 
 workflow sjl_example {
   # Generate synthetic test tile and border points data

--- a/modules/ww-smoove/testrun.wdl
+++ b/modules/ww-smoove/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-smoove/ww-smoove.wdl" as ww_smoove
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-smoove.wdl" as ww_smoove
 
 struct SmooveSample {
     String name

--- a/modules/ww-sourmash/testrun.wdl
+++ b/modules/ww-sourmash/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sourmash/ww-sourmash.wdl" as ww_sourmash
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-sourmash.wdl" as ww_sourmash
 
 workflow sourmash_example {
   # Pull down reference genome and index files for chr1

--- a/modules/ww-spades/testrun.wdl
+++ b/modules/ww-spades/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-spades/ww-spades.wdl" as ww_spades
+import "../ww-sra/ww-sra.wdl" as ww_sra
+import "./ww-spades.wdl" as ww_spades
 
 workflow spades_example {
   # Download test data from SRA

--- a/modules/ww-sra/testrun.wdl
+++ b/modules/ww-sra/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
+import "./ww-sra.wdl" as ww_sra
 
 workflow sra_example {
   # Pulling down test SRA data

--- a/modules/ww-star/testrun.wdl
+++ b/modules/ww-star/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as ww_star
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-star.wdl" as ww_star
 
 struct StarSample {
     String name

--- a/modules/ww-starling/testrun.wdl
+++ b/modules/ww-starling/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module under test and testdata module using relative paths for local development
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-starling/ww-starling.wdl" as ww_starling
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-starling.wdl" as ww_starling
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/modules/ww-strelka/testrun.wdl
+++ b/modules/ww-strelka/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-strelka/ww-strelka.wdl" as ww_strelka
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-strelka.wdl" as ww_strelka
 
 struct StrelkaSample {
     String name

--- a/modules/ww-template/testrun.wdl
+++ b/modules/ww-template/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module in question as well as the testdata module for automatic demo functionality
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-template/ww-template.wdl" as ww_template
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-template.wdl" as ww_template
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 # Define data structures for sample inputs if needed
 struct TemplateSample {

--- a/modules/ww-testdata/testrun.wdl
+++ b/modules/ww-testdata/testrun.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-testdata.wdl" as ww_testdata
 
 workflow testdata_example {
   # Pull down reference genome and index files for chr1

--- a/modules/ww-trimgalore/testrun.wdl
+++ b/modules/ww-trimgalore/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
 # Import module in question as well as the testdata module for automatic demo functionality
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-trimgalore/ww-trimgalore.wdl" as ww_trimgalore
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-trimgalore.wdl" as ww_trimgalore
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 # Define data structure for paired-end sample inputs
 struct TrimGaloreSample {

--- a/modules/ww-tritonnp/testrun.wdl
+++ b/modules/ww-tritonnp/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-tritonnp/ww-tritonnp.wdl" as ww_tritonnp
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-tritonnp.wdl" as ww_tritonnp
 
 struct TritonSample {
     String name

--- a/modules/ww-umi-tools/testrun.wdl
+++ b/modules/ww-umi-tools/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-umi-tools/ww-umi-tools.wdl" as ww_umi_tools
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-umi-tools.wdl" as ww_umi_tools
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 struct DedupSample {
   String name

--- a/modules/ww-varscan/testrun.wdl
+++ b/modules/ww-varscan/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-samtools/ww-samtools.wdl" as ww_samtools
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-varscan/ww-varscan.wdl" as ww_varscan
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../ww-samtools/ww-samtools.wdl" as ww_samtools
+import "./ww-varscan.wdl" as ww_varscan
 
 workflow varscan_example {
   # Download test data

--- a/modules/ww-viennarna/testrun.wdl
+++ b/modules/ww-viennarna/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-viennarna/ww-viennarna.wdl" as ww_viennarna
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-viennarna.wdl" as ww_viennarna
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
 
 #### TEST WORKFLOW DEFINITION ####
 

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -98,19 +98,12 @@ This works because all pipelines import modules using GitHub URLs, so your WDL e
 
 ### **Testing and Demonstration**
 
-Pipelines also include zero-configuration test workflows for quick demonstrations:
+Pipelines also include zero-configuration test workflows for quick demonstrations. Because `testrun.wdl` uses relative path imports, you need the repository cloned to run it:
 
 ```bash
-# Download and run a test workflow (no inputs needed)
-curl -O https://raw.githubusercontent.com/getwilds/wilds-wdl-library/main/pipelines/ww-sra-star/testrun.wdl
-sprocket run testrun.wdl
-```
-
-If you have the repository cloned:
-
-```bash
-# Navigate to pipeline directory
-cd pipelines/ww-sra-star
+# Clone the repository and navigate to a pipeline directory
+git clone https://github.com/getwilds/wilds-wdl-library.git
+cd wilds-wdl-library/pipelines/ww-sra-star
 
 # Run test workflow with your preferred executor (no inputs needed):
 # Sprocket

--- a/pipelines/ww-bwa-gatk/testrun.wdl
+++ b/pipelines/ww-bwa-gatk/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-bwa-gatk/ww-bwa-gatk.wdl" as bwa_gatk_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bwa-gatk.wdl" as bwa_gatk_workflow
 
 struct BwaSample {
     String name

--- a/pipelines/ww-ena-star/testrun.wdl
+++ b/pipelines/ww-ena-star/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-ena-star/ww-ena-star.wdl" as ena_star_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-ena-star.wdl" as ena_star_workflow
 
 workflow ena_star_example {
   # Call testdata workflow to get test data

--- a/pipelines/ww-fastq-to-cram/testrun.wdl
+++ b/pipelines/ww-fastq-to-cram/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-fastq-to-cram/ww-fastq-to-cram.wdl" as fastq_to_cram_wf
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-fastq-to-cram.wdl" as fastq_to_cram_wf
 
 # Import structs from the workflow
 struct FastqGroup {

--- a/pipelines/ww-imputation/testrun.wdl
+++ b/pipelines/ww-imputation/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-imputation/ww-imputation.wdl" as ww_imputation
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-imputation.wdl" as ww_imputation
 
 #### TEST WORKFLOW DEFINITION ####
 # This workflow demonstrates the ww-imputation pipeline with automatic test data download.

--- a/pipelines/ww-jetlag/testrun.wdl
+++ b/pipelines/ww-jetlag/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-jetlag/ww-jetlag.wdl" as ww_jetlag
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-jetlag.wdl" as ww_jetlag
 
 workflow jetlag_example {
   # Generate synthetic test tile and border points data

--- a/pipelines/ww-leukemia/testrun.wdl
+++ b/pipelines/ww-leukemia/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-leukemia.wdl" as leukemia
 
 workflow leukemia_test {
   # Download test reference data

--- a/pipelines/ww-leukemia/testrun_hpc.wdl
+++ b/pipelines/ww-leukemia/testrun_hpc.wdl
@@ -6,8 +6,8 @@ version 1.0
 # this end-to-end variant is intended to be exercised on Fred Hutch HPC
 # infrastructure (Sprocket or PROOF).
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-leukemia/ww-leukemia.wdl" as leukemia
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-leukemia.wdl" as leukemia
 
 workflow leukemia_test {
   # Download test reference data

--- a/pipelines/ww-proseq/testrun.wdl
+++ b/pipelines/ww-proseq/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-proseq/ww-proseq.wdl" as proseq_workflow
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
+import "./ww-proseq.wdl" as proseq_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../../modules/ww-sra/ww-sra.wdl" as ww_sra
 
 struct ProseqSample {
     String name

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-rnaseq/ww-rnaseq.wdl" as rnaseq_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../../modules/ww-sra/ww-sra.wdl" as ww_sra
+import "./ww-rnaseq.wdl" as rnaseq_workflow
 
 struct RefGenome {
     String name

--- a/pipelines/ww-saturation/testrun.wdl
+++ b/pipelines/ww-saturation/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-saturation/ww-saturation.wdl" as saturation_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-saturation.wdl" as saturation_workflow
 
 struct SaturationSample {
     String name

--- a/pipelines/ww-splicing-proteomics/testrun.wdl
+++ b/pipelines/ww-splicing-proteomics/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl" as splicing_proteomics_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../../modules/ww-sra/ww-sra.wdl" as ww_sra
+import "./ww-splicing-proteomics.wdl" as splicing_proteomics_workflow
 
 struct SampleInfo {
     String name

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 workflow sra_cellranger_example {
   # Download a small GEX reference for Cell Ranger

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC variant of the ww-sra-cellranger pipeline testrun. Dispatches via

--- a/pipelines/ww-sra-salmon/testrun.wdl
+++ b/pipelines/ww-sra-salmon/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-salmon/ww-sra-salmon.wdl" as sra_salmon_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-sra-salmon.wdl" as sra_salmon_workflow
 
 workflow sra_salmon_example {
   # Call testdata workflow to get test transcriptome

--- a/pipelines/ww-sra-star/testrun.wdl
+++ b/pipelines/ww-sra-star/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-sra-star/ww-sra-star.wdl" as sra_star_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-sra-star.wdl" as sra_star_workflow
 
 workflow sra_star_example {
   # Call testdata workflow to get test data

--- a/pipelines/ww-star-deseq2/testrun.wdl
+++ b/pipelines/ww-star-deseq2/testrun.wdl
@@ -1,8 +1,8 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-sra/ww-sra.wdl" as ww_sra
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-star-deseq2/ww-star-deseq2.wdl" as star_deseq2_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../../modules/ww-sra/ww-sra.wdl" as ww_sra
+import "./ww-star-deseq2.wdl" as star_deseq2_workflow
 
 struct SampleInfo {
     String name

--- a/pipelines/ww-starling-batch/testrun.wdl
+++ b/pipelines/ww-starling-batch/testrun.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-starling-batch/ww-starling-batch.wdl" as starling_batch_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-starling-batch.wdl" as starling_batch_workflow
 
 workflow starling_batch_example {
   # Create a test FASTA with multiple short IDP sequences


### PR DESCRIPTION
## Type of Change

- Other: Maintenance/refactor — switch `testrun.wdl` imports from GitHub raw URLs to relative paths

## Description

All `testrun.wdl` and `testrun_hpc.wdl` files (73 total across modules and pipelines) have been updated to use relative path imports instead of GitHub raw URL imports.

Previously, every `testrun.wdl` imported its dependencies via absolute URLs pointing to `refs/heads/main`, e.g.:

```wdl
import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-star/ww-star.wdl" as ww_star
```

This meant contributors had to manually update URLs to point to their dev branch before testing, then switch them back to `main` before merging, a recurring pain point and a common source of CI failures.

`testrun.wdl` files are only ever run by CI or by developers with the repo cloned locally, so relative imports work just as well and eliminate this painpoint entirely. The relative path conventions used are:

- Own module/pipeline: `"./ww-foo.wdl"`
- `ww-testdata` from a module: `"../ww-testdata/ww-testdata.wdl"`
- Sibling module fixture from a module: `"../ww-bwa/ww-bwa.wdl"`
- `ww-testdata` from a pipeline: `"../../modules/ww-testdata/ww-testdata.wdl"`
- Module fixture from a pipeline: `"../../modules/ww-sra/ww-sra.wdl"`

For now, pipeline and module source WDL files (`ww-*.wdl`) are **not** changed. They keep GitHub URL imports for end-user plug-and-play usability, but we are still exploring the possibility of converting them to relative paths and may do so in the near future.

Documentation updates:
- `CLAUDE.md` and `AGENTS.md`: clarified that URL imports apply to source WDL files, added the relative import rule for testrun files, removed the obsolete "switch to main before merging" pitfall
- `.github/CONTRIBUTING.md`: updated the testrun import bullet to specify relative paths with examples, added a note explaining why testrun diverges from the URL convention
- `.agents/skills/create-module/SKILL.md` and `.claude/skills/create-module/SKILL.md`: replaced the misleading "user will update to GitHub raw URLs when ready" note with the correct rationale
- `.agents/skills/create-pipeline/SKILL.md` and `.claude/skills/create-pipeline/SKILL.md`: added explicit relative import guidance to the `testrun.wdl` section
- `pipelines/README.md`: removed the `curl testrun.wdl && sprocket run` shortcut (which would break with relative imports since the pipeline WDL wouldn't be alongside it) and replaced it with a clone-based flow

## Related Issue

Partially addresses #364

## Testing

**How did you test these changes?**

Verified with `grep` that no `raw.githubusercontent.com` URLs remain in any `testrun*.wdl` file, and spot-checked representative files covering all import patterns (own module, sibling module fixture, ww-testdata from module, pipeline own WDL, module from pipeline).

**What workflow engine did you use?**

Import path changes only, no WDL logic was modified. CI will validate all executors. Also executing HPC test run using this branch on Rhino just to make sure.

**Did the tests pass?**

Yes, see below and here: https://github.com/getwilds/wilds-wdl-library/issues/324#issuecomment-5010300869

## Documentation

- [x] I updated the README (if applicable)
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~

## Additional Context

The decision to keep URL imports in the pipeline source WDL files (`ww-*.wdl`) was deliberate: those files are what end users download and run directly, so URL imports let executors fetch all dependencies without requiring a local clone. Only `testrun.wdl` and `testrun_hpc.wdl` are switching to relative paths, as those are developer/CI-only files.