### PR TITLE
Switching import URL's back to `main` in ww-imputation workflow

### DIFF
--- a/pipelines/ww-imputation/ww-imputation.wdl
+++ b/pipelines/ww-imputation/ww-imputation.wdl
@@ -7,8 +7,8 @@
 
 version 1.2
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/imputation-v1.1/modules/ww-glimpse2/ww-glimpse2.wdl" as glimpse2
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/imputation-v1.1/modules/ww-bcftools/ww-bcftools.wdl" as bcftools
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-glimpse2/ww-glimpse2.wdl" as glimpse2
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-bcftools/ww-bcftools.wdl" as bcftools
 
 struct ChromosomeData {
     String chromosome


### PR DESCRIPTION
## Type of Change

- Other: fixing import URL's

## Description

- No functional changes, just switching import URL's back to `main` for `ww-imputation`
- See GitHub Action test runs below just in case