### PR TITLE
Adding initial draft of `ww-edger` WILDS WDL module

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -324,6 +324,22 @@ tools:
       branches:
         - main
 
+  - name: ww-edger
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-edger/ww-edger.wdl
+    readMePath: /modules/ww-edger/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for differential expression analysis using edgeR
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-diamond
     subclass: WDL
     primaryDescriptorPath: /modules/ww-diamond/ww-diamond.wdl

--- a/modules/ww-edger/README.md
+++ b/modules/ww-edger/README.md
@@ -1,0 +1,223 @@
+# ww-edger
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for differential expression analysis using edgeR.
+
+## Overview
+
+This module provides a reusable WDL task for differential gene expression analysis using edgeR's quasi-likelihood (QL) pipeline. It takes a combined count matrix and sample metadata as input, applies TMM normalization, filters low-count genes with `filterByExpr`, fits a QL negative binomial model, and outputs comprehensive results and visualizations.
+
+The module is designed to accept the same count matrix format produced by `ww-deseq2`'s `combine_count_matrices` task, making it easy to run both tools side-by-side for comparison.
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
+
+- **Tasks**: `run_edger`
+- **Scripts**: `edger_analysis.R` (fetched via curl at runtime)
+- **Test workflow**: `testrun.wdl` (demonstration workflow using Pasilla test data)
+- **Containers**: `getwilds/edger:4.10.0` (edgeR analysis), `getwilds/python-utils:0.1.0` (count matrix prep and validation)
+- **Dependencies**: Integrates with `ww-testdata` module for test data generation
+
+## Scripts
+
+All scripts are fetched from this repository at runtime via `curl`. This keeps the Docker images generic and makes it easy to iterate on analysis logic without rebuilding containers.
+
+| Script | Used by | Language | Description |
+|--------|---------|----------|-------------|
+| [`edger_analysis.R`](edger_analysis.R) | `run_edger` | R | Runs the full edgeR QL pipeline: reads counts and metadata, applies `filterByExpr` filtering, calculates TMM normalization factors, estimates dispersion, fits a QL model, performs QL F-tests, and generates MD/BCV/volcano/heatmap plots with results CSVs |
+
+## Tasks
+
+### `run_edger`
+
+Performs differential expression analysis using edgeR's quasi-likelihood pipeline with TMM normalization.
+
+The analysis follows the recommended edgeR QL workflow:
+1. `DGEList` construction with TMM normalization via `calcNormFactors`
+2. Low-count gene filtering via `filterByExpr`
+3. Dispersion estimation via `estimateDisp`
+4. QL model fitting via `glmQLFit`
+5. QL F-test via `glmQLFTest`
+6. Results extraction via `topTags`
+
+**Inputs:**
+- `counts_matrix` (File): Combined matrix of gene-level counts (tab-delimited, genes as rows, samples as columns)
+- `sample_metadata` (File): Sample metadata with experimental conditions (tab-delimited)
+- `condition_column` (String): Column name containing experimental conditions (default: "condition")
+- `reference_level` (String): Reference/control level for the contrast (default: first alphabetically)
+- `contrast` (String): Contrast in format `treatment,control`; empty = use second vs. first factor level (default: "")
+- `fdr_threshold` (Float): FDR threshold for calling significant genes (default: 0.05)
+- `lfc_threshold` (Float): Minimum absolute log2 fold change for calling significant genes (default: 1.0)
+- `min_count` (Int): Minimum count per sample passed to `filterByExpr` (default: 10)
+- `min_total_count` (Int): Minimum total count across all samples passed to `filterByExpr` (default: 15)
+- `memory_gb` (Int): Memory allocation in GB (default: 8)
+- `cpu_cores` (Int): Number of CPU cores (default: 2)
+- `docker_image` (String): Docker image (default: `getwilds/edger:4.10.0`)
+
+**Outputs:**
+- `edger_results` (File): Complete edgeR results with statistics for all genes (logFC, logCPM, F, PValue, FDR)
+- `edger_significant` (File): Filtered results for genes meeting FDR and LFC thresholds
+- `edger_normalized_counts` (File): TMM-normalized CPM values for all samples
+- `edger_md_plot` (File): MD plot showing log fold change vs. mean log CPM
+- `edger_volcano_plot` (File): Volcano plot showing log fold change vs. statistical significance
+- `edger_heatmap` (File): Heatmap of top differentially expressed genes (up to 50)
+- `edger_bcv_plot` (File): Biological coefficient of variation plot showing dispersion estimates
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-edger/ww-edger.wdl" as edger_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
+
+workflow my_rna_seq_analysis {
+  input {
+    Array[File] star_count_files
+    Array[String] sample_names
+    Array[String] conditions
+    String treatment_condition
+    String control_condition
+  }
+
+  call deseq2_tasks.combine_count_matrices {
+    input:
+      gene_count_files = star_count_files,
+      sample_names = sample_names,
+      sample_conditions = conditions
+  }
+
+  call edger_tasks.run_edger {
+    input:
+      counts_matrix = combine_count_matrices.counts_matrix,
+      sample_metadata = combine_count_matrices.sample_metadata,
+      condition_column = "condition",
+      reference_level = control_condition,
+      contrast = "${treatment_condition},${control_condition}"
+  }
+
+  output {
+    File de_results = run_edger.edger_results
+    File significant_genes = run_edger.edger_significant
+    File md_plot = run_edger.edger_md_plot
+    File volcano_plot = run_edger.edger_volcano_plot
+    File heatmap = run_edger.edger_heatmap
+  }
+}
+```
+
+### Advanced Usage Examples
+
+**Explicit contrast specification:**
+```wdl
+call edger_tasks.run_edger {
+  input:
+    counts_matrix = my_counts,
+    sample_metadata = my_metadata,
+    condition_column = "treatment_group",
+    reference_level = "vehicle_control",
+    contrast = "drug_treated,vehicle_control"
+}
+```
+
+**Relaxed significance thresholds:**
+```wdl
+call edger_tasks.run_edger {
+  input:
+    counts_matrix = my_counts,
+    sample_metadata = my_metadata,
+    fdr_threshold = 0.10,
+    lfc_threshold = 0.5
+}
+```
+
+**Resource optimization for large datasets:**
+```wdl
+call edger_tasks.run_edger {
+  input:
+    counts_matrix = my_counts,
+    sample_metadata = my_metadata,
+    memory_gb = 16,
+    cpu_cores = 4
+}
+```
+
+### Integration Examples
+
+This module integrates seamlessly with other WILDS components:
+- **ww-deseq2**: Use `combine_count_matrices` to prepare input; run edgeR and DESeq2 side-by-side for robust DE calling
+- **ww-star**: Use gene count outputs from STAR alignment as input after combining with `combine_count_matrices`
+- **ww-testdata**: Automatic provisioning of Pasilla test count data and metadata
+- **Downstream analysis**: Results CSVs can feed into pathway enrichment or other analysis modules
+
+## Testing the Module
+
+The module includes a test workflow that runs with test data and requires no inputs:
+
+```bash
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl
+```
+
+### Test Data Workflow
+
+The test workflow automatically:
+1. Generates the Pasilla test dataset (7 samples, 10,000 genes) using `ww-testdata`
+2. Combines individual STAR count files into a count matrix
+3. Performs differential expression analysis with edgeR
+4. Generates all visualizations and results files
+5. Validates all outputs
+
+No input files or parameters are required.
+
+## Configuration Guidelines
+
+### Resource Allocation
+
+- **Memory**: 4-16 GB recommended (scales with dataset size)
+- **CPUs**: 1-4 cores recommended; edgeR is primarily single-threaded
+
+### Statistical Parameters
+
+- **contrast**: Specify as `treatment,control`; leave empty to compare second vs. first factor level
+- **reference_level**: Set control/baseline condition for proper fold change direction
+- **fdr_threshold**: 0.05 is standard; relax to 0.10 for exploratory analyses
+- **lfc_threshold**: 1.0 (2-fold change) is a common practical cutoff; set to 0 for FDR-only filtering
+
+### filterByExpr Parameters
+
+- **min_count**: Minimum count in the smallest group (default 10 matches edgeR's recommendation)
+- **min_total_count**: Minimum summed count across all samples (default 15); raise for larger datasets
+
+## Requirements
+
+- WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
+- Internet access for fetching scripts from GitHub at runtime
+- R environment with edgeR, ggplot2, pheatmap, RColorBrewer (provided by `getwilds/edger:4.10.0`)
+- Python 3 with pandas (provided by `getwilds/python-utils:0.1.0` for count matrix prep and validation)
+
+## Support
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+For questions specific to edgeR usage or interpretation, refer to the [edgeR user guide](https://bioconductor.org/packages/release/bioc/vignettes/edgeR/inst/doc/edgeRusersguide.pdf). Please cite their work if you use edgeR in your analyses:
+
+Chen Y, Lun ATL, Smyth GK. From reads to genes to pathways: differential expression analysis of RNA-Seq experiments using Rsubread and the edgeR quasi-likelihood pipeline. F1000Research. 2016;5:1438.
+
+Robinson MD, McCarthy DJ, Smyth GK. edgeR: a Bioconductor package for differential expression analysis of digital gene expression data. Bioinformatics. 2010;26(1):139-140.
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL module, please see our [contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/modules/ww-edger/edger_analysis.R
+++ b/modules/ww-edger/edger_analysis.R
@@ -1,0 +1,174 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(edgeR)
+  library(ggplot2)
+  library(pheatmap)
+  library(optparse)
+  library(RColorBrewer)
+})
+
+option_list <- list(
+  make_option("--counts_file", type="character", help="Path to input counts matrix file (tab-delimited, genes as rows)"),
+  make_option("--metadata_file", type="character", help="Path to sample metadata file (tab-delimited)"),
+  make_option("--condition_column", type="character", default="condition", help="Column in metadata to use for comparison [default: %default]"),
+  make_option("--reference_level", type="character", default="", help="Reference level for comparison [default: first alphabetically]"),
+  make_option("--contrast", type="character", default="", help="Contrast: 'treatment,control' [default: infer from condition_column]"),
+  make_option("--fdr_threshold", type="double", default=0.05, help="FDR threshold for significance [default: %default]"),
+  make_option("--lfc_threshold", type="double", default=1.0, help="Minimum absolute log2 fold change for significance [default: %default]"),
+  make_option("--min_count", type="integer", default=10, help="Minimum count for filterByExpr [default: %default]"),
+  make_option("--min_total_count", type="integer", default=15, help="Minimum total count for filterByExpr [default: %default]"),
+  make_option("--output_prefix", type="character", default="edger_results", help="Prefix for output files [default: %default]")
+)
+
+opt <- parse_args(OptionParser(option_list=option_list))
+
+if (is.null(opt$counts_file) || is.null(opt$metadata_file)) {
+  stop("Counts file and metadata file are required")
+}
+
+cat("Reading input data...\n")
+counts_data <- read.delim(opt$counts_file, row.names=1, check.names=FALSE)
+sample_metadata <- read.delim(opt$metadata_file, row.names=1, check.names=FALSE)
+
+common_samples <- intersect(colnames(counts_data), rownames(sample_metadata))
+if (length(common_samples) == 0) {
+  stop("No matching samples between counts and metadata")
+}
+counts_data <- counts_data[, common_samples]
+sample_metadata <- sample_metadata[common_samples, , drop=FALSE]
+
+if (!opt$condition_column %in% colnames(sample_metadata)) {
+  stop("Condition column '", opt$condition_column, "' not found in metadata")
+}
+
+condition <- as.factor(sample_metadata[[opt$condition_column]])
+if (length(levels(condition)) < 2) {
+  stop("Need at least two different levels in condition column for comparison")
+}
+
+if (opt$reference_level != "") {
+  if (!opt$reference_level %in% levels(condition)) {
+    stop("Reference level '", opt$reference_level, "' not found in condition column")
+  }
+  condition <- relevel(condition, ref=opt$reference_level)
+}
+
+cat("Setting up DGEList...\n")
+dge <- DGEList(counts=round(counts_data), group=condition)
+
+cat("Filtering low-count genes with filterByExpr...\n")
+cat("Genes before filtering:", nrow(dge), "\n")
+keep <- filterByExpr(dge, min.count=opt$min_count, min.total.count=opt$min_total_count)
+dge <- dge[keep, , keep.lib.sizes=FALSE]
+cat("Genes after filtering:", nrow(dge), "\n")
+
+cat("Calculating TMM normalization factors...\n")
+dge <- calcNormFactors(dge, method="TMM")
+
+cat("Estimating dispersion...\n")
+design <- model.matrix(~ condition)
+dge <- estimateDisp(dge, design)
+
+cat("Creating BCV plot...\n")
+pdf(paste0(opt$output_prefix, "_bcv_plot.pdf"), width=8, height=6)
+plotBCV(dge, main="Biological Coefficient of Variation")
+dev.off()
+
+cat("Fitting quasi-likelihood model...\n")
+fit <- glmQLFit(dge, design)
+
+cat("Running quasi-likelihood F-test...\n")
+if (opt$contrast != "") {
+  contrast_parts <- strsplit(opt$contrast, ",")[[1]]
+  if (length(contrast_parts) != 2) {
+    stop("Contrast should be in format: treatment,control")
+  }
+  treatment <- contrast_parts[1]
+  control <- contrast_parts[2]
+  contrast_levels <- levels(condition)
+  treatment_idx <- which(contrast_levels == treatment)
+  control_idx <- which(contrast_levels == control)
+  if (length(treatment_idx) == 0 || length(control_idx) == 0) {
+    stop("One or both contrast levels not found in condition column")
+  }
+  contrast_vec <- makeContrasts(
+    contrasts=paste0("condition", treatment, "-condition", control),
+    levels=design
+  )
+  qlf <- glmQLFTest(fit, contrast=contrast_vec)
+} else {
+  qlf <- glmQLFTest(fit, coef=2)
+}
+
+cat("Extracting results...\n")
+all_results <- topTags(qlf, n=Inf, sort.by="PValue")$table
+all_results$gene <- rownames(all_results)
+
+sig_results <- subset(all_results, FDR < opt$fdr_threshold & abs(logFC) >= opt$lfc_threshold)
+cat("Significant genes (FDR <", opt$fdr_threshold, ", |LFC| >=", opt$lfc_threshold, "):", nrow(sig_results), "\n")
+
+cat("Computing normalized CPM...\n")
+norm_cpm <- cpm(dge, normalized.lib.sizes=TRUE, log=FALSE)
+
+cat("Writing output files...\n")
+write.csv(all_results, file=paste0(opt$output_prefix, "_all_genes.csv"), row.names=FALSE)
+write.csv(sig_results, file=paste0(opt$output_prefix, "_significant.csv"), row.names=FALSE)
+write.csv(norm_cpm, file=paste0(opt$output_prefix, "_normalized_cpm.csv"))
+
+cat("Creating MD plot...\n")
+pdf(paste0(opt$output_prefix, "_md_plot.pdf"), width=8, height=6)
+plotMD(qlf, main="MD Plot")
+abline(h=c(-opt$lfc_threshold, opt$lfc_threshold), col="blue", lty=2)
+dev.off()
+
+cat("Creating volcano plot...\n")
+volcano_data <- all_results
+volcano_data$significant <- ifelse(
+  volcano_data$FDR < opt$fdr_threshold & abs(volcano_data$logFC) >= opt$lfc_threshold,
+  "Significant", "Not Sig"
+)
+volcano_data$neg_log10_fdr <- -log10(volcano_data$FDR)
+
+volcano_plot <- ggplot(volcano_data, aes(x=logFC, y=neg_log10_fdr, color=significant)) +
+  geom_point(alpha=0.6) +
+  scale_color_manual(values=c("Significant"="red", "Not Sig"="grey")) +
+  theme_classic() +
+  geom_vline(xintercept=c(-opt$lfc_threshold, opt$lfc_threshold), linetype="dashed") +
+  geom_hline(yintercept=-log10(opt$fdr_threshold), linetype="dashed") +
+  labs(x="Log2 Fold Change", y="-Log10 FDR", color="Significance") +
+  ggtitle("Volcano Plot")
+ggsave(paste0(opt$output_prefix, "_volcano.pdf"), volcano_plot, width=8, height=6)
+
+cat("Creating heatmap...\n")
+if (nrow(sig_results) > 0) {
+  top_genes <- rownames(sig_results)[1:min(50, nrow(sig_results))]
+  log_cpm <- cpm(dge, normalized.lib.sizes=TRUE, log=TRUE, prior.count=2)
+  heatmap_data <- log_cpm[top_genes, ]
+  heatmap_data_z <- t(scale(t(heatmap_data)))
+
+  anno_col <- data.frame(Condition=sample_metadata[[opt$condition_column]])
+  rownames(anno_col) <- colnames(heatmap_data)
+
+  pheatmap(
+    heatmap_data_z,
+    annotation_col=anno_col,
+    clustering_distance_rows="correlation",
+    clustering_distance_cols="correlation",
+    show_rownames=TRUE,
+    show_colnames=TRUE,
+    fontsize_row=8,
+    color=colorRampPalette(rev(brewer.pal(11, "RdBu")))(255),
+    filename=paste0(opt$output_prefix, "_heatmap.pdf"),
+    width=8,
+    height=10
+  )
+} else {
+  cat("No significant genes found for heatmap.\n")
+  pdf(paste0(opt$output_prefix, "_heatmap.pdf"), width=8, height=6)
+  plot.new()
+  text(0.5, 0.5, "No significant differentially expressed genes found")
+  dev.off()
+}
+
+cat("edgeR analysis complete!\n")

--- a/modules/ww-edger/testrun.wdl
+++ b/modules/ww-edger/testrun.wdl
@@ -1,0 +1,204 @@
+version 1.0
+
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-edger.wdl" as ww_edger
+
+workflow edger_example {
+  call ww_testdata.generate_pasilla_counts as generate_test_data { input:
+      n_samples = 7,
+      n_genes = 10000,
+      condition_name = "condition"
+  }
+
+  call ww_deseq2_combine_counts as combine_counts { input:
+      gene_count_files = generate_test_data.individual_count_files,
+      sample_names = generate_test_data.sample_names,
+      sample_conditions = generate_test_data.sample_conditions
+  }
+
+  call ww_edger.run_edger { input:
+      counts_matrix = combine_counts.counts_matrix,
+      sample_metadata = combine_counts.sample_metadata,
+      condition_column = "condition",
+      reference_level = "",
+      contrast = ""
+  }
+
+  call validate_outputs { input:
+      edger_results = run_edger.edger_results,
+      edger_significant = run_edger.edger_significant,
+      normalized_counts = run_edger.edger_normalized_counts,
+      expected_samples = length(generate_test_data.sample_names)
+  }
+
+  output {
+    File combined_counts_matrix = combine_counts.counts_matrix
+    File final_metadata = combine_counts.sample_metadata
+    File edger_all_results = run_edger.edger_results
+    File edger_significant_results = run_edger.edger_significant
+    File edger_normalized_cpm = run_edger.edger_normalized_counts
+    File edger_md_plot = run_edger.edger_md_plot
+    File edger_volcano_plot = run_edger.edger_volcano_plot
+    File edger_heatmap = run_edger.edger_heatmap
+    File edger_bcv_plot = run_edger.edger_bcv_plot
+    File validation_report = validate_outputs.validation_report
+  }
+}
+
+task ww_deseq2_combine_counts {
+  meta {
+    description: "Combine STAR gene count files from multiple samples into a single count matrix for edgeR input"
+    outputs: {
+        counts_matrix: "Combined matrix of gene-level counts from all samples",
+        sample_metadata: "Metadata file containing sample names and conditions"
+    }
+  }
+
+  parameter_meta {
+    gene_count_files: "Array of STAR gene count files (ReadsPerGene.out.tab) from each sample"
+    sample_names: "Array of sample names corresponding to the gene_count_files"
+    sample_conditions: "Array of experimental conditions corresponding to each sample"
+    count_column: "Column number in STAR count files to extract (2=unstranded, 3=forward strand, 4=reverse strand)"
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    Array[File] gene_count_files
+    Array[String] sample_names
+    Array[String] sample_conditions
+    Int count_column = 2
+    Int memory_gb = 4
+    Int cpu_cores = 1
+    String docker_image = "getwilds/python-utils:0.1.0"
+  }
+
+  command <<<
+    set -eo pipefail
+
+    curl -so combine_star_counts.py \
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/combine_star_counts.py"
+
+    python combine_star_counts.py \
+      --input ~{sep=" " gene_count_files} \
+      --names ~{sep=" " sample_names} \
+      --conditions ~{sep=" " sample_conditions} \
+      --output combined_counts_matrix.txt \
+      --count_column ~{count_column}
+  >>>
+
+  output {
+    File counts_matrix = "combined_counts_matrix.txt"
+    File sample_metadata = "sample_metadata.txt"
+  }
+
+  runtime {
+    docker: docker_image
+    memory: "~{memory_gb} GB"
+    cpu: cpu_cores
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate edgeR analysis outputs for correctness and completeness"
+    outputs: {
+        validation_report: "Report summarizing validation results and any issues found"
+    }
+  }
+
+  parameter_meta {
+    edger_results: "edgeR all-genes results file to validate"
+    edger_significant: "Significant results file to validate"
+    normalized_counts: "Normalized CPM counts file to validate"
+    expected_samples: "Expected number of samples in the analysis"
+    expected_genes_min: "Minimum expected number of genes in results"
+  }
+
+  input {
+    File edger_results
+    File edger_significant
+    File normalized_counts
+    Int expected_samples
+    Int expected_genes_min = 1000
+  }
+
+  command <<<
+    set -eo pipefail
+
+    python3 << 'EOF'
+import pandas as pd
+import sys
+
+validation_issues = []
+
+try:
+    results_df = pd.read_csv("~{edger_results}")
+    print(f"Results file loaded: {len(results_df)} genes")
+
+    required_cols = ["logFC", "logCPM", "F", "PValue", "FDR"]
+    missing_cols = [col for col in required_cols if col not in results_df.columns]
+    if missing_cols:
+        validation_issues.append(f"Missing required columns in results: {missing_cols}")
+    else:
+        print("All required columns present in results")
+
+    if len(results_df) < ~{expected_genes_min}:
+        validation_issues.append(f"Too few genes in results: {len(results_df)} < ~{expected_genes_min}")
+
+except Exception as e:
+    validation_issues.append(f"Failed to validate results file: {str(e)}")
+
+try:
+    sig_df = pd.read_csv("~{edger_significant}")
+    print(f"Significant results file loaded: {len(sig_df)} genes")
+
+    if len(sig_df) > len(results_df):
+        validation_issues.append("More significant genes than total genes")
+
+except Exception as e:
+    validation_issues.append(f"Failed to validate significant results file: {str(e)}")
+
+try:
+    counts_df = pd.read_csv("~{normalized_counts}", index_col=0)
+    print(f"Normalized CPM loaded: {counts_df.shape[0]} genes, {counts_df.shape[1]} samples")
+
+    if counts_df.shape[1] != ~{expected_samples}:
+        validation_issues.append(f"Expected ~{expected_samples} samples, got {counts_df.shape[1]}")
+
+    if (counts_df < 0).any().any():
+        validation_issues.append("Negative values found in normalized CPM counts")
+
+except Exception as e:
+    validation_issues.append(f"Failed to validate normalized counts: {str(e)}")
+
+with open("validation_report.txt", "w") as f:
+    f.write("edgeR Output Validation Report\n")
+    f.write("=" * 33 + "\n\n")
+
+    if validation_issues:
+        f.write("VALIDATION FAILED\n")
+        f.write("Issues found:\n")
+        for issue in validation_issues:
+            f.write(f"- {issue}\n")
+        sys.exit(1)
+    else:
+        f.write("VALIDATION PASSED\n")
+        f.write("All outputs validated successfully.\n")
+
+EOF
+
+    echo "Validation completed successfully"
+  >>>
+
+  output {
+    File validation_report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "getwilds/python-utils:0.1.0"
+    memory: "2 GB"
+    cpu: 1
+  }
+}

--- a/modules/ww-edger/ww-edger.wdl
+++ b/modules/ww-edger/ww-edger.wdl
@@ -23,11 +23,11 @@ task run_edger {
     topic: "transcriptomics,gene_expression"
     species: "human,eukaryote,prokaryote,virus"
     operation: "statistical_calculation"
-    input_sample_required: "counts_matrix:gene_expression_matrix:matrix,sample_metadata:report:textual_format"
+    input_sample_required: "counts_matrix:gene_expression_matrix:tsv,sample_metadata:report:textual_format"
     input_sample_optional: "none"
     input_reference_required: "none"
     input_reference_optional: "none"
-    output_sample: "edger_results:report:csv,edger_significant:report:csv,edger_normalized_counts:report:csv,edger_md_plot:plot:pdf,edger_volcano_plot:plot:pdf,edger_heatmap:plot:pdf"
+    output_sample: "edger_results:report:csv,edger_significant:report:csv,edger_normalized_counts:report:csv,edger_md_plot:plot:pdf,edger_volcano_plot:plot:pdf,edger_heatmap:plot:pdf,edger_bcv_plot:plot:pdf"
     output_reference: "none"
   }
 

--- a/modules/ww-edger/ww-edger.wdl
+++ b/modules/ww-edger/ww-edger.wdl
@@ -1,0 +1,98 @@
+## WILDS WDL Module: ww-edger
+## Description: Module for differential expression analysis using edgeR
+## Author: Taylor Firman
+## Contact: tfirman@fredhutch.org
+
+version 1.0
+
+task run_edger {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Perform differential expression analysis using edgeR's quasi-likelihood pipeline"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-edger/ww-edger.wdl"
+    outputs: {
+        edger_results: "Complete edgeR differential expression results with statistics for all genes",
+        edger_significant: "Filtered results containing only statistically significant differentially expressed genes",
+        edger_normalized_counts: "TMM-normalized CPM values for all samples",
+        edger_md_plot: "MD plot showing log fold change vs. mean log CPM",
+        edger_volcano_plot: "Volcano plot showing log fold change vs. statistical significance",
+        edger_heatmap: "Heatmap visualization of differentially expressed genes across samples",
+        edger_bcv_plot: "Biological coefficient of variation plot showing dispersion estimates"
+    }
+    topic: "transcriptomics,gene_expression"
+    species: "human,eukaryote,prokaryote,virus"
+    operation: "statistical_calculation"
+    input_sample_required: "counts_matrix:gene_expression_matrix:matrix,sample_metadata:report:textual_format"
+    input_sample_optional: "none"
+    input_reference_required: "none"
+    input_reference_optional: "none"
+    output_sample: "edger_results:report:csv,edger_significant:report:csv,edger_normalized_counts:report:csv,edger_md_plot:plot:pdf,edger_volcano_plot:plot:pdf,edger_heatmap:plot:pdf"
+    output_reference: "none"
+  }
+
+  parameter_meta {
+    counts_matrix: "Combined matrix of gene-level counts (genes as rows, samples as columns, tab-delimited with header)"
+    sample_metadata: "Metadata file containing sample information including experimental conditions (tab-delimited with header)"
+    condition_column: "Column name in the metadata file that contains the experimental condition"
+    reference_level: "Reference level for the contrast (typically the control condition; empty = first alphabetically)"
+    contrast: "Contrast string in the format 'treatment,control' to specify comparison (empty = infer from condition_column)"
+    fdr_threshold: "FDR threshold for calling significant genes"
+    lfc_threshold: "Minimum absolute log2 fold change threshold for calling significant genes"
+    min_count: "Minimum count threshold used by filterByExpr for low-count gene filtering"
+    min_total_count: "Minimum total count across all samples used by filterByExpr"
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    File counts_matrix
+    File sample_metadata
+    String condition_column = "condition"
+    String reference_level = ""
+    String contrast = ""
+    Float fdr_threshold = 0.05
+    Float lfc_threshold = 1.0
+    Int min_count = 10
+    Int min_total_count = 15
+    Int memory_gb = 8
+    Int cpu_cores = 2
+    String docker_image = "getwilds/edger:4.10.0"
+  }
+
+  command <<<
+    set -eo pipefail
+
+    curl -so edger_analysis.R \
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-edger-module/modules/ww-edger/edger_analysis.R"
+
+    Rscript edger_analysis.R \
+      --counts_file="~{counts_matrix}" \
+      --metadata_file="~{sample_metadata}" \
+      --condition_column="~{condition_column}" \
+      --reference_level="~{reference_level}" \
+      --contrast="~{contrast}" \
+      --fdr_threshold=~{fdr_threshold} \
+      --lfc_threshold=~{lfc_threshold} \
+      --min_count=~{min_count} \
+      --min_total_count=~{min_total_count} \
+      --output_prefix="edger_results"
+  >>>
+
+  output {
+    File edger_results = "edger_results_all_genes.csv"
+    File edger_significant = "edger_results_significant.csv"
+    File edger_normalized_counts = "edger_results_normalized_cpm.csv"
+    File edger_md_plot = "edger_results_md_plot.pdf"
+    File edger_volcano_plot = "edger_results_volcano.pdf"
+    File edger_heatmap = "edger_results_heatmap.pdf"
+    File edger_bcv_plot = "edger_results_bcv_plot.pdf"
+  }
+
+  runtime {
+    docker: docker_image
+    memory: "~{memory_gb} GB"
+    cpu: cpu_cores
+  }
+}


### PR DESCRIPTION
## Type of Change

- New module

## Description

Adds `ww-edger`, a new WILDS WDL module for differential expression analysis using [edgeR](https://bioconductor.org/packages/release/bioc/html/edgeR.html), a core [Bioconductor](https://bioconductor.org/) package. This module is part of an ongoing effort to bring key Bioconductor tools into the WILDS ecosystem, and complements the existing `ww-deseq2` module by giving users a second well-established DE framework to run alongside or instead of DESeq2.

The module implements edgeR's recommended quasi-likelihood (QL) pipeline:
1. `DGEList` construction with TMM normalization via `calcNormFactors`
2. Low-count gene filtering via `filterByExpr`
3. Dispersion estimation via `estimateDisp`
4. QL model fitting via `glmQLFit`
5. QL F-test via `glmQLFTest`
6. Results extraction via `topTags`

The `run_edger` task accepts the same count matrix and sample metadata format produced by `ww-deseq2`'s `combine_count_matrices` task, so both tools can be run on the same inputs with minimal extra configuration.

**Outputs:** all-genes results CSV, significant genes CSV, TMM-normalized CPM matrix, MD plot, volcano plot, heatmap (top 50 DE genes), and BCV plot.

**Docker image:** `getwilds/edger:4.10.0`

**Note:** The curl in `ww-edger.wdl` currently points to this branch (`add-edger-module`) so the test run works before merge. It will be flipped back to `refs/heads/main` before or after merge.

## Testing

**How did you test these changes?**
Ran `make lint NAME=ww-edger` locally, CI test run below using all three execution engines, will run on PROOF as well.

**What workflow engine did you use?**
Sprocket (lint), Cromwell/miniWDL/Sprocket (CI), PROOF/Cromwell (PROOF)

**Did the tests pass?**
Lint and CI both pass clean across all three engines (sprocket, miniwdl, WOMtool). TBD for PROOF.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- This module is part of a broader effort to incorporate Bioconductor tools into WILDS, including a planned OSCA stack addition. It will be highlighted at BioC2026 next month.
- This module is registered in `.dockstore.yml` under `tools:` between `ww-deseq2` and `ww-diamond` (alphabetical order).
- The `testrun.wdl` reuses the Pasilla test dataset from `ww-testdata` (same as `ww-deseq2`) and includes an inline count-matrix-combine task rather than importing `ww-deseq2` directly, keeping the module self-contained per project conventions.
- `edger_analysis.R` is fetched at runtime via curl (same pattern as `deseq2_analysis.R`).