### PR TITLE
Fixing `gpu` runtime parameter and updating contributor docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Note: `testrun.wdl` files use relative path imports (unlike the pipeline source 
 - Use descriptive parameter names
 - Include optional parameters with sensible defaults
 - Support both single samples and batch processing where applicable
-- GPU tasks should expose a `Boolean gpu_enabled` input and use `gpu: gpu_enabled` in the runtime block (not `gpus: "1"`)
+- GPU tasks should expose a `Boolean gpu_enabled` input and use `gpu: gpu_enabled` in the runtime block
 
 **Docker image preferences:**
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -145,12 +145,14 @@ Note: `testrun.wdl` files use relative path imports (unlike the pipeline source 
 - Use descriptive parameter names
 - Include optional parameters with sensible defaults
 - Support both single samples and batch processing where applicable
+- GPU tasks should expose a `Boolean gpu_enabled` input and use `gpu: gpu_enabled` in the runtime block (not `gpus: "1"`)
 
 **Docker image preferences:**
 
 - Use images from the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) when available
 - If creating new images, follow WILDS container standards and consider contributing to the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library).
 - Specify exact image versions (avoid `latest` tags)
+- Declare the image as an overridable input parameter with a pinned default: `String docker_image = "getwilds/tool:version"` in the task `input` block, referenced via `docker: docker_image` in the `runtime` block
 - Document image dependencies in the README
 
 **Module manifest (`module.json`), experimental:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ pipelines/ww-pipeline-name/
 - Every task needs `meta` (author, email, description, url, outputs) and `parameter_meta` blocks
 - Command blocks: start with `set -eo pipefail`, use `<<<...>>>` heredoc syntax
 - Docker images: always from `getwilds/` with exact version pins (never `latest`); declared as `String docker_image = "getwilds/tool:version"` in the `input` block and referenced via `docker: docker_image` in `runtime`
-- Resource params: `cpu_cores` and `memory_gb` with sensible defaults
+- Resource params: `cpu_cores` and `memory_gb` with sensible defaults; GPU tasks add `gpu_enabled Boolean` and use `gpu: gpu_enabled` in the runtime block
 - Pipeline and module source WDL files (`ww-*.wdl`) use GitHub raw URL imports: `https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-*/ww-*.wdl`
 - `testrun.wdl` and `testrun_hpc.wdl` use relative path imports (e.g. `"./ww-toolname.wdl"`, `"../ww-testdata/ww-testdata.wdl"`)
 - Modules are self-contained: `ww-<toolname>.wdl` files never import other modules. Cross-module composition happens only in `testrun.wdl` (for test fixtures) and in pipelines. If a task needs another tool's output, add it to the existing module rather than introducing a cross-module import in the source WDL.

--- a/modules/ww-cellbender/ww-cellbender.wdl
+++ b/modules/ww-cellbender/ww-cellbender.wdl
@@ -104,6 +104,6 @@ task remove_background {
     docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
+    gpu: gpu_enabled
   }
 }

--- a/modules/ww-clair3/README.md
+++ b/modules/ww-clair3/README.md
@@ -50,7 +50,7 @@ Runs Clair3 to call germline variants from aligned reads using deep learning pil
 - `ctg_name` (String?, optional): Contig/chromosome name to restrict calling
 - `include_all_ctgs` (Boolean, default=false): Call on all contigs (required for non-human species)
 - `pileup_only` (Boolean, default=false): Use only the pileup model for faster variant calling (skips full-alignment stage)
-- `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for Clair3 inference. Note: the `gpus` runtime attribute is specified as a string (e.g., `"1"`) rather than an integer, as required by Fred Hutch PROOF/Cromwell configuration, but can be adjusted as necessary.
+- `gpu_enabled` (Boolean, default=false): Enable GPU acceleration for Clair3 inference. Passed directly to the `gpu` runtime attribute.
 - `cpu_cores` (Int, default=8): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=32): Memory allocated for the task in GB
 - `docker_image` (String, default=`getwilds/clair3:2.0.0`): Docker image to use for this task

--- a/modules/ww-clair3/ww-clair3.wdl
+++ b/modules/ww-clair3/ww-clair3.wdl
@@ -113,6 +113,6 @@ task run_clair3 {
     docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
+    gpu: gpu_enabled
   }
 }

--- a/modules/ww-colabfold/README.md
+++ b/modules/ww-colabfold/README.md
@@ -188,13 +188,7 @@ The test workflow runs on CPU (`gpu_enabled = false`) with minimal settings for 
 
 The `gpu_enabled` input controls two things:
 1. **JAX execution mode**: When `false`, sets `JAX_PLATFORMS=cpu` to force CPU-only execution
-2. **PROOF GPU allocation**: Translates to the `gpus` runtime attribute (`"1"` or `"0"`), which is specific to PROOF's Cromwell configuration. Other executors like miniWDL and Sprocket silently ignore this attribute.
-
-### For PROOF Users
-GPU allocation works automatically with the default (`gpu_enabled = true`). ColabFold only supports a single GPU for structure prediction.
-
-### For Other Executors
-Configure GPU passthrough at the engine level (e.g., Docker `--gpus` flag). Set `gpu_enabled = true` to ensure ColabFold uses the GPU via JAX.
+2. **GPU allocation**: Passed directly to the `gpu` runtime attribute, honored by Cromwell (including PROOF), miniWDL, and Sprocket alike. ColabFold only supports a single GPU for structure prediction.
 
 ### CPU-Only Mode
 Set `gpu_enabled = false` to force CPU execution via `JAX_PLATFORMS=cpu`. This is functional but significantly slower and intended primarily for testing.

--- a/modules/ww-colabfold/ww-colabfold.wdl
+++ b/modules/ww-colabfold/ww-colabfold.wdl
@@ -170,6 +170,6 @@ task colabfold_predict {
     docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
+    gpu: gpu_enabled
   }
 }

--- a/modules/ww-esmfold/ww-esmfold.wdl
+++ b/modules/ww-esmfold/ww-esmfold.wdl
@@ -86,6 +86,6 @@ task esmfold_predict {
     docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
+    gpu: gpu_enabled
   }
 }

--- a/modules/ww-starling/ww-starling.wdl
+++ b/modules/ww-starling/ww-starling.wdl
@@ -80,7 +80,7 @@ task generate_ensemble {
     docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
+    gpu: gpu_enabled
   }
 }
 
@@ -156,7 +156,7 @@ task generate_ensemble_batch {
     docker: docker_image
     cpu: cpu_cores
     memory: "~{memory_gb} GB"
-    gpus: if gpu_enabled then "1" else "0"
+    gpu: gpu_enabled
   }
 }
 


### PR DESCRIPTION
## Type of Change

- Bug fix
- Documentation update

## Description

Fixes the GPU runtime parameter in all GPU-enabled modules, switching from the non-standard `gpus: if gpu_enabled then "1" else "0"` pattern to the correct `gpu: gpu_enabled` boolean form supported by Cromwell (via its backend config), miniWDL, and Sprocket.

Affected modules: `ww-cellbender`, `ww-clair3`, `ww-colabfold`, `ww-esmfold`, `ww-starling` (two tasks).

Also adds documentation for this convention and the `docker_image` input parameter pattern in `AGENTS.md` and `.github/CONTRIBUTING.md`.

## Testing

**How did you test these changes?**
CI/CD test runs below and test run execution on Dev PROOF Workbench

**What workflow engine did you use?**
Sprocket, miniwdl, Cromwell for CI/CD, PROOF/Cromwell for HPC testing

**Did the tests pass?**
In progress...

## Documentation

- [x] ~~I updated the README (if applicable)~~
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] ~~I ran `make docs` to check documentation rendering (if applicable)~~

## Additional Context

All five modules remain at `version 1.0`, as `gpu: Boolean` should still work via Cromwell's backend configuration, so no version bump is needed.
