### PR TITLE
Adding Redd Wang as a contributor

### DIFF
--- a/pipelines/ww-proseq/README.md
+++ b/pipelines/ww-proseq/README.md
@@ -242,7 +242,7 @@ For the qPRO-seq variant this pipeline implements and the reference shell pipeli
 
 ## Acknowledgments
 
-This pipeline was developed in collaboration with [Ruihong Wang](https://github.com/redd-wang) through the [WILDS WDL Development Program](https://sciwiki.fredhutch.org/datascience/wilds_workflow_dev/). Thank you for the initial motivation and testing!
+This pipeline was developed in collaboration with [Redd Wang](https://github.com/redd-wang) through the [WILDS WDL Development Program](https://sciwiki.fredhutch.org/datascience/wilds_workflow_dev/). Thank you for the initial motivation and testing!
 
 ## Support
 


### PR DESCRIPTION
## Type of Change

- Other: contributor addition

## Description

Fixing Redd Wang's author name in the `ww-proseq` README and adding him as a co-author on the commit to list him as a contributor in the GitHub repo. No functional change to `ww-proseq`, no testing necessary.