### PR TITLE
Adding more module json's in anticipation of WDL v1.4

### DIFF
--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -34,7 +34,7 @@ Also review `modules/ww-testdata/ww-testdata.wdl` to see what test data is avail
 
 ### 3. Create the Module Files
 
-Create three files in `modules/ww-$ARGUMENTS/`:
+Create four files in `modules/ww-$ARGUMENTS/`:
 
 #### `ww-$ARGUMENTS.wdl`
 - Start with `version 1.0`
@@ -63,6 +63,15 @@ Create three files in `modules/ww-$ARGUMENTS/`:
 #### `README.md`
 - Follow the exact format of `modules/ww-template/README.md`
 - Include: badges, overview, module structure, available tasks (with inputs/outputs), usage examples, testing instructions, Docker container info, citations, parameters/resources
+
+#### `module.json`
+- Use an existing module's `module.json` as a template (e.g. `modules/ww-bwa/module.json`) rather than writing one from scratch. Field definitions come from the upstream spec linked in `.github/CONTRIBUTING.md`; don't rely on your own summary of that spec, since it has changed before.
+- `name` is the module directory name, `license` is `"MIT"` (this repo's own license, not the wrapped tool's)
+- Omit the top-level `version` field entirely
+- Add one `tools[]` entry for the wrapped tool: `name`, `version` (matching the pinned Docker tag), and `license` (current SPDX identifier, e.g. `GPL-3.0-only`). Use `url` for the tool's homepage/repo and `ids` for identifiers as CURIE strings (e.g. `["doi:10.1093/bioinformatics/btp324"]`) if you have a real one; don't fabricate one. Never use `homepage` or `doi` fields directly on a `tools[]` entry.
+- If the tool has a nonstandard license, use an SPDX `LicenseRef-` placeholder (e.g. `"LicenseRef-VarScan-NonCommercial"`) and call it out in the summary at the end of this skill.
+- If the module doesn't wrap one clear external tool (e.g. a data-download utility or a custom script), omit `tools[]` entirely.
+- Run `make lint_module_json NAME=ww-$ARGUMENTS` to validate structure.
 
 ### 4. Lint the Module
 
@@ -98,4 +107,5 @@ Report to the user:
 - What files were created
 - What Docker image and version was used
 - What test data tasks are used
+- Any nonstandard tool license used in `module.json` (`LicenseRef-*` placeholder) that needs reviewer sign-off
 - Any issues that need follow-up (missing Docker image, missing test data in ww-testdata, lint warnings, etc.)

--- a/.agents/skills/create-pipeline/SKILL.md
+++ b/.agents/skills/create-pipeline/SKILL.md
@@ -43,7 +43,7 @@ Present the design to the user for confirmation before proceeding.
 
 ### 4. Create Pipeline Files
 
-Create four files in `pipelines/ww-$0/`:
+Create five files in `pipelines/ww-$0/`:
 
 #### `ww-$0.wdl`
 - `version 1.0`
@@ -87,6 +87,12 @@ Create four files in `pipelines/ww-$0/`:
 #### `README.md`
 - Follow existing pipeline README format (see `pipelines/ww-sra-star/README.md` or `pipelines/ww-star-deseq2/README.md`)
 - Include: badges, overview, complexity level, pipeline structure, module dependencies, usage, input parameters, output files, testing section, citations
+
+#### `module.json`
+- Use `pipelines/ww-bwa-gatk/module.json` as the template. Field definitions come from the upstream spec linked in `.github/CONTRIBUTING.md`; don't rely on your own summary of that spec, since it has changed before.
+- `name` is the pipeline directory name, `license` is `"MIT"`, omit the top-level `version` field
+- Add a `dependencies{}` entry for each module imported in `ww-$0.wdl`, one per module, following the `git`/`branch`/`path` pattern in the template (pointing at this repo's `main` branch and `modules/ww-<name>`)
+- Run `make lint_module_json NAME=ww-$0` to validate structure.
 
 ### 5. Lint the Pipeline
 

--- a/.agents/skills/lint-module/SKILL.md
+++ b/.agents/skills/lint-module/SKILL.md
@@ -34,7 +34,7 @@ make lint_sprocket NAME=$ARGUMENTS
 
 For each lint error:
 - Read the relevant WDL file
-- Fix the issue following project conventions (see CLAUDE.md)
+- Fix the issue following project conventions (see AGENTS.md)
 - Re-run linting to confirm the fix
 
 **Known Sprocket exceptions** (these are OK and won't cause failures):

--- a/.agents/skills/lint-module/SKILL.md
+++ b/.agents/skills/lint-module/SKILL.md
@@ -23,7 +23,7 @@ Check if `$ARGUMENTS` exists in `modules/` or `pipelines/`:
 make lint NAME=$ARGUMENTS
 ```
 
-This runs sprocket, miniwdl, and WOMtool linters.
+This runs sprocket, miniwdl, WOMtool, Cirro validation (pipelines only), and module.json structural validation (if a module.json is present).
 
 If make targets aren't available, run sprocket directly:
 ```bash

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -153,15 +153,17 @@ Note: `testrun.wdl` files use relative path imports (unlike the pipeline source 
 - Specify exact image versions (avoid `latest` tags)
 - Document image dependencies in the README
 
-**Module manifest (`module.json`), experimental:**
+**Module manifest (`module.json`):**
 
-You may notice `module.json` files in a handful of modules (currently `ww-bwa`, `ww-gatk`) and pipelines (`ww-bwa-gatk`). These are an early experiment with the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765), which standardizes module metadata (name, version, license, upstream tool provenance, and dependency declarations). The format has been informally validated against Sprocket's `wdl-modules` crate by collaborators at St. Jude.
+Every module and pipeline in this library ships a `module.json` manifest, an early adoption of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765). For the schema itself (field definitions, dependency selectors, versioning rules) see the spec's [`modules/SPEC.md`](https://github.com/openwdl/wdl/blob/wdl-1.4/modules/SPEC.md) and [`module.schema.json`](https://github.com/openwdl/wdl/blob/wdl-1.4/modules/schemas/module.schema.json). Since the spec is still unmerged and changing, treat that upstream source as ground truth over any summary written here or elsewhere in this repo.
 
-A few things to know:
+WILDS-specific conventions on top of the spec:
 
-- **Contributors are not required to add `module.json` files.** No executor consumes them at runtime yet, and the upstream spec is still unmerged. We're keeping a small set of examples around so the library is ready when tooling support arrives.
-- **The schema is a moving target.** Field names and constraints may change before the spec is finalized.
-- **If you do add one**, license strings must use current [SPDX identifiers](https://spdx.org/licenses/) (e.g. `GPL-3.0-only`, not `GPL-3.0`). The parser rejects deprecated forms.
+- **Add a `module.json` for every new module and pipeline.** No executor consumes it at runtime yet, but please add one anyway to keep the library consistent. Use an existing module's `module.json` as a template.
+- **CI validates structure**, not content: `make lint_module_json` (see `.github/scripts/validate_module_json.py`) checks any `module.json` it finds against the spec's required fields and shapes.
+- **This repo's own `license` is always `"MIT"`.** Per-tool licenses in `tools[]` must use current [SPDX identifiers](https://spdx.org/licenses/); the parser rejects deprecated forms (e.g. `GPL-3.0-only`, not `GPL-3.0`).
+- **For a tool with a nonstandard license**, use an SPDX `LicenseRef-` placeholder (e.g. `"LicenseRef-VarScan-NonCommercial"`) and flag it for reviewer attention in your PR description, since there is no real SPDX identifier for these.
+- **See `pipelines/ww-bwa-gatk/module.json`** for the reference pattern for declaring module dependencies in a pipeline's manifest.
 
 ## Pipeline Development Guidelines
 

--- a/.github/scripts/validate_module_json.py
+++ b/.github/scripts/validate_module_json.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Validate module.json manifests in WILDS modules and pipelines.
+
+module.json is optional (see .github/CONTRIBUTING.md) and follows the
+experimental WDL v1.4 module manifest spec (openwdl/wdl#765). This script
+checks structure only where a module.json is present; it does not require
+every module/pipeline to have one.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+DEP_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+TOOL_ID_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9._-]*:.+$")
+VERSION_SELECTORS = ("version", "tag", "branch", "commit")
+
+
+def validate_tool(tool, idx):
+    """Validate a single tools[] entry. Returns list of error strings."""
+    errors = []
+    if not isinstance(tool, dict):
+        return [f"  tools[{idx}]: expected an object"]
+
+    for field in ("name", "version", "license"):
+        if field not in tool:
+            errors.append(f"  tools[{idx}]: missing required field '{field}'")
+        elif not isinstance(tool[field], str) or not tool[field]:
+            errors.append(f"  tools[{idx}].{field}: expected a non-empty string")
+
+    if "url" in tool and not isinstance(tool["url"], str):
+        errors.append(f"  tools[{idx}].url: expected a string")
+
+    if "ids" in tool:
+        if not isinstance(tool["ids"], list):
+            errors.append(f"  tools[{idx}].ids: expected an array")
+        else:
+            for cid in tool["ids"]:
+                if not isinstance(cid, str) or not TOOL_ID_RE.match(cid):
+                    errors.append(
+                        f"  tools[{idx}].ids: '{cid}' is not a valid CURIE (expected 'prefix:reference')"
+                    )
+
+    for legacy in ("homepage", "doi"):
+        if legacy in tool:
+            errors.append(
+                f"  tools[{idx}]: uses legacy field '{legacy}' — use 'url' for links and "
+                f"'ids' (e.g. [\"doi:10.xxxx/...\"]) for identifiers instead"
+            )
+
+    return errors
+
+
+def validate_dependency(name, dep):
+    """Validate a single dependencies{} entry. Returns list of error strings."""
+    errors = []
+    if not DEP_NAME_RE.match(name):
+        errors.append(f"  dependencies.{name}: key must match ^[A-Za-z][A-Za-z0-9_-]*$")
+
+    if not isinstance(dep, dict):
+        return errors + [f"  dependencies.{name}: expected an object"]
+
+    has_git = "git" in dep
+    selectors_present = [s for s in VERSION_SELECTORS if s in dep]
+
+    if has_git:
+        if len(selectors_present) != 1:
+            errors.append(
+                f"  dependencies.{name}: git dependency must specify exactly one of "
+                f"'version', 'tag', 'branch', 'commit' (found {selectors_present or 'none'})"
+            )
+    else:
+        if "path" not in dep:
+            errors.append(
+                f"  dependencies.{name}: must specify either 'git' (with a version selector) or 'path'"
+            )
+        elif selectors_present:
+            errors.append(
+                f"  dependencies.{name}: local 'path' dependency must not specify a version selector"
+            )
+
+    return errors
+
+
+def validate_module_json(filepath):
+    """Validate a single module.json file. Returns list of error strings."""
+    errors = []
+    try:
+        with open(filepath) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        return [f"  Invalid JSON: {e}"]
+
+    if not isinstance(data, dict):
+        return ["  Expected a JSON object at the top level"]
+
+    for field in ("name", "license"):
+        if field not in data:
+            errors.append(f"  Missing required field '{field}'")
+        elif not isinstance(data[field], str) or not data[field]:
+            errors.append(f"  '{field}': expected a non-empty string")
+
+    if "version" in data:
+        errors.append(
+            "  Unexpected top-level 'version' field — module versioning comes from "
+            "Git tags, not the manifest (see openwdl/wdl#765)"
+        )
+
+    if "authors" in data and not (
+        isinstance(data["authors"], list) and all(isinstance(a, str) for a in data["authors"])
+    ):
+        errors.append("  'authors': expected an array of strings")
+
+    if "readme" in data and not (data["readme"] is False or isinstance(data["readme"], str)):
+        errors.append("  'readme': expected a string path or `false`")
+
+    if "exclude" in data and not (
+        isinstance(data["exclude"], list) and all(isinstance(p, str) for p in data["exclude"])
+    ):
+        errors.append("  'exclude': expected an array of strings")
+
+    module_dir = filepath.parent
+
+    entrypoint = data.get("entrypoint", "index.wdl")
+    if isinstance(entrypoint, str) and not (module_dir / entrypoint).exists():
+        errors.append(f"  'entrypoint' points to a file that doesn't exist: {entrypoint}")
+
+    readme = data.get("readme", "README.md")
+    if isinstance(readme, str) and not (module_dir / readme).exists():
+        errors.append(f"  'readme' points to a file that doesn't exist: {readme}")
+
+    if "tools" in data:
+        if not isinstance(data["tools"], list):
+            errors.append("  'tools': expected an array")
+        else:
+            for i, tool in enumerate(data["tools"]):
+                errors.extend(validate_tool(tool, i))
+
+    if "dependencies" in data:
+        if not isinstance(data["dependencies"], dict):
+            errors.append("  'dependencies': expected an object")
+        else:
+            for name, dep in data["dependencies"].items():
+                errors.extend(validate_dependency(name, dep))
+
+    return errors
+
+
+def find_module_json_files(name=None):
+    """Find module.json files under modules/ and pipelines/, optionally scoped to one name."""
+    files = []
+    for tier in ("modules", "pipelines"):
+        tier_dir = Path(tier)
+        if not tier_dir.is_dir():
+            continue
+        if name:
+            candidate = tier_dir / name / "module.json"
+            if candidate.exists():
+                files.append(candidate)
+        else:
+            files.extend(sorted(tier_dir.glob("*/module.json")))
+    return files
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Validate module.json manifests in WILDS modules/pipelines.")
+    parser.add_argument(
+        "name", nargs="?", default=None,
+        help="Specific module/pipeline name to validate (e.g., ww-bwa). If omitted, validates all."
+    )
+    args = parser.parse_args()
+
+    files = find_module_json_files(args.name)
+
+    if not files:
+        if args.name:
+            print(f"Skipping {args.name} (no module.json found)")
+        else:
+            print("No module.json files found")
+        return 0
+
+    all_errors = {}
+    for filepath in files:
+        label = f"{filepath.parent.parent.name}/{filepath.parent.name}"
+        print(f"Validating {filepath} ...")
+        errors = validate_module_json(filepath)
+        if errors:
+            all_errors[label] = errors
+            print(f"  FAIL ({len(errors)} issue(s))")
+        else:
+            print("  OK")
+
+    if all_errors:
+        print(f"\n{'=' * 50}")
+        print(f"module.json validation failed for {len(all_errors)} item(s):\n")
+        for label, errors in all_errors.items():
+            print(f"{label}:")
+            for error in errors:
+                print(error)
+            print()
+        return 1
+
+    print(f"\nAll {len(files)} module.json file(s) valid!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -102,3 +102,18 @@ jobs:
     -
       name: Validate Cirro Configurations
       run: python .github/scripts/validate_cirro.py
+
+  module_json_validation:
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v4
+    -
+      name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+    -
+      name: Validate module.json Manifests
+      run: python .github/scripts/validate_module_json.py

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ cromwell-workflow-logs/
 # miniwdl test run outputs
 _LAST
 [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9]_*/
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,14 +41,18 @@ pipelines/ww-pipeline-name/
 
 ## Linting & Testing
 ```bash
-make lint NAME=ww-toolname          # All linting (Sprocket + miniwdl + WOMtool + Cirro)
-make lint_sprocket NAME=ww-toolname # Sprocket only
-make run NAME=ww-toolname           # Run testrun.wdl on all engines
-make run_sprocket NAME=ww-toolname  # Run testrun.wdl with Sprocket
-make run_miniwdl NAME=ww-toolname   # Run testrun.wdl with miniwdl
-make run_cromwell NAME=ww-toolname  # Run testrun.wdl with Cromwell
+make lint NAME=ww-toolname             # All linting (Sprocket + miniwdl + WOMtool + Cirro + module.json)
+make lint_sprocket NAME=ww-toolname    # Sprocket only
+make lint_module_json NAME=ww-toolname # Validate module.json structure only
+make run NAME=ww-toolname              # Run testrun.wdl on all engines
+make run_sprocket NAME=ww-toolname     # Run testrun.wdl with Sprocket
+make run_miniwdl NAME=ww-toolname      # Run testrun.wdl with miniwdl
+make run_cromwell NAME=ww-toolname     # Run testrun.wdl with Cromwell
 ```
 Sprocket exceptions (from sprocket.toml): TodoComment, ContainerUri, UnusedInput
+
+## Module Manifest (module.json)
+Every module/pipeline has a `module.json` following the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765); treat that upstream spec as ground truth for field definitions, not summaries in this repo. WILDS-specific notes: omit it only for brand-new modules if truly necessary (add one anyway when possible), this repo's own `license` is always `"MIT"`, per-tool `tools[].license` needs a current SPDX identifier (use `LicenseRef-*` placeholders for nonstandard licenses and flag them in the PR), and `tools[]` uses `url`/`ids` fields, never legacy `homepage`/`doi`. See `.github/CONTRIBUTING.md` for details and `pipelines/ww-bwa-gatk/module.json` for the dependency-declaration pattern.
 
 ## Common Development Pitfalls
 - Docker image version conflicts (especially with complex tools like ColabFold) - always pin versions

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,15 @@ lint_cirro: check_name ## Validate .cirro configurations in pipelines (use NAME=
 		python3 .github/scripts/validate_cirro.py; \
 	fi
 
-lint: lint_sprocket lint_miniwdl lint_womtool lint_cirro ## Run all linting checks
+lint_module_json: check_name ## Validate module.json manifests, if present (use NAME=foo for specific item)
+	@echo "Validating module.json manifests..."
+	@if [ "$(NAME)" != "*" ]; then \
+		python3 .github/scripts/validate_module_json.py $(NAME); \
+	else \
+		python3 .github/scripts/validate_module_json.py; \
+	fi
+
+lint: lint_sprocket lint_miniwdl lint_womtool lint_cirro lint_module_json ## Run all linting checks
 
 ##@ Run
 

--- a/modules/ww-annotsv/module.json
+++ b/modules/ww-annotsv/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-annotsv",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for comprehensive structural variant annotation using AnnotSV",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-annotsv.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "annotsv",
+      "version": "3.4.4",
+      "license": "LGPL-3.0-only",
+      "url": "https://github.com/lgmgeo/AnnotSV"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-annovar/module.json
+++ b/modules/ww-annovar/module.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-annovar",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for variant annotation using Annovar",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-annovar.wdl",
+  "readme": "README.md",
+  "dependencies": {}
+}

--- a/modules/ww-aws-sso/module.json
+++ b/modules/ww-aws-sso/module.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-aws-sso",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for AWS operations using traditional AWS credentials and SSO authentication via the AWS CLI",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-aws-sso.wdl",
+  "readme": "README.md",
+  "dependencies": {}
+}

--- a/modules/ww-bcftools/module.json
+++ b/modules/ww-bcftools/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-bcftools",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for variant calling and manipulation using bcftools",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-bcftools.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "bcftools",
+      "version": "1.19",
+      "license": "MIT",
+      "url": "https://www.htslib.org/"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-bedparse/module.json
+++ b/modules/ww-bedparse/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-bedparse",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for genomic file format conversions using bedparse",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-bedparse.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "bedparse",
+      "version": "0.2.3",
+      "license": "MIT",
+      "url": "https://github.com/tleonardi/bedparse",
+      "ids": [
+        "doi:10.21105/joss.01228"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-bedtools/module.json
+++ b/modules/ww-bedtools/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-bedtools",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for working with genomic intervals using BEDTools",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-bedtools.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "bedtools",
+      "version": "2.31.1",
+      "license": "MIT",
+      "url": "https://bedtools.readthedocs.io/"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-bowtie/module.json
+++ b/modules/ww-bowtie/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-bowtie",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for performing short-read alignment using Bowtie",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-bowtie.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "bowtie",
+      "version": "1.3.1",
+      "license": "Artistic-2.0",
+      "url": "https://bowtie-bio.sourceforge.net/index.shtml",
+      "ids": [
+        "doi:10.1186/gb-2009-10-3-r25"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-bowtie2/module.json
+++ b/modules/ww-bowtie2/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-bowtie2",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for performing sequence alignment using Bowtie 2",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-bowtie2.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "bowtie2",
+      "version": "2.5.4",
+      "license": "GPL-3.0-only",
+      "url": "https://bowtie-bio.sourceforge.net/bowtie2/index.shtml",
+      "ids": [
+        "doi:10.1038/nmeth.1923"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-bwa/module.json
+++ b/modules/ww-bwa/module.json
@@ -1,8 +1,10 @@
 {
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
   "name": "ww-bwa",
-  "version": "0.2.0",
   "license": "MIT",
-  "authors": ["Emma Bishop <ebishop@fredhutch.org>"],
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
   "description": "WILDS WDL for sequence alignment using BWA-MEM",
   "repository": "https://github.com/getwilds/wilds-wdl-library",
   "homepage": "https://getwilds.org/",
@@ -13,15 +15,20 @@
       "name": "bwa",
       "version": "0.7.17",
       "license": "GPL-3.0-only",
-      "homepage": "https://github.com/lh3/bwa",
-      "doi": "10.1093/bioinformatics/btp324"
+      "url": "https://github.com/lh3/bwa",
+      "ids": [
+        "doi:10.1093/bioinformatics/btp324"
+      ]
     },
     {
       "name": "samtools",
       "version": "1.11",
       "license": "MIT",
-      "homepage": "https://www.htslib.org/",
-      "doi": "10.1093/gigascience/giab008"
+      "url": "https://www.htslib.org/",
+      "ids": [
+        "doi:10.1093/gigascience/giab008"
+      ]
     }
-  ]
+  ],
+  "dependencies": {}
 }

--- a/modules/ww-cellbender/module.json
+++ b/modules/ww-cellbender/module.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-cellbender",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Hrishi Venkatesh <hvenkate@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for removing ambient RNA contamination and barcode swapping artifacts from single-cell RNA sequencing data using CellBender",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-cellbender.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "cellbender",
+      "version": "0.3.2",
+      "license": "BSD-3-Clause",
+      "url": "https://cellbender.readthedocs.io/",
+      "ids": [
+        "doi:10.1101/791699"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-cellranger/module.json
+++ b/modules/ww-cellranger/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-cellranger",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for single-cell RNA-seq analysis using Cell Ranger",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-cellranger.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "cellranger",
+      "version": "10.0.0",
+      "license": "LicenseRef-proprietary",
+      "url": "https://www.10xgenomics.com/support/software/cell-ranger"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-clair3/module.json
+++ b/modules/ww-clair3/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-clair3",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for Clair3, a deep learning-based germline small variant caller",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-clair3.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "clair3",
+      "version": "2.0.0",
+      "license": "BSD-3-Clause",
+      "url": "https://github.com/HKU-BAL/Clair3",
+      "ids": [
+        "doi:10.1038/s43588-022-00387-x"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-cnvkit/module.json
+++ b/modules/ww-cnvkit/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-cnvkit",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for copy number variation (CNV) detection using CNVkit",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-cnvkit.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "cnvkit",
+      "version": "0.9.10",
+      "license": "Apache-2.0",
+      "url": "https://cnvkit.readthedocs.io/"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-colabfold/module.json
+++ b/modules/ww-colabfold/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-colabfold",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for predicting protein 3D structures from amino acid sequences using ColabFold",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-colabfold.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "colabfold",
+      "version": "1.5.5",
+      "license": "MIT",
+      "url": "https://github.com/sokrypton/ColabFold",
+      "ids": [
+        "doi:10.1038/s41592-022-01488-1"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-consensus/module.json
+++ b/modules/ww-consensus/module.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-consensus",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for consensus variant calling using annotated variants from multiple callers",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-consensus.wdl",
+  "readme": "README.md",
+  "dependencies": {}
+}

--- a/modules/ww-deeptools/module.json
+++ b/modules/ww-deeptools/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-deeptools",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for deepTools, a suite of tools for exploring deep sequencing data",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-deeptools.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "deeptools",
+      "version": "3.5.6",
+      "license": "GPL-3.0-only",
+      "url": "https://deeptools.readthedocs.io/",
+      "ids": [
+        "doi:10.1093/nar/gkw257"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-deepvariant/module.json
+++ b/modules/ww-deepvariant/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-deepvariant",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for DeepVariant, Google's deep-learning-based germline variant caller",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-deepvariant.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "deepvariant",
+      "version": "1.10.0",
+      "license": "BSD-3-Clause",
+      "url": "https://github.com/google/deepvariant",
+      "ids": [
+        "doi:10.1038/nbt.4235"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-delly/module.json
+++ b/modules/ww-delly/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-delly",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for structural variant calling using Delly",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-delly.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "delly",
+      "version": "1.2.9",
+      "license": "BSD-3-Clause",
+      "url": "https://github.com/dellytools/delly",
+      "ids": [
+        "doi:10.1093/bioinformatics/bts378"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-deseq2/module.json
+++ b/modules/ww-deseq2/module.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-deseq2",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Elaine Glenny <eglenny@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for differential expression analysis using DESeq2",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-deseq2.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "deseq2",
+      "version": "1.40.2",
+      "license": "LGPL-3.0-or-later",
+      "url": "https://bioconductor.org/packages/DESeq2/"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-diamond/module.json
+++ b/modules/ww-diamond/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-diamond",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for fast protein sequence alignment using DIAMOND",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-diamond.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "diamond",
+      "version": "2.1.16",
+      "license": "GPL-3.0-or-later",
+      "url": "https://github.com/bbuchfink/diamond"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-edger/module.json
+++ b/modules/ww-edger/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-edger",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for differential expression analysis using edgeR",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-edger.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "edger",
+      "version": "4.10.0",
+      "license": "GPL-2.0-or-later",
+      "url": "https://bioconductor.org/packages/edgeR/",
+      "ids": [
+        "doi:10.1093/bioinformatics/btp616"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-ena/module.json
+++ b/modules/ww-ena/module.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-ena",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for downloading sequencing data files from the European Nucleotide Archive (ENA)",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-ena.wdl",
+  "readme": "README.md",
+  "dependencies": {}
+}

--- a/modules/ww-esmfold/module.json
+++ b/modules/ww-esmfold/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-esmfold",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for predicting protein 3D structures using ESMFold",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-esmfold.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "esmfold",
+      "version": "2.0.0",
+      "license": "MIT",
+      "url": "https://github.com/facebookresearch/esm",
+      "ids": [
+        "doi:10.1126/science.ade2574"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-fastp/module.json
+++ b/modules/ww-fastp/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-fastp",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for fastp, an ultra-fast all-in-one FASTQ preprocessor",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-fastp.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "fastp",
+      "version": "1.1.0",
+      "license": "MIT",
+      "url": "https://github.com/OpenGene/fastp",
+      "ids": [
+        "doi:10.1093/bioinformatics/bty560"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-fastqc/module.json
+++ b/modules/ww-fastqc/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-fastqc",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for FastQC quality control analysis of high-throughput sequencing data",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-fastqc.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "fastqc",
+      "version": "0.12.1",
+      "license": "GPL-3.0-only",
+      "url": "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-gatk/module.json
+++ b/modules/ww-gatk/module.json
@@ -1,6 +1,6 @@
 {
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
   "name": "ww-gatk",
-  "version": "0.2.0",
   "license": "MIT",
   "authors": [
     "Taylor Firman <tfirman@fredhutch.org>",
@@ -16,22 +16,29 @@
       "name": "gatk",
       "version": "4.6.1.0",
       "license": "Apache-2.0",
-      "homepage": "https://gatk.broadinstitute.org/",
-      "doi": "10.1101/gr.107524.110"
+      "url": "https://gatk.broadinstitute.org/",
+      "ids": [
+        "doi:10.1101/gr.107524.110"
+      ]
     },
     {
       "name": "samtools",
       "version": "1.20",
       "license": "MIT",
-      "homepage": "https://www.htslib.org/",
-      "doi": "10.1093/gigascience/giab008"
+      "url": "https://www.htslib.org/",
+      "ids": [
+        "doi:10.1093/gigascience/giab008"
+      ]
     },
     {
       "name": "htslib",
       "version": "1.20",
       "license": "MIT",
-      "homepage": "https://www.htslib.org/",
-      "doi": "10.1093/gigascience/giab007"
+      "url": "https://www.htslib.org/",
+      "ids": [
+        "doi:10.1093/gigascience/giab007"
+      ]
     }
-  ]
+  ],
+  "dependencies": {}
 }

--- a/modules/ww-gdc/module.json
+++ b/modules/ww-gdc/module.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-gdc",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for downloading genomic data from the NCI Genomic Data Commons (GDC)",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-gdc.wdl",
+  "readme": "README.md",
+  "dependencies": {}
+}

--- a/modules/ww-gffread/module.json
+++ b/modules/ww-gffread/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-gffread",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module wrapping gffread for GTF/GFF3 annotation manipulation",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-gffread.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "gffread",
+      "version": "0.12.7",
+      "license": "MIT",
+      "url": "https://github.com/gpertea/gffread",
+      "ids": [
+        "doi:10.12688/f1000research.23297.2"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-glimpse2/module.json
+++ b/modules/ww-glimpse2/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-glimpse2",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for GLIMPSE2 genotype imputation from low-coverage whole genome sequencing data",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-glimpse2.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "glimpse2",
+      "version": "2.0.1",
+      "license": "MIT",
+      "url": "https://odelaneau.github.io/GLIMPSE/",
+      "ids": [
+        "doi:10.1038/s41588-020-00756-0"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-ichorcna/module.json
+++ b/modules/ww-ichorcna/module.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-ichorcna",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for tumor fraction estimation in cfDNA using ichorCNA",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-ichorcna.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "hmmcopy",
+      "version": "1.0.0",
+      "license": "GPL-2.0-only",
+      "url": "https://github.com/shahcompbio/hmmcopy_utils"
+    },
+    {
+      "name": "ichorcna",
+      "version": "0.2.0",
+      "license": "GPL-3.0-or-later",
+      "url": "https://github.com/broadinstitute/ichorCNA"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-jcast/module.json
+++ b/modules/ww-jcast/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-jcast",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for JCAST (Junction Centric Alternative Splicing Translator)",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-jcast.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "jcast",
+      "version": "0.3.5",
+      "license": "MIT",
+      "url": "https://github.com/ed-lau/jcast"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-manta/module.json
+++ b/modules/ww-manta/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-manta",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for structural variant calling using Manta",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-manta.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "manta",
+      "version": "1.6.0",
+      "license": "GPL-3.0-only",
+      "url": "https://github.com/Illumina/manta"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-megahit/module.json
+++ b/modules/ww-megahit/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-megahit",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for de novo metagenomic assembly using MEGAHIT",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-megahit.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "megahit",
+      "version": "1.2.9",
+      "license": "GPL-3.0-only",
+      "url": "https://github.com/voutcn/megahit",
+      "ids": [
+        "doi:10.1093/bioinformatics/btv033"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-mosdepth/module.json
+++ b/modules/ww-mosdepth/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-mosdepth",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for calculating sequencing coverage depth using mosdepth",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-mosdepth.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "mosdepth",
+      "version": "0.3.14",
+      "license": "MIT",
+      "url": "https://github.com/brentp/mosdepth",
+      "ids": [
+        "doi:10.1093/bioinformatics/btx699"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-multiqc/module.json
+++ b/modules/ww-multiqc/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-multiqc",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for MultiQC, a tool that aggregates results from multiple bioinformatics analyses into a single report",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-multiqc.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "multiqc",
+      "version": "1.33",
+      "license": "GPL-3.0-only",
+      "url": "https://multiqc.info/",
+      "ids": [
+        "doi:10.1093/bioinformatics/btw354"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-rmats-turbo/module.json
+++ b/modules/ww-rmats-turbo/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-rmats-turbo",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for rMATS-turbo, a tool for detecting differential alternative splicing events from RNA-seq data",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-rmats-turbo.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "rmats-turbo",
+      "version": "4.3.0",
+      "license": "BSD-2-Clause",
+      "url": "https://github.com/Xinglab/rmats-turbo",
+      "ids": [
+        "doi:10.1073/pnas.1419161111"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-rseqc/module.json
+++ b/modules/ww-rseqc/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-rseqc",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for running comprehensive RNA-seq quality control analysis using RSeQC",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-rseqc.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "rseqc",
+      "version": "5.0.4",
+      "license": "GPL-2.0-or-later",
+      "url": "https://rseqc.sourceforge.net/",
+      "ids": [
+        "doi:10.1093/bioinformatics/bts356"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-salmon/module.json
+++ b/modules/ww-salmon/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-salmon",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for RNA-seq transcript quantification using Salmon",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-salmon.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "salmon",
+      "version": "1.10.3",
+      "license": "GPL-3.0-only",
+      "url": "https://combine-lab.github.io/salmon/"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-samtools/module.json
+++ b/modules/ww-samtools/module.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-samtools",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for processing genomic files with Samtools",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-samtools.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "samtools",
+      "version": "1.19",
+      "license": "MIT",
+      "url": "https://www.htslib.org/",
+      "ids": [
+        "doi:10.1093/bioinformatics/btp352"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-seurat/module.json
+++ b/modules/ww-seurat/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-seurat",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for single-cell RNA-seq analysis using Seurat",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-seurat.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "seurat",
+      "version": "5.2.1",
+      "license": "MIT",
+      "url": "https://satijalab.org/seurat/"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-shapemapper/module.json
+++ b/modules/ww-shapemapper/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-shapemapper",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for ShapeMapper 2, a tool for analyzing RNA structure probing data",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-shapemapper.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "shapemapper",
+      "version": "2.3",
+      "license": "MIT",
+      "url": "https://github.com/Weeks-UNC/shapemapper2",
+      "ids": [
+        "doi:10.1261/rna.061945.117"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-sjl/module.json
+++ b/modules/ww-sjl/module.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-sjl",
+  "license": "MIT",
+  "authors": [
+    "Caroline Nondin <cnondin@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for calculating sunrise and sunset time differences across geographic tiles as part of the Solar Jetlag (SJL) project",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-sjl.wdl",
+  "readme": "README.md",
+  "dependencies": {}
+}

--- a/modules/ww-smoove/module.json
+++ b/modules/ww-smoove/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-smoove",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for structural variant calling using Smoove",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-smoove.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "smoove",
+      "version": "0.2.8",
+      "license": "MIT",
+      "url": "https://github.com/brentp/smoove"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-sourmash/module.json
+++ b/modules/ww-sourmash/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-sourmash",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for genomic sequence comparison and metagenome analysis using sourmash",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-sourmash.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "sourmash",
+      "version": "4.8.2",
+      "license": "BSD-3-Clause",
+      "url": "https://sourmash.readthedocs.io/"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-spades/module.json
+++ b/modules/ww-spades/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-spades",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for de novo metagenomic assembly using metaSPAdes",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-spades.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "spades",
+      "version": "4.2.0",
+      "license": "GPL-2.0-only",
+      "url": "https://github.com/ablab/spades",
+      "ids": [
+        "doi:10.1101/gr.213959.116"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-sra/module.json
+++ b/modules/ww-sra/module.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-sra",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for downloading genomic data from the NCBI Sequence Read Archive (SRA)",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-sra.wdl",
+  "readme": "README.md",
+  "dependencies": {}
+}

--- a/modules/ww-star/module.json
+++ b/modules/ww-star/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-star",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for RNA-seq alignment using STAR's two-pass methodology",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-star.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "star",
+      "version": "2.7.6a",
+      "license": "GPL-3.0-only",
+      "url": "https://github.com/alexdobin/STAR"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-starling/module.json
+++ b/modules/ww-starling/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-starling",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for STARLING, a latent-space probabilistic denoising diffusion model for predicting structural ensembles of intrinsically disordered proteins",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-starling.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "starling",
+      "version": "2.0.0a3",
+      "license": "MIT",
+      "url": "https://github.com/idptools/starling",
+      "ids": [
+        "doi:10.1038/s41592-023-02159-5"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-strelka/module.json
+++ b/modules/ww-strelka/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-strelka",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for germline and somatic variant calling using Strelka",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-strelka.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "strelka",
+      "version": "2.9.10",
+      "license": "GPL-3.0-only",
+      "url": "https://github.com/Illumina/strelka",
+      "ids": [
+        "doi:10.1038/s41592-018-0051-x"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-testdata/module.json
+++ b/modules/ww-testdata/module.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-testdata",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Chris Lo <clo2@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for downloading and provisioning test data used across WILDS WDL module and pipeline test runs",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-testdata.wdl",
+  "readme": "README.md",
+  "dependencies": {}
+}

--- a/modules/ww-trimgalore/module.json
+++ b/modules/ww-trimgalore/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-trimgalore",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module wrapping Trim Galore for adapter and quality trimming of FASTQ files",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-trimgalore.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "trim-galore",
+      "version": "0.6.11",
+      "license": "GPL-3.0-only",
+      "url": "https://github.com/FelixKrueger/TrimGalore"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-tritonnp/module.json
+++ b/modules/ww-tritonnp/module.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-tritonnp",
+  "license": "MIT",
+  "authors": [
+    "Chris Lo <clo2@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for running TritonNP nucleosome positioning analysis for cell-free DNA samples",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-tritonnp.wdl",
+  "readme": "README.md",
+  "dependencies": {}
+}

--- a/modules/ww-umi-tools/module.json
+++ b/modules/ww-umi-tools/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-umi-tools",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for UMI-tools, a suite for handling Unique Molecular Identifiers (UMIs) in NGS data",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-umi-tools.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "umi_tools",
+      "version": "1.1.6",
+      "license": "MIT",
+      "url": "https://github.com/CGATOxford/UMI-tools",
+      "ids": [
+        "doi:10.1101/gr.209601.116"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-varscan/module.json
+++ b/modules/ww-varscan/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-varscan",
+  "license": "MIT",
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for somatic and germline variant calling using VarScan2",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-varscan.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "varscan",
+      "version": "2.4.6",
+      "license": "LicenseRef-VarScan-NonCommercial",
+      "url": "https://github.com/dkoboldt/varscan",
+      "ids": [
+        "doi:10.1101/gr.129684.111"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-viennarna/module.json
+++ b/modules/ww-viennarna/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-viennarna",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for RNA secondary structure prediction and analysis using the ViennaRNA package",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-viennarna.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "viennarna",
+      "version": "2.7.2",
+      "license": "LicenseRef-ViennaRNA-NonCommercial",
+      "url": "https://www.tbi.univie.ac.at/RNA/",
+      "ids": [
+        "doi:10.1186/1748-7188-6-26"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/pipelines/ww-bwa-gatk/module.json
+++ b/pipelines/ww-bwa-gatk/module.json
@@ -1,8 +1,10 @@
 {
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
   "name": "ww-bwa-gatk",
-  "version": "0.2.0",
   "license": "MIT",
-  "authors": ["Emma Bishop <ebishop@fredhutch.org>"],
+  "authors": [
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
   "description": "WILDS WDL pipeline aligning sequencing reads with BWA-MEM and performing GATK preprocessing (mark duplicates + base recalibration)",
   "repository": "https://github.com/getwilds/wilds-wdl-library",
   "homepage": "https://getwilds.org/",

--- a/pipelines/ww-ena-star/module.json
+++ b/pipelines/ww-ena-star/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-ena-star",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline demonstrating RNA-seq analysis from ENA download to alignment using modular WILDS components",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-ena-star.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_ena": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-ena"
+    },
+    "ww_star": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-star"
+    }
+  }
+}

--- a/pipelines/ww-fastq-to-cram/module.json
+++ b/pipelines/ww-fastq-to-cram/module.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-fastq-to-cram",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline for converting paired FASTQ files to unmapped CRAM format with validation",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-fastq-to-cram.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_gatk": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-gatk"
+    },
+    "ww_samtools": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-samtools"
+    }
+  }
+}

--- a/pipelines/ww-imputation/module.json
+++ b/pipelines/ww-imputation/module.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-imputation",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Louisa Goss <lgoss2@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline for genotype imputation from low-coverage whole genome sequencing data using GLIMPSE2",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-imputation.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_glimpse2": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-glimpse2"
+    },
+    "ww_bcftools": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-bcftools"
+    }
+  }
+}

--- a/pipelines/ww-jetlag/module.json
+++ b/pipelines/ww-jetlag/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-jetlag",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Caroline Nondin <cnondin@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline for running Solar Jetlag (SJL) tile processing across an array of geographic tiles",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-jetlag.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_sjl": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-sjl"
+    }
+  }
+}

--- a/pipelines/ww-leukemia/module.json
+++ b/pipelines/ww-leukemia/module.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-leukemia",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Sitapriya Moorthi <smoorthi@fredhutch.org>"
+  ],
+  "description": "Consensus variant calling workflow for human panel/PCR-based targeted DNA sequencing for leukemia",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-leukemia.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_annotsv": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-annotsv"
+    },
+    "ww_annovar": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-annovar"
+    },
+    "ww_bcftools": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-bcftools"
+    },
+    "ww_bwa": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-bwa"
+    },
+    "ww_delly": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-delly"
+    },
+    "ww_gatk": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-gatk"
+    },
+    "ww_ichorcna": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-ichorcna"
+    },
+    "ww_manta": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-manta"
+    },
+    "ww_samtools": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-samtools"
+    },
+    "ww_smoove": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-smoove"
+    },
+    "ww_consensus": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-consensus"
+    }
+  }
+}

--- a/pipelines/ww-proseq/module.json
+++ b/pipelines/ww-proseq/module.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-proseq",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Ruihong Wang <rwang4@fredhutch.org>"
+  ],
+  "description": "Paired-end PRO-seq pipeline with UMI deduplication and spike-in normalization, adapted from JAJ256/PROseq_alignment.sh",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-proseq.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_fastp": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-fastp"
+    },
+    "ww_bowtie2": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-bowtie2"
+    },
+    "ww_samtools": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-samtools"
+    },
+    "ww_umi_tools": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-umi-tools"
+    },
+    "ww_deeptools": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-deeptools"
+    },
+    "ww_multiqc": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-multiqc"
+    }
+  }
+}

--- a/pipelines/ww-rnaseq/module.json
+++ b/pipelines/ww-rnaseq/module.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-rnaseq",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Elaine Glenny <eglenny@fredhutch.org>"
+  ],
+  "description": "Comprehensive RNA-seq pipeline covering read QC, adapter trimming, alignment, post-alignment QC, differential expression, and aggregated reporting",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-rnaseq.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_fastqc": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-fastqc"
+    },
+    "ww_trimgalore": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-trimgalore"
+    },
+    "ww_star": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-star"
+    },
+    "ww_bedparse": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-bedparse"
+    },
+    "ww_rseqc": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-rseqc"
+    },
+    "ww_deseq2": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-deseq2"
+    },
+    "ww_multiqc": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-multiqc"
+    },
+    "ww_gffread": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-gffread"
+    }
+  }
+}

--- a/pipelines/ww-saturation/module.json
+++ b/pipelines/ww-saturation/module.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-saturation",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Sitapriya Moorthi <smoorthi@fredhutch.org>",
+    "Siobhan O'Brien <sobrien2@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline for analyzing saturation mutagenesis experiments using modular WILDS components",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-saturation.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_bwa": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-bwa"
+    },
+    "ww_gatk": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-gatk"
+    }
+  }
+}

--- a/pipelines/ww-splicing-proteomics/module.json
+++ b/pipelines/ww-splicing-proteomics/module.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-splicing-proteomics",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline for generating custom protein databases from RNA-seq alternative splicing data for mass spectrometry proteomics analysis",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-splicing-proteomics.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_star": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-star"
+    },
+    "ww_rmats_turbo": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-rmats-turbo"
+    },
+    "ww_jcast": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-jcast"
+    }
+  }
+}

--- a/pipelines/ww-sra-cellranger/module.json
+++ b/pipelines/ww-sra-cellranger/module.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-sra-cellranger",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Hrishi Venkatesh <hvenkate@fredhutch.org>"
+  ],
+  "description": "WDL workflow to download single-cell RNA-seq data from SRA and process using Cell Ranger count",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-sra-cellranger.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_sra": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-sra"
+    },
+    "ww_cellranger": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-cellranger"
+    },
+    "ww_cellbender": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-cellbender"
+    }
+  }
+}

--- a/pipelines/ww-sra-salmon/module.json
+++ b/pipelines/ww-sra-salmon/module.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-sra-salmon",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Alice Berger <aberger@fredhutch.org>",
+    "Janet Young <jyoung@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline demonstrating RNA-seq quantification from SRA download to transcript-level abundance estimation using modular WILDS components",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-sra-salmon.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_sra": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-sra"
+    },
+    "ww_salmon": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-salmon"
+    }
+  }
+}

--- a/pipelines/ww-sra-star/module.json
+++ b/pipelines/ww-sra-star/module.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-sra-star",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Alice Berger <aberger@fredhutch.org>",
+    "Janet Young <jyoung@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline demonstrating RNA-seq analysis from SRA download to alignment using modular WILDS components",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-sra-star.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_sra": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-sra"
+    },
+    "ww_star": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-star"
+    }
+  }
+}

--- a/pipelines/ww-star-deseq2/module.json
+++ b/pipelines/ww-star-deseq2/module.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-star-deseq2",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>",
+    "Emma Bishop <ebishop@fredhutch.org>",
+    "Ethan Bouvet <ebouvet@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline for RNA-seq alignment via STAR and DESeq2 differential expression analysis",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-star-deseq2.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_star": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-star"
+    },
+    "ww_deseq2": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-deseq2"
+    },
+    "ww_rseqc": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-rseqc"
+    },
+    "ww_bedparse": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-bedparse"
+    }
+  }
+}

--- a/pipelines/ww-starling-batch/module.json
+++ b/pipelines/ww-starling-batch/module.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-starling-batch",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "Batch ensemble generation pipeline splitting a protein FASTA into chunks for parallel STARLING processing",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-starling-batch.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_starling": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-starling"
+    }
+  }
+}


### PR DESCRIPTION
## Type of Change

- Documentation update
- Other (module.json manifest rollout + CI validation)

## Description

Rolls out `module.json` manifests (the experimental WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765)) across the entire library and corrects the format based on the latest guidance from Sprocket/St. Jude collaborators.

- **Fixed the 3 existing `module.json` files** (`ww-bwa`, `ww-gatk`, `ww-bwa-gatk`) to match the current spec: removed the non-spec top-level `version` field (module versioning comes from Git tags, not the manifest), renamed `tools[].homepage` to `tools[].url`, and converted `tools[].doi` to the spec's `tools[].ids` CURIE array format (e.g. `["doi:10.1093/bioinformatics/btp324"]`).
- **Added `module.json` to every remaining module and pipeline** (53 modules + 14 pipelines), generated from each module's Docker image tag (tool + version), `.dockstore.yml` author lists, and README/WDL content. Modules that don't wrap a single clear external tool (e.g. `ww-testdata`, `ww-aws-sso`, `ww-sra`, `ww-gdc`, `ww-ena`, `ww-sjl`, `ww-consensus`, `ww-tritonnp`, `ww-annovar`) omit the `tools[]` array.
- **Added CI validation**: `.github/scripts/validate_module_json.py` (stdlib-only, matching the existing `validate_cirro.py` pattern) structurally validates any `module.json` it finds, no `jsonschema` dependency required. Wired into a new `make lint_module_json` target (folded into `make lint`) and a new `module_json_validation` job in `.github/workflows/linting.yml`. This checks structure only (required fields, tool entry shape, dependency selector rules, and rejects legacy `homepage`/`doi` fields on `tools[]`) since no executor consumes `module.json` at runtime yet.
- **Updated documentation** (`.github/CONTRIBUTING.md`, `AGENTS.md`) to point at the upstream spec files in `openwdl/wdl#765` as ground truth rather than re-describing the schema locally, and to document WILDS-specific conventions (always `"MIT"` for our own license, `LicenseRef-*` placeholders for nonstandard tool licenses, `url`/`ids` fields only).
- **Updated `create-module` and `create-pipeline` skills** so newly scaffolded modules/pipelines include a `module.json` from the start, with guidance on populating `tools[]`/`dependencies{}` correctly.

## Testing

**How did you test these changes?**
- Validated all 70 `module.json` files (`python3 -m json.tool`) for JSON syntax correctness.
- Ran the new `.github/scripts/validate_module_json.py` against all 70 real files (all pass) and against a deliberately malformed fixture covering 12 distinct violation types (missing required fields, top-level `version`, legacy `homepage`/`doi` on tools, malformed CURIEs, invalid dependency selector combinations) to confirm the validator catches real problems.
- Spot-checked a representative sample of generated files (`ww-fastqc`, `ww-samtools`, `ww-glimpse2`, `ww-sra`, `ww-rnaseq`) against `.dockstore.yml` authors and each pipeline's actual `import` statements to confirm accuracy.
- Ran `make lint_module_json` (all scopes: full sweep, single module, module without a `module.json`) to confirm graceful behavior in each case.
- In the process of testing out the modular functionality with `sprocket dev`

**What workflow engine did you use?**
Structural validation via the new Python script, functional validation via Sprocket Dev.

**Did the tests pass?**
All 70 `module.json` files pass both JSON validity and the new structural validator with zero errors. Functional validation still in progress.

## Documentation

- [x] ~~I updated the README (if applicable)~~
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~

## Additional Context

- No Docker images, WDL task definitions, or `testrun.wdl` files were touched in this PR. Changes are limited to `module.json` files, CI/tooling for validating them, and contributor documentation.
- The `openwdl/wdl#765` spec is still unmerged and has already changed once since this repo's first `module.json` files were written; CONTRIBUTING.md now explicitly tells contributors to treat the upstream spec as ground truth rather than any summary in this repo.