### PR TITLE
Add per-sample parameter support to `ww-sra-cellranger`

### DIFF
--- a/pipelines/ww-sra-cellranger/README.md
+++ b/pipelines/ww-sra-cellranger/README.md
@@ -147,8 +147,10 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `organize_results` | When true, package all Cell Ranger outputs into a tarball organized by sample subdirectory. | Boolean | No | `false` |
 | `output_prefix` | Prefix for the organized results tarball filename. | String | No | `cellranger_results` |
 | `cellbender_gpu_enabled` | Enable GPU acceleration for CellBender. Set to `false` for CPU-only execution. | Boolean | No | `true` |
-| `cellbender_expected_cells` | Expected number of real cells per sample passed to CellBender. | Int | No | auto |
-| `cellbender_total_droplets_included` | Total number of droplets for CellBender to analyze per sample. | Int | No | auto |
+| `cellbender_expected_cells` | Expected number of real cells, applied to every sample. Ignored for samples covered by `cellbender_expected_cells_each`. | Int | No | auto |
+| `cellbender_total_droplets_included` | Total number of droplets for CellBender to analyze, applied to every sample. Ignored for samples covered by `cellbender_total_droplets_each`. | Int | No | auto |
+| `cellbender_expected_cells_each` | Per-sample expected number of real cells, in the same order as `sra_id_list`/`sra_id_file`. Must be the same length as the sample list. Takes precedence over `cellbender_expected_cells`. | Array[Int] | No | - |
+| `cellbender_total_droplets_each` | Per-sample total number of droplets for CellBender to analyze, in the same order as `sra_id_list`/`sra_id_file`. Must be the same length as the sample list. Takes precedence over `cellbender_total_droplets_included`. | Array[Int] | No | - |
 | `cellbender_epochs` | Number of CellBender training epochs. | Int | No | `150` |
 | `cellbender_low_count_threshold` | Droplets with total UMI count below this value are excluded from CellBender analysis. | Int | No | `5` |
 | `cellbender_cpu_cores` | Number of CPU cores for CellBender. | Int | No | `4` |

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -22,8 +22,8 @@ workflow sra_cellranger_example {
     organize_results = true,
     cellbender_gpu_enabled = false,
     cellbender_memory_gb = 8,
-    cellbender_expected_cells_each = [500, 500],
-    cellbender_total_droplets_each = [5000, 5000]
+    cellbender_expected_cells_each = [200, 200],
+    cellbender_total_droplets_each = [2000, 2000]
   }
 
   Int n_results = length(sra_cellranger.cellranger_results)

--- a/pipelines/ww-sra-cellranger/testrun.wdl
+++ b/pipelines/ww-sra-cellranger/testrun.wdl
@@ -21,7 +21,9 @@ workflow sra_cellranger_example {
     skip_on_chemistry_failure = true,
     organize_results = true,
     cellbender_gpu_enabled = false,
-    cellbender_memory_gb = 8
+    cellbender_memory_gb = 8,
+    cellbender_expected_cells_each = [500, 500],
+    cellbender_total_droplets_each = [5000, 5000]
   }
 
   Int n_results = length(sra_cellranger.cellranger_results)

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -21,7 +21,9 @@ workflow sra_cellranger_example {
     max_reads = 5000000,
     skip_on_chemistry_failure = true,
     execution_mode = "hpc_sprocket",
-    cellbender_gpu_enabled = false # Can't test this in current HPC test run setup
+    cellbender_gpu_enabled = false, # Can't test this in current HPC test run setup
+    cellbender_expected_cells_each = [500, 500],
+    cellbender_total_droplets_each = [5000, 5000]
   }
 
   Int n_results = length(sra_cellranger.cellranger_results)

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -1,10 +1,7 @@
 version 1.0
 
-# import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-# import "./ww-sra-cellranger.wdl" as sra_cellranger_workflow
-
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/per-sample-cellbender/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC variant of the ww-sra-cellranger pipeline testrun. Dispatches via

--- a/pipelines/ww-sra-cellranger/testrun_hpc.wdl
+++ b/pipelines/ww-sra-cellranger/testrun_hpc.wdl
@@ -1,7 +1,10 @@
 version 1.0
 
-import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
-import "./ww-sra-cellranger.wdl" as sra_cellranger_workflow
+# import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+# import "./ww-sra-cellranger.wdl" as sra_cellranger_workflow
+
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/per-sample-cellbender/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl" as sra_cellranger_workflow
 
 #### TEST WORKFLOW DEFINITION ####
 # HPC variant of the ww-sra-cellranger pipeline testrun. Dispatches via
@@ -22,8 +25,8 @@ workflow sra_cellranger_example {
     skip_on_chemistry_failure = true,
     execution_mode = "hpc_sprocket",
     cellbender_gpu_enabled = false, # Can't test this in current HPC test run setup
-    cellbender_expected_cells_each = [500, 500],
-    cellbender_total_droplets_each = [5000, 5000]
+    cellbender_expected_cells_each = [200, 200],
+    cellbender_total_droplets_each = [2000, 2000]
   }
 
   Int n_results = length(sra_cellranger.cellranger_results)

--- a/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
+++ b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl
@@ -49,8 +49,10 @@ workflow sra_cellranger {
     organize_results: "When true, package all Cell Ranger outputs into a tarball organized by sample subdirectory."
     output_prefix: "Prefix for the organized results tarball filename (default: 'cellranger_results')."
     cellbender_gpu_enabled: "Enable GPU acceleration for CellBender (default: true); set to false for CPU-only execution."
-    cellbender_expected_cells: "Optional expected number of real cells per sample passed to CellBender."
-    cellbender_total_droplets_included: "Optional total number of droplets for CellBender to analyze per sample."
+    cellbender_expected_cells: "Optional expected number of real cells, applied to every sample. Ignored for samples covered by `cellbender_expected_cells_each`."
+    cellbender_total_droplets_included: "Optional total number of droplets for CellBender to analyze, applied to every sample. Ignored for samples covered by `cellbender_total_droplets_each`."
+    cellbender_expected_cells_each: "Optional per-sample expected number of real cells, in the same order as `sra_id_list`/`sra_id_file`. Must be the same length as the sample list. Takes precedence over `cellbender_expected_cells`."
+    cellbender_total_droplets_each: "Optional per-sample total number of droplets for CellBender to analyze, in the same order as `sra_id_list`/`sra_id_file`. Must be the same length as the sample list. Takes precedence over `cellbender_total_droplets_included`."
     cellbender_epochs: "Number of CellBender training epochs (default: 150)."
     cellbender_low_count_threshold: "Droplets with total UMI count below this value are excluded from CellBender analysis (default: 5)."
     cellbender_cpu_cores: "Number of CPU cores for CellBender (default: 4)."
@@ -76,6 +78,8 @@ workflow sra_cellranger {
     Boolean cellbender_gpu_enabled = true
     Int? cellbender_expected_cells
     Int? cellbender_total_droplets_included
+    Array[Int]? cellbender_expected_cells_each
+    Array[Int]? cellbender_total_droplets_each
     Int cellbender_epochs = 150
     Int cellbender_low_count_threshold = 5
     Int cellbender_cpu_cores = 4
@@ -90,7 +94,19 @@ workflow sra_cellranger {
     then read_lines(select_first([sra_id_file]))
     else select_first([sra_id_list])
 
-  scatter (id in sra_ids) {
+  # Per-sample CellBender arrays, when provided, must line up 1:1 with
+  # sra_ids. Fails loudly before any SRA downloads start, rather than
+  # silently mis-pairing samples with the wrong expected_cells/
+  # total_droplets values partway through the run.
+  call check_per_sample_lengths { input:
+      sample_ids = sra_ids,
+      cellbender_expected_cells_each = cellbender_expected_cells_each,
+      cellbender_total_droplets_each = cellbender_total_droplets_each
+  }
+
+  scatter (i in range(length(check_per_sample_lengths.validated_ids))) {
+    String id = check_per_sample_lengths.validated_ids[i]
+
     # Download FASTQ files from SRA
     call sra_tasks.fastqdump { input:
         sra_id = id,
@@ -186,13 +202,22 @@ workflow sra_cellranger {
                   else if defined(run_count_hpc_cromwell.raw_h5) then run_count_hpc_cromwell.raw_h5
                   else run_count_hpc_sprocket.raw_h5
 
+    # Per-sample CellBender values take precedence over the broadcast
+    # scalars when provided (length already validated above).
+    Int? sample_expected_cells = if defined(cellbender_expected_cells_each)
+      then select_first([cellbender_expected_cells_each])[i]
+      else cellbender_expected_cells
+    Int? sample_total_droplets = if defined(cellbender_total_droplets_each)
+      then select_first([cellbender_total_droplets_each])[i]
+      else cellbender_total_droplets_included
+
     # Run CellBender on samples that produced a raw h5 (skipped samples won't have one)
     if (defined(raw_h5)) {
       call cellbender_tasks.remove_background { input:
         input_h5 = select_first([raw_h5]),
         sample_name = id,
-        expected_cells = cellbender_expected_cells,
-        total_droplets_included = cellbender_total_droplets_included,
+        expected_cells = sample_expected_cells,
+        total_droplets_included = sample_total_droplets,
         epochs = cellbender_epochs,
         low_count_threshold = cellbender_low_count_threshold,
         gpu_enabled = cellbender_gpu_enabled,
@@ -238,6 +263,60 @@ workflow sra_cellranger {
     Array[File] cellbender_output_h5s = select_all(remove_background.output_h5)
     Array[File] cellbender_filtered_h5s = select_all(remove_background.filtered_h5)
     File? organized_results = organize_outputs.results_zip
+  }
+}
+
+task check_per_sample_lengths {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Validate that optional per-sample CellBender arrays, if provided, are the same length as the sample list. Passes sample_ids through unchanged so downstream calls can depend on successful validation."
+    outputs: {
+        validated_ids: "sample_ids, unchanged, once length validation has passed"
+    }
+  }
+
+  parameter_meta {
+    sample_ids: "Sample IDs being processed by the pipeline"
+    cellbender_expected_cells_each: "Optional per-sample expected_cells array; must match length(sample_ids) if provided"
+    cellbender_total_droplets_each: "Optional per-sample total_droplets_included array; must match length(sample_ids) if provided"
+  }
+
+  input {
+    Array[String] sample_ids
+    Array[Int]? cellbender_expected_cells_each
+    Array[Int]? cellbender_total_droplets_each
+  }
+
+  Int expected_cells_count = length(select_first([cellbender_expected_cells_each, []]))
+  Int total_droplets_count = length(select_first([cellbender_total_droplets_each, []]))
+
+  command <<<
+    set -eo pipefail
+
+    SAMPLE_COUNT=~{length(sample_ids)}
+
+    if [ ~{expected_cells_count} -ne 0 ] && [ ~{expected_cells_count} -ne "$SAMPLE_COUNT" ]; then
+      echo "ERROR: cellbender_expected_cells_each has ~{expected_cells_count} element(s) but there are $SAMPLE_COUNT sample(s)" >&2
+      exit 1
+    fi
+
+    if [ ~{total_droplets_count} -ne 0 ] && [ ~{total_droplets_count} -ne "$SAMPLE_COUNT" ]; then
+      echo "ERROR: cellbender_total_droplets_each has ~{total_droplets_count} element(s) but there are $SAMPLE_COUNT sample(s)" >&2
+      exit 1
+    fi
+
+    printf '%s\n' ~{sep=' ' sample_ids} > validated_ids.txt
+  >>>
+
+  output {
+    Array[String] validated_ids = read_lines("validated_ids.txt")
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    cpu: 1
+    memory: "2 GB"
   }
 }
 


### PR DESCRIPTION
## Type of Change

- Other (feature enhancement to an existing pipeline)

## Description

Adds support for per-sample `expected_cells` and `total_droplets_included` values in the `ww-sra-cellranger` pipeline's CellBender step, instead of requiring a single value applied to every sample, as requested by @hvenkat94.

- Added `Array[Int]? cellbender_expected_cells_each` and `Array[Int]? cellbender_total_droplets_each` inputs. When provided, these take precedence per-sample over the existing scalar `cellbender_expected_cells` / `cellbender_total_droplets_included` inputs (which still broadcast to all samples as before, so this is fully backward compatible).
- Added a new pipeline-local task, `check_per_sample_lengths`, that validates the per-sample arrays (if given) are the same length as the sample list before any SRA downloads start, failing loudly with a clear error message on mismatch. Follows the same pattern as the existing `summarize_chemistry_status`/`organize_outputs` helper tasks already defined in this pipeline WDL.
- Switched the main scatter from `scatter (id in sra_ids)` to an index-based `scatter (i in range(...))` so each iteration can index into the new per-sample arrays.
- Updated `parameter_meta` and the README input table to document the new parameters.
- Updated `testrun.wdl` and `testrun_hpc.wdl` to pass `cellbender_expected_cells_each`/`cellbender_total_droplets_each` (matching the 2-sample test fixture), so CI exercises the new array inputs and the `check_per_sample_lengths` validation path.

## Testing

**How did you test these changes?**
GitHub Action CI/CD test runs below, will test on PROOF as well.

**What workflow engine did you use?**
Sprocket, miniwdl, and Cromwell for CI/CD, Cromwell for PROOF.

**Did the tests pass?**
In progress.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- This is a backward-compatible change: existing callers passing scalar `cellbender_expected_cells`/`cellbender_total_droplets_included` are unaffected.
- The `check_per_sample_lengths` task is intentionally pipeline-local (not a new module), consistent with this pipeline's existing convention of keeping small validation/orchestration tasks directly in `ww-sra-cellranger.wdl`.