### PR TITLE
Add GFF3 support to ww-rnaseq reference input

### DIFF
--- a/modules/ww-gffread/README.md
+++ b/modules/ww-gffread/README.md
@@ -103,10 +103,11 @@ workflow bacterial_rnaseq {
 
 ### Automatic Demo Mode
 
-The `testrun.wdl` workflow runs `normalize_gtf` against two contrasting inputs with no user configuration:
+The `testrun.wdl` workflow runs `normalize_gtf` and `gff3_to_gtf` against contrasting inputs with no user configuration:
 
 1. **Bacterial case**: the NCBI PAO1 GTF (via `ww-testdata.download_pao1_ref`). Exercises the CDS→exon synthesis path.
 2. **Eukaryotic case**: the Ensembl human chromosome 15 GTF (via `ww-testdata.download_jcast_test_data`). Exercises the pass-through path.
+3. **GFF3 conversion case**: the NCBI PAO1 GFF3 (via `ww-testdata.download_pao1_ref`). Exercises the `gff3_to_gtf` conversion path.
 
 Run locally with:
 
@@ -116,9 +117,10 @@ make run_sprocket NAME=ww-gffread
 make run_miniwdl NAME=ww-gffread
 ```
 
-After the run completes, inspect the normalized GTF output files to verify:
+After the run completes, inspect the output files to verify:
 - The bacterial case has ~5500 `exon` rows (up from ~100 in the input).
 - The eukaryotic case has roughly the same number of `exon` rows as the input.
+- The GFF3 conversion case produces a valid GTF with feature counts matching the source PAO1 GFF3.
 
 ## Docker Container
 

--- a/modules/ww-gffread/README.md
+++ b/modules/ww-gffread/README.md
@@ -50,6 +50,8 @@ Converts a GFF3 annotation file to GTF format. Useful when an upstream source (e
 **Outputs:**
 - `gtf_file` (File): GTF-format annotation converted from the input GFF3
 
+**A note on gffread + `?` strand values:** GFF3 allows a strand value of `?` for "relevant, but unknown" (e.g. some annotators use this for origin-of-replication features), but `gffread` cannot parse it and errors out. The `gff3_to_gtf` task handles this automatically by stripping any row with strand `?` before invoking `gffread`. These rows are not gene/transcript features, so nothing relevant to downstream RNA-seq quantification is lost.
+
 ## Usage as a Module
 
 ### Importing into Your Workflow

--- a/modules/ww-gffread/testrun.wdl
+++ b/modules/ww-gffread/testrun.wdl
@@ -20,8 +20,15 @@ workflow gffread_example {
       output_prefix = "ensembl_chr15_normalized"
   }
 
+  # Case 3: GFF3-to-GTF conversion, reusing the PAO1 GFF3 fetched above
+  call ww_gffread.gff3_to_gtf { input:
+      input_gff3 = download_pao1_ref.gff3,
+      output_prefix = "pao1_converted"
+  }
+
   output {
     File bacterial_normalized_gtf = normalize_bacterial.normalized_gtf
     File eukaryotic_normalized_gtf = normalize_eukaryotic.normalized_gtf
+    File pao1_converted_gtf = gff3_to_gtf.gtf_file
   }
 }

--- a/modules/ww-gffread/ww-gffread.wdl
+++ b/modules/ww-gffread/ww-gffread.wdl
@@ -91,8 +91,13 @@ task gff3_to_gtf {
   command <<<
     set -eo pipefail
 
+    # Some GFF3s can include features with strand `?` 
+    # (GFF3-legal for "relevant but unknown"), which gffread cannot parse.
+    # These are not gene/transcript features, so drop them before conversion.
+    awk -F'\t' '/^#/ || $7 != "?"' "~{input_gff3}" > stripped.gff3
+
     # -T emits GTF instead of the default GFF3
-    gffread "~{input_gff3}" -T -o "~{output_prefix}.gtf"
+    gffread stripped.gff3 -T -o "~{output_prefix}.gtf"
   >>>
 
   output {

--- a/modules/ww-testdata/README.md
+++ b/modules/ww-testdata/README.md
@@ -241,7 +241,7 @@ call colabfold_tasks.colabfold_predict {
 
 ### download_ref_data
 
-Downloads a UCSC reference chromosome FASTA + GTF + BED + samtools index/dict for the requested assembly. For assemblies that ship per-chromosome FASTAs (hg19, hg38, mm10, etc.) the per-chromosome file is fetched directly. For assemblies that only ship a whole-genome FASTA at `bigZips/<version>.fa.gz` (e.g. dm6, sacCer3), the task transparently falls back to downloading the whole-genome file and extracting the requested chromosome via `samtools faidx`.
+Downloads a UCSC reference chromosome FASTA + GTF + BED + samtools index/dict for the requested assembly. For assemblies that ship per-chromosome FASTAs (hg19, hg38, mm10, etc.) the per-chromosome file is fetched directly. For assemblies that only ship a whole-genome FASTA at `bigZips/<version>.fa.gz` (e.g. dm6, sacCer3), the task transparently falls back to downloading the whole-genome file and extracting the requested chromosome via `samtools faidx`. For `hg38`, a matching GFF3 is also fetched from NCBI RefSeq, since UCSC doesn't publish one alongside its GTF.
 
 **Inputs**:
 - `chromo` (String): Chromosome to download (default: "chr1")
@@ -259,6 +259,7 @@ Downloads a UCSC reference chromosome FASTA + GTF + BED + samtools index/dict fo
 - `fasta_index` (File): Samtools FASTA index (.fai)
 - `dict` (File): Samtools FASTA dictionary file (.dict) for GATK compatibility
 - `gtf` (File): Chromosome-specific gene annotations (filtered to region if specified)
+- `gff3` (File, optional): Chromosome-specific gene annotations in GFF3 format, from NCBI RefSeq (only populated when `version` is "hg38")
 - `bed` (File): BED file covering the entire chromosome or specified region
 
 ### merge_fastas_with_prefix
@@ -884,7 +885,7 @@ Generates synthetic tile and border points data for testing the `ww-sjl` module 
 
 ### download_pao1_ref
 
-Downloads the Pseudomonas aeruginosa PAO1 reference genome (FASTA + GTF) from NCBI RefSeq (assembly GCF_000006765.1 / ASM676v1) for use in bacterial RNA-seq test runs. The downloaded GTF uses the classic NCBI bacterial layout (~5573 CDS rows, ~5697 gene rows, only ~106 exon rows for tRNAs/rRNAs), making it the canonical input for testing the `ww-gffread` `normalize_gtf` task.
+Downloads the Pseudomonas aeruginosa PAO1 reference genome (FASTA + GTF + GFF3) from NCBI RefSeq (assembly GCF_000006765.1 / ASM676v1) for use in bacterial RNA-seq test runs. The downloaded GTF uses the classic NCBI bacterial layout (~5573 CDS rows, ~5697 gene rows, only ~106 exon rows for tRNAs/rRNAs), making it the canonical input for testing the `ww-gffread` `normalize_gtf` task. The GFF3 is the same annotation in GFF3 form, used for testing the `ww-gffread` `gff3_to_gtf` task.
 
 **Inputs**:
 - `output_prefix` (String): Prefix used for output filenames (default: "pao1")
@@ -897,6 +898,7 @@ Downloads the Pseudomonas aeruginosa PAO1 reference genome (FASTA + GTF) from NC
 - `fasta_index` (File): Samtools FASTA index (.fai)
 - `dict` (File): Samtools FASTA dictionary file (.dict)
 - `gtf` (File): NCBI RefSeq GTF annotation for PAO1
+- `gff3` (File): NCBI RefSeq GFF3 annotation for PAO1
 
 ## Data Sources
 

--- a/modules/ww-testdata/testrun.wdl
+++ b/modules/ww-testdata/testrun.wdl
@@ -10,6 +10,9 @@ workflow testdata_example {
       region = "1-10000000"
   }
 
+  # download_ref_data only populates gff3 for hg38, which this testrun always uses
+  File resolved_ref_gff3 = select_first([download_ref_data.gff3])
+
   call ww_testdata.download_fastq_data { }
 
   call ww_testdata.interleave_fastq { input:
@@ -101,6 +104,7 @@ workflow testdata_example {
     ref_fasta_index = download_ref_data.fasta_index,
     ref_dict = download_ref_data.dict,
     ref_gtf = download_ref_data.gtf,
+    ref_gff3 = resolved_ref_gff3,
     ref_bed = download_ref_data.bed,
     r1_fastq = download_fastq_data.r1_fastq,
     r2_fastq = download_fastq_data.r2_fastq,
@@ -156,6 +160,7 @@ workflow testdata_example {
     pao1_fasta_index = download_pao1_ref.fasta_index,
     pao1_dict = download_pao1_ref.dict,
     pao1_gtf = download_pao1_ref.gtf,
+    pao1_gff3 = download_pao1_ref.gff3,
     merged_demo_fasta = merge_fastas_with_prefix.merged_fasta,
     merged_demo_fasta_index = merge_fastas_with_prefix.merged_fasta_index,
     rrna_fasta = download_rrna_reference.fasta,
@@ -168,6 +173,7 @@ workflow testdata_example {
     File ref_fasta_index = download_ref_data.fasta_index
     File ref_dict = download_ref_data.dict
     File ref_gtf = download_ref_data.gtf
+    File ref_gff3 = resolved_ref_gff3
     File ref_bed = download_ref_data.bed
     # Outputs from the fastq, cram, and bam data downloads
     File r1_fastq = download_fastq_data.r1_fastq
@@ -240,6 +246,7 @@ workflow testdata_example {
     File pao1_fasta_index = download_pao1_ref.fasta_index
     File pao1_dict = download_pao1_ref.dict
     File pao1_gtf = download_pao1_ref.gtf
+    File pao1_gff3 = download_pao1_ref.gff3
     # Outputs from merged-FASTA + rRNA reference helpers
     File merged_demo_fasta = merge_fastas_with_prefix.merged_fasta
     File merged_demo_fasta_index = merge_fastas_with_prefix.merged_fasta_index
@@ -264,6 +271,7 @@ task validate_outputs {
     ref_fasta_index: "Reference FASTA index file to validate"
     ref_dict: "Reference FASTA dictionary file to validate"
     ref_gtf: "GTF annotation file to validate"
+    ref_gff3: "GFF3 annotation file to validate"
     ref_bed: "BED file to validate"
     r1_fastq: "R1 FASTQ file to validate"
     r2_fastq: "R2 FASTQ file to validate"
@@ -319,6 +327,7 @@ task validate_outputs {
     pao1_fasta_index: "PAO1 reference FASTA index file to validate"
     pao1_dict: "PAO1 reference FASTA dictionary file to validate"
     pao1_gtf: "PAO1 NCBI RefSeq GTF annotation file to validate"
+    pao1_gff3: "PAO1 NCBI RefSeq GFF3 annotation file to validate"
     merged_demo_fasta: "Merged FASTA produced by merge_fastas_with_prefix to validate"
     merged_demo_fasta_index: "Index for the merged FASTA to validate"
     rrna_fasta: "Human 45S rRNA precursor FASTA from download_rrna_reference to validate"
@@ -332,6 +341,7 @@ task validate_outputs {
     File ref_fasta_index
     File ref_dict
     File ref_gtf
+    File ref_gff3
     File ref_bed
     File r1_fastq
     File r2_fastq
@@ -387,6 +397,7 @@ task validate_outputs {
     File pao1_fasta_index
     File pao1_dict
     File pao1_gtf
+    File pao1_gff3
     File merged_demo_fasta
     File merged_demo_fasta_index
     File rrna_fasta
@@ -423,6 +434,7 @@ task validate_outputs {
     validate_file "~{ref_fasta_index}" "Reference FASTA index" || validation_passed=false
     validate_file "~{ref_dict}" "Reference FASTA dict" || validation_passed=false
     validate_file "~{ref_gtf}" "GTF file" || validation_passed=false
+    validate_file "~{ref_gff3}" "GFF3 file" || validation_passed=false
     validate_file "~{ref_bed}" "BED file" || validation_passed=false
     validate_file "~{r1_fastq}" "R1 FASTQ" || validation_passed=false
     validate_file "~{r2_fastq}" "R2 FASTQ" || validation_passed=false
@@ -483,6 +495,7 @@ task validate_outputs {
     validate_file "~{pao1_fasta_index}" "PAO1 reference FASTA index" || validation_passed=false
     validate_file "~{pao1_dict}" "PAO1 reference FASTA dict" || validation_passed=false
     validate_file "~{pao1_gtf}" "PAO1 NCBI RefSeq GTF" || validation_passed=false
+    validate_file "~{pao1_gff3}" "PAO1 NCBI RefSeq GFF3" || validation_passed=false
     validate_file "~{merged_demo_fasta}" "Merged demo FASTA" || validation_passed=false
     validate_file "~{merged_demo_fasta_index}" "Merged demo FASTA index" || validation_passed=false
     validate_file "~{rrna_fasta}" "Human 45S rRNA precursor FASTA" || validation_passed=false
@@ -502,7 +515,7 @@ task validate_outputs {
     {
       echo ""
       echo "=== Validation Summary ==="
-      echo "Total files validated: 61"
+      echo "Total files validated: 63"
     } >> validation_report.txt
 
     if [[ "$validation_passed" == "true" ]]; then

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -127,8 +127,11 @@ task download_ref_data {
         BASE_URL="https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.40_GRCh38.p14"
         wget -q --no-check-certificate -O "GRCh38.gff3.gz" "${BASE_URL}/GCF_000001405.40_GRCh38.p14_genomic.gff.gz"
         gunzip "GRCh38.gff3.gz"
-        # Extract only this chromosome's annotations (by RefSeq accession)
-        awk -F'\t' -v acc="$ACCESSION" '$1 == acc' "GRCh38.gff3" > temp.gff3
+        # Extract only this chromosome's annotations (by RefSeq accession),
+        # renaming column 1 from the RefSeq accession to the UCSC chromosome
+        # name so it matches the FASTA's sequence header (~{chromo}) above.
+        awk -F'\t' -v OFS='\t' -v acc="$ACCESSION" -v chr="~{chromo}" \
+          '$1 == acc { $1 = chr; print }' "GRCh38.gff3" > temp.gff3
         rm "GRCh38.gff3"
 
         if [ -n "$REGION" ]; then

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -8,13 +8,14 @@ task download_ref_data {
   meta {
     author: "Taylor Firman"
     email: "tfirman@fredhutch.org"
-    description: "Downloads chromosome or whole-genome FASTA + GTF + BED + samtools index/dict from a UCSC assembly."
+    description: "Downloads chromosome or whole-genome FASTA + GTF + BED + samtools index/dict from a UCSC assembly. For hg38, also fetches a matching GFF3 from NCBI (UCSC doesn't publish one)."
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
         fasta: "Reference genome FASTA file",
         fasta_index: "Index file for the reference FASTA",
         dict: "Dictionary file for the reference FASTA",
         gtf: "GTF file containing gene annotations for the specified chromosome",
+        gff3: "GFF3 file containing gene annotations for the specified chromosome (only populated when version is hg38)",
         bed: "BED file covering the entire chromosome"
     }
   }
@@ -100,6 +101,42 @@ task download_ref_data {
     # Get length from the FASTA file
     CHR_LENGTH=$(($(grep -v "^>" "~{final_output_name}.fa" | tr -d '\n' | wc -c)))
     echo -e "~{chromo}\t0\t${CHR_LENGTH}" > "~{final_output_name}.bed"
+
+    # UCSC doesn't publish a GFF3 alongside its GTF, so for hg38 fetch the
+    # matching annotation from NCBI instead (coordinates match UCSC's hg38
+    # base-for-base, since both trace back to GRCh38). NCBI's GFF3 uses
+    # RefSeq accessions (e.g. NC_000001.11) rather than UCSC chromosome
+    # names, so map the standard chromosome names before filtering.
+    if [ "~{version}" = "hg38" ]; then
+      declare -A CHR_ACCESSIONS=(
+        [chr1]="NC_000001.11" [chr2]="NC_000002.12" [chr3]="NC_000003.12"
+        [chr4]="NC_000004.12" [chr5]="NC_000005.10" [chr6]="NC_000006.12"
+        [chr7]="NC_000007.14" [chr8]="NC_000008.11" [chr9]="NC_000009.12"
+        [chr10]="NC_000010.11" [chr11]="NC_000011.10" [chr12]="NC_000012.12"
+        [chr13]="NC_000013.11" [chr14]="NC_000014.9" [chr15]="NC_000015.10"
+        [chr16]="NC_000016.10" [chr17]="NC_000017.11" [chr18]="NC_000018.10"
+        [chr19]="NC_000019.10" [chr20]="NC_000020.11" [chr21]="NC_000021.9"
+        [chr22]="NC_000022.11" [chrX]="NC_000023.11" [chrY]="NC_000024.10"
+        [chrM]="NC_012920.1"
+      )
+      ACCESSION="${CHR_ACCESSIONS[~{chromo}]:-}"
+      if [ -n "$ACCESSION" ]; then
+        BASE_URL="https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.40_GRCh38.p14"
+        wget -q -O "GRCh38.gff3.gz" "${BASE_URL}/GCF_000001405.40_GRCh38.p14_genomic.gff.gz"
+        gunzip "GRCh38.gff3.gz"
+        # Extract only this chromosome's annotations (by RefSeq accession)
+        awk -F'\t' -v acc="$ACCESSION" '$1 == acc' "GRCh38.gff3" > temp.gff3
+        rm "GRCh38.gff3"
+
+        if [ -n "$REGION" ]; then
+          awk -F'\t' -v start="$REGION_START" -v end="$REGION_END" \
+            '$4 <= end && $5 >= start' temp.gff3 > "~{final_output_name}.gff3"
+          rm temp.gff3
+        else
+          mv temp.gff3 "~{final_output_name}.gff3"
+        fi
+      fi
+    fi
   >>>
 
   output {
@@ -107,6 +144,7 @@ task download_ref_data {
     File fasta_index = "~{final_output_name}.fa.fai"
     File dict = "~{final_output_name}.dict"
     File gtf = "~{final_output_name}.gtf"
+    File? gff3 = "~{final_output_name}.gff3"
     File bed = "~{final_output_name}.bed"
   }
 
@@ -1889,13 +1927,14 @@ task download_pao1_ref {
   meta {
     author: "Taylor Firman"
     email: "tfirman@fredhutch.org"
-    description: "Downloads the Pseudomonas aeruginosa PAO1 reference genome (FASTA and GTF) from NCBI RefSeq for bacterial RNA-seq test runs"
+    description: "Downloads the Pseudomonas aeruginosa PAO1 reference genome (FASTA, GTF, and GFF3) from NCBI RefSeq for bacterial RNA-seq test runs"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-testdata/ww-testdata.wdl"
     outputs: {
         fasta: "Pseudomonas aeruginosa PAO1 reference genome FASTA (NC_002516.2)",
         fasta_index: "Index file for the PAO1 reference FASTA",
         dict: "Dictionary file for the PAO1 reference FASTA",
-        gtf: "NCBI RefSeq GTF annotation for PAO1 (bacterial layout: mostly CDS rows with only tRNA/rRNA exons)"
+        gtf: "NCBI RefSeq GTF annotation for PAO1 (bacterial layout: mostly CDS rows with only tRNA/rRNA exons)",
+        gff3: "NCBI RefSeq GFF3 annotation for PAO1"
     }
   }
 
@@ -1937,6 +1976,11 @@ task download_pao1_ref {
     # the case the ww-gffread normalize_gtf task is designed to handle.
     wget -q --no-check-certificate -O "~{output_prefix}.gtf.gz" "${BASE_URL}/GCF_000006765.1_ASM676v1_genomic.gtf.gz"
     gunzip "~{output_prefix}.gtf.gz"
+
+    # Download PAO1 GFF3 annotation from NCBI RefSeq (same assembly, for
+    # testing the ww-gffread gff3_to_gtf conversion task)
+    wget -q --no-check-certificate -O "~{output_prefix}.gff3.gz" "${BASE_URL}/GCF_000006765.1_ASM676v1_genomic.gff.gz"
+    gunzip "~{output_prefix}.gff3.gz"
   >>>
 
   output {
@@ -1944,6 +1988,7 @@ task download_pao1_ref {
     File fasta_index = "~{output_prefix}.fa.fai"
     File dict = "~{output_prefix}.dict"
     File gtf = "~{output_prefix}.gtf"
+    File gff3 = "~{output_prefix}.gff3"
   }
 
   runtime {

--- a/modules/ww-testdata/ww-testdata.wdl
+++ b/modules/ww-testdata/ww-testdata.wdl
@@ -107,6 +107,9 @@ task download_ref_data {
     # base-for-base, since both trace back to GRCh38). NCBI's GFF3 uses
     # RefSeq accessions (e.g. NC_000001.11) rather than UCSC chromosome
     # names, so map the standard chromosome names before filtering.
+    # Note: --no-check-certificate is required because the getwilds/samtools:1.11
+    # container's CA bundle is older than the intermediate CA that NCBI's FTP
+    # endpoint presents, so strict TLS verification fails (see download_pao1_ref).
     if [ "~{version}" = "hg38" ]; then
       declare -A CHR_ACCESSIONS=(
         [chr1]="NC_000001.11" [chr2]="NC_000002.12" [chr3]="NC_000003.12"
@@ -122,7 +125,7 @@ task download_ref_data {
       ACCESSION="${CHR_ACCESSIONS[~{chromo}]:-}"
       if [ -n "$ACCESSION" ]; then
         BASE_URL="https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.40_GRCh38.p14"
-        wget -q -O "GRCh38.gff3.gz" "${BASE_URL}/GCF_000001405.40_GRCh38.p14_genomic.gff.gz"
+        wget -q --no-check-certificate -O "GRCh38.gff3.gz" "${BASE_URL}/GCF_000001405.40_GRCh38.p14_genomic.gff.gz"
         gunzip "GRCh38.gff3.gz"
         # Extract only this chromosome's annotations (by RefSeq accession)
         awk -F'\t' -v acc="$ACCESSION" '$1 == acc' "GRCh38.gff3" > temp.gff3

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -77,7 +77,7 @@ This pipeline extends the simpler `ww-star-deseq2` pipeline with upstream read Q
 ## Module Dependencies
 
 This pipeline imports and uses:
-- **ww-gffread module**: GTF normalization to ensure exon features exist (`normalize_gtf` task)
+- **ww-gffread module**: GFF3-to-GTF conversion and GTF normalization to ensure exon features exist (`gff3_to_gtf`, `normalize_gtf` tasks)
 - **ww-fastqc module**: Pre-trim and post-trim read quality assessment (`run_fastqc` task)
 - **ww-trimgalore module**: Adapter and quality trimming (`trimgalore_paired` task)
 - **ww-star module**: Genome indexing and read alignment (`build_index`, `align_two_pass` tasks)
@@ -182,7 +182,7 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 | `r1_fastqs` | Array of R1 FASTQ file paths | Array[File] | No* | - |
 | `r2_fastqs` | Array of R2 FASTQ file paths | Array[File] | No* | - |
 | `conditions` | Array of condition labels per sample | Array[String] | No* | - |
-| `reference_genome` | Reference genome information (name, fasta, gtf) | RefGenome | Yes | - |
+| `reference_genome` | Reference genome information (name, fasta, and either gtf or gff3) | RefGenome | Yes | - |
 | `reference_level` | Reference level for DESeq2 contrast (e.g., 'control') | String | No | "" |
 | `contrast` | DESeq2 contrast string (e.g., 'condition,treatment,control') | String | No | "" |
 | `trim_quality` | Quality threshold for Trim Galore trimming | Int | No | 20 |
@@ -201,11 +201,21 @@ Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-h
 
 ### RefGenome Structure
 
+Provide either `gtf` or `gff3` (not both need to be set, but at least one is required). If `gff3` is provided, it is converted to GTF internally via the `ww-gffread` module's `gff3_to_gtf` task before use.
+
 ```json
 {
   "name": "genome_name",
   "fasta": "/path/to/genome.fasta",
   "gtf": "/path/to/annotation.gtf"
+}
+```
+
+```json
+{
+  "name": "genome_name",
+  "fasta": "/path/to/genome.fasta",
+  "gff3": "/path/to/annotation.gff3"
 }
 ```
 

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -34,10 +34,10 @@ workflow rnaseq_example {
   # gff3 is only conditionally populated by download_ref_data (hg38 only),
   # but this testrun always uses hg38 so it will always be defined here.
   File chr1_gff3 = select_first([download_ref_data.gff3])
-  RefGenome reference = {
-    "name": "chr1_50M",
-    "fasta": download_ref_data.fasta,
-    "gff3": chr1_gff3
+  RefGenome reference = object {
+    name: "chr1_50M",
+    fasta: download_ref_data.fasta,
+    gff3: chr1_gff3
   }
 
   # Run the full RNA-seq pipeline with reduced resources for testing

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -12,7 +12,9 @@ struct RefGenome {
 }
 
 workflow rnaseq_example {
-  # Download reference data: 50Mbp region of chr1 to keep STAR index size manageable
+  # Download reference data: 50Mbp region of chr1 to keep STAR index size manageable.
+  # Also fetches a matching GFF3 (hg38 only) so this testrun can exercise the
+  # pipeline's gff3 input path via gffread's gff3_to_gtf task.
   call ww_testdata.download_ref_data {
     input:
       region = "1-50000000",
@@ -27,11 +29,15 @@ workflow rnaseq_example {
   call ww_sra.fastqdump as treated1 { input: sra_id = "SRR1039508", ncpu = 2, max_reads = 250000 }
   call ww_sra.fastqdump as treated2 { input: sra_id = "SRR1039512", ncpu = 2, max_reads = 250000 }
 
-  # Construct RefGenome struct
+  # Construct RefGenome struct, providing gff3 (not gtf) to exercise the
+  # pipeline's gff3-to-gtf conversion path. select_first is used because
+  # gff3 is only conditionally populated by download_ref_data (hg38 only),
+  # but this testrun always uses hg38 so it will always be defined here.
+  File chr1_gff3 = select_first([download_ref_data.gff3])
   RefGenome reference = {
     "name": "chr1_50M",
     "fasta": download_ref_data.fasta,
-    "gtf": download_ref_data.gtf
+    "gff3": chr1_gff3
   }
 
   # Run the full RNA-seq pipeline with reduced resources for testing

--- a/pipelines/ww-rnaseq/testrun.wdl
+++ b/pipelines/ww-rnaseq/testrun.wdl
@@ -7,7 +7,8 @@ import "./ww-rnaseq.wdl" as rnaseq_workflow
 struct RefGenome {
     String name
     File fasta
-    File gtf
+    File? gtf
+    File? gff3
 }
 
 workflow rnaseq_example {

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -12,7 +12,8 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 struct RefGenome {
     String name
     File fasta
-    File gtf
+    File? gtf
+    File? gff3
 }
 
 workflow rnaseq {
@@ -74,7 +75,7 @@ workflow rnaseq {
     r1_fastqs: "Array of R1 FASTQ file paths, one per sample"
     r2_fastqs: "Array of R2 FASTQ file paths, one per sample"
     conditions: "Array of condition labels for each sample (e.g., 'control', 'treatment')"
-    reference_genome: "Reference genome object containing name, fasta, and gtf files"
+    reference_genome: "Reference genome object containing name, fasta, and gene annotations (provide either gtf or gff3; gff3 is converted to GTF internally)"
     reference_level: "Reference level for DESeq2 contrast (e.g., 'control' when comparing treatment vs. control)"
     contrast: "DESeq2 contrast string in the format 'condition,treatment,control'"
     trim_quality: "Quality threshold for Trim Galore adapter/quality trimming"
@@ -124,12 +125,22 @@ workflow rnaseq {
   Int n_samples = if defined(sample_names) then length(select_first([sample_names])) else (length(tsv_rows) - 1)
   Array[Int] sample_indices = range(n_samples)
 
+  # Accept either a GTF or a GFF3 as the gene annotation input. If only a
+  # GFF3 is provided, convert it to GTF first so the rest of the pipeline
+  # (which is GTF-only) can proceed unchanged.
+  if (!defined(reference_genome.gtf)) {
+    call gffread_tasks.gff3_to_gtf { input:
+        input_gff3 = select_first([reference_genome.gff3])
+    }
+  }
+  File input_gtf = select_first([reference_genome.gtf, gff3_to_gtf.gtf_file])
+
   # Normalize GTF to ensure exon features exist for every transcript.
   # This is critical for bacterial NCBI GTFs which only have CDS rows —
   # without this step, STAR GeneCounts and RSeQC would silently ignore
   # 98% of protein-coding genes. For eukaryotic GTFs this is a pass-through.
   call gffread_tasks.normalize_gtf { input:
-      input_gtf = reference_genome.gtf
+      input_gtf = input_gtf
   }
 
   # Build STAR genome index (runs once)
@@ -215,7 +226,7 @@ workflow rnaseq {
   call deseq2_tasks.compile_deseq2_results as step08_compile_results { input:
       deseq2_results = step07_deseq2.deseq2_results,
       normalized_counts = step07_deseq2.deseq2_normalized_counts,
-      gtf_file = reference_genome.gtf
+      gtf_file = input_gtf
   }
 
   # Step 9: MultiQC aggregation of all QC reports

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rseqc/ww-rseqc.wdl" as rseqc_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as multiqc_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-gff3-conversion/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
 
 struct RefGenome {
     String name


### PR DESCRIPTION
## Type of Change

- Documentation update
- Bug fix

## Description

Adds support for GFF3 as an alternative to GTF for the `ww-rnaseq` pipeline's `reference_genome` input, and adds test coverage for the underlying `gff3_to_gtf` conversion.

- **`ww-rnaseq`**: `RefGenome.gtf` is now optional and a new optional `RefGenome.gff3` field is available. Users can provide either annotation format; if only a GFF3 is supplied, the pipeline converts it to GTF internally via the existing `ww-gffread` module's `gff3_to_gtf` task before proceeding through the rest of the (GTF-only) pipeline.
- **`ww-testdata`**: `download_ref_data` now also fetches a matching GFF3 from NCBI RefSeq when `version` is `hg38` (UCSC does not publish a GFF3 alongside its GTF, so this uses NCBI's GRCh38.p14 assembly instead, filtered down to the requested chromosome/region via a RefSeq-accession lookup). Verified that NCBI's GRCh38.p14 chr1 sequence matches UCSC's hg38 chr1 base-for-base at spot-checked coordinates, so the GFF3 annotations line up correctly with the existing FASTA. `download_pao1_ref` also now fetches a GFF3 from the same NCBI assembly directory already used for its FASTA/GTF.
- **`ww-gffread`**: Fixed a bug found while running `gff3_to_gtf` against a real-world Bakta-annotated GFF3: `gffread` cannot parse a strand value of `?` (GFF3-legal for "relevant, but unknown," used by some annotators for features like origin-of-replication). `gff3_to_gtf` now strips any row with strand `?` before invoking `gffread`; these are not gene/transcript features, so nothing relevant to downstream RNA-seq quantification is lost. Documented in the module README.
- Updated `testrun.wdl` for all three affected modules/pipelines to exercise the new gff3 code paths, and updated `validate_outputs` in `ww-testdata/testrun.wdl` to validate the two new `gff3` outputs (file count bumped from 61 to 63).
- Updated READMEs for `ww-rnaseq`, `ww-testdata`, and `ww-gffread` to document the new inputs/outputs, test cases, and the `?`-strand fix.

## Testing

**How did you test these changes?**
Ran `make lint`, all pass cleanly. Additionally ran ww-rnaseq on Fred Hutch HPC, which surfaced the `?`-strand parsing bug against a researcher's GFF3. After the fix, reran on HPC and confirmed `gff3_to_gtf` now converts successfully end-to-end.

**What workflow engine did you use?**
Sprocket, miniWDL, and WOMtool (Cromwell) for linting/validation as well as the CI/CD test runs below. Cromwell on Fred Hutch HPC for full `testrun.wdl` execution.

**Did the tests pass?**
Yes, all lint/validation checks passed, and the full `testrun.wdl` now runs successfully on HPC.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- No new modules or pipelines added; this is additive/backward-compatible — existing pipelines/callers passing `gtf` continue to work unchanged.