### PR TITLE
Adding cryptographic signing for WDL modules and pipelines

### DIFF
--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -72,6 +72,7 @@ Create four files in `modules/ww-$ARGUMENTS/`:
 - If the tool has a nonstandard license, use an SPDX `LicenseRef-` placeholder (e.g. `"LicenseRef-VarScan-NonCommercial"`) and call it out in the summary at the end of this skill.
 - If the module doesn't wrap one clear external tool (e.g. a data-download utility or a custom script), omit `tools[]` entirely.
 - Run `make lint_module_json NAME=ww-$ARGUMENTS` to validate structure.
+- Do NOT create a `module.sig` file. CI signs it automatically once the module is merged to `main`.
 
 ### 4. Lint the Module
 

--- a/.agents/skills/create-pipeline/SKILL.md
+++ b/.agents/skills/create-pipeline/SKILL.md
@@ -93,6 +93,7 @@ Create five files in `pipelines/ww-$0/`:
 - `name` is the pipeline directory name, `license` is `"MIT"`, omit the top-level `version` field
 - Add a `dependencies{}` entry for each module imported in `ww-$0.wdl`, one per module, following the `git`/`branch`/`path` pattern in the template (pointing at this repo's `main` branch and `modules/ww-<name>`)
 - Run `make lint_module_json NAME=ww-$0` to validate structure.
+- Do NOT create a `module.sig` file. CI signs it automatically once the pipeline is merged to `main`.
 
 ### 5. Lint the Pipeline
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -157,7 +157,7 @@ Note: `testrun.wdl` files use relative path imports (unlike the pipeline source 
 
 **Module manifest (`module.json`):**
 
-Every module and pipeline in this library ships a `module.json` manifest, an early adoption of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765). For the schema itself (field definitions, dependency selectors, versioning rules) see the spec's [`modules/SPEC.md`](https://github.com/openwdl/wdl/blob/wdl-1.4/modules/SPEC.md) and [`module.schema.json`](https://github.com/openwdl/wdl/blob/wdl-1.4/modules/schemas/module.schema.json). Since the spec is still unmerged and changing, treat that upstream source as ground truth over any summary written here or elsewhere in this repo.
+Every module and pipeline in this library ships a `module.json` manifest, an early adoption of the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765). We're adding these ahead of that spec being finalized, so the library is ready as WDL module-management tooling (like Sprocket's symbolic module imports) matures; the spec itself is still an unmerged draft and its field definitions may still change. For the schema itself (field definitions, dependency selectors, versioning rules) see the spec's [`modules/SPEC.md`](https://github.com/openwdl/wdl/blob/wdl-1.4/modules/SPEC.md) and [`module.schema.json`](https://github.com/openwdl/wdl/blob/wdl-1.4/modules/schemas/module.schema.json). Since the spec is still unmerged and changing, treat that upstream source as ground truth over any summary written here or elsewhere in this repo.
 
 WILDS-specific conventions on top of the spec:
 
@@ -170,6 +170,8 @@ WILDS-specific conventions on top of the spec:
 **Module signature (`module.sig`):**
 
 Every module and pipeline with a `module.json` also carries a `module.sig`, an Ed25519 signature over the module's deterministic content hash, produced by `sprocket dev module sign`. This lets a consumer verify that a module's files (WDL, README, scripts, everything except `module.json`'s own `module.sig`/`module-lock.json`) haven't been tampered with since WILDS published them.
+
+**These signatures aren't usable yet.** `sprocket dev module sign`/`sprocket dev module verify` are not in any released Sprocket version; we're adding `module.sig` files now, ahead of that tooling shipping, so the library is ready once it does. There's nothing to check or verify against these signatures today.
 
 A few things to know:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -175,7 +175,7 @@ A few things to know:
 
 - **You don't need to sign anything yourself.** CI re-signs any module or pipeline whose directory content changed in a push to `main` (see `.github/workflows/sign-modules.yml` and `.github/scripts/sign_modules.py`) and commits the updated `module.sig` automatically. Don't hand-edit `module.sig` files or worry about them in your PR.
 - **Any change to a module's directory invalidates its old signature**, not just WDL edits: a README tweak, a fixed typo, a new test fixture, anything under `modules/ww-toolname/` or `pipelines/ww-pipeline-name/` changes the content hash CI signs.
-- **Ed25519 signatures aren't deterministic.** Two signatures over the identical content with the identical key will have different bytes but both verify correctly; don't be surprised if `module.sig` changes even when nothing about the underlying content did (e.g. after a manual re-sign).
+- **Ed25519 signatures are deterministic**: signing the same content with the same key always produces the same signature bytes. If `module.sig` changes with no apparent change to the module's content, the key used to sign it changed instead (e.g. after rotating the signing key).
 - **The signing key is a standard Ed25519 SSH key** (the kind `ssh-keygen -t ed25519` produces), in OpenSSH format. `sprocket dev module sign` and `sprocket dev module verify` are not yet in a released Sprocket version; see the pinned commit in `.github/workflows/sign-modules.yml` for what CI currently installs.
 
 ## Pipeline Development Guidelines

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -167,6 +167,17 @@ WILDS-specific conventions on top of the spec:
 - **For a tool with a nonstandard license**, use an SPDX `LicenseRef-` placeholder (e.g. `"LicenseRef-VarScan-NonCommercial"`) and flag it for reviewer attention in your PR description, since there is no real SPDX identifier for these.
 - **See `pipelines/ww-bwa-gatk/module.json`** for the reference pattern for declaring module dependencies in a pipeline's manifest.
 
+**Module signature (`module.sig`):**
+
+Every module and pipeline with a `module.json` also carries a `module.sig`, an Ed25519 signature over the module's deterministic content hash, produced by `sprocket dev module sign`. This lets a consumer verify that a module's files (WDL, README, scripts, everything except `module.json`'s own `module.sig`/`module-lock.json`) haven't been tampered with since WILDS published them.
+
+A few things to know:
+
+- **You don't need to sign anything yourself.** CI re-signs any module or pipeline whose directory content changed in a push to `main` (see `.github/workflows/sign-modules.yml` and `.github/scripts/sign_modules.py`) and commits the updated `module.sig` automatically. Don't hand-edit `module.sig` files or worry about them in your PR.
+- **Any change to a module's directory invalidates its old signature**, not just WDL edits: a README tweak, a fixed typo, a new test fixture, anything under `modules/ww-toolname/` or `pipelines/ww-pipeline-name/` changes the content hash CI signs.
+- **Ed25519 signatures aren't deterministic.** Two signatures over the identical content with the identical key will have different bytes but both verify correctly; don't be surprised if `module.sig` changes even when nothing about the underlying content did (e.g. after a manual re-sign).
+- **The signing key is a standard Ed25519 SSH key** (the kind `ssh-keygen -t ed25519` produces), in OpenSSH format. `sprocket dev module sign` and `sprocket dev module verify` are not yet in a released Sprocket version; see the pinned commit in `.github/workflows/sign-modules.yml` for what CI currently installs.
+
 ## Pipeline Development Guidelines
 
 **Pipelines should:**

--- a/.github/scripts/sign_modules.py
+++ b/.github/scripts/sign_modules.py
@@ -4,10 +4,9 @@ Sign module.json manifests in WILDS modules and pipelines, writing/updating
 each one's module.sig.
 
 Only re-signs a module/pipeline whose directory content actually changed
-between two given git refs (Ed25519 signatures aren't deterministic, so
-re-signing an unchanged module still produces a different signature byte
-string and a needless commit). Pass --all to sign every module/pipeline
-with a module.json regardless of what changed.
+between two given git refs, so CI doesn't spend time re-invoking `sprocket
+dev module sign` on every module on every push. Pass --all to sign every
+module/pipeline with a module.json regardless of what changed.
 
 Requires a `sprocket` build with `dev module sign` (not yet in a released
 Sprocket version as of this writing; see .github/workflows/sign-modules.yml

--- a/.github/scripts/sign_modules.py
+++ b/.github/scripts/sign_modules.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Sign module.json manifests in WILDS modules and pipelines, writing/updating
+each one's module.sig.
+
+Only re-signs a module/pipeline whose directory content actually changed
+between two given git refs (Ed25519 signatures aren't deterministic, so
+re-signing an unchanged module still produces a different signature byte
+string and a needless commit). Pass --all to sign every module/pipeline
+with a module.json regardless of what changed.
+
+Requires a `sprocket` build with `dev module sign` (not yet in a released
+Sprocket version as of this writing; see .github/workflows/sign-modules.yml
+for which branch/commit CI installs).
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_manifest_dirs():
+    """Find every modules/*/ and pipelines/*/ directory containing a module.json."""
+    dirs = []
+    for tier in ("modules", "pipelines"):
+        tier_dir = Path(tier)
+        if not tier_dir.is_dir():
+            continue
+        for item_dir in sorted(tier_dir.iterdir()):
+            if (item_dir / "module.json").exists():
+                dirs.append(item_dir)
+    return dirs
+
+
+def changed_manifest_dirs(before_ref, after_ref):
+    """Return manifest dirs whose contents differ between before_ref and after_ref."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", before_ref, after_ref],
+        capture_output=True, text=True, check=True,
+    )
+    changed_top_dirs = set()
+    for line in result.stdout.splitlines():
+        parts = line.split("/", 2)
+        if len(parts) >= 2 and parts[0] in ("modules", "pipelines"):
+            changed_top_dirs.add(Path(parts[0]) / parts[1])
+
+    return sorted(d for d in changed_top_dirs if (d / "module.json").exists())
+
+
+def sign_manifest_dir(manifest_dir, key_path):
+    """Run `sprocket dev module sign` against a single manifest directory."""
+    subprocess.run(
+        [
+            "sprocket", "dev", "module", "sign",
+            "--key", str(key_path),
+            "--manifest-path", str(manifest_dir),
+        ],
+        check=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sign module.json manifests in WILDS modules/pipelines."
+    )
+    parser.add_argument("--key", required=True, help="Path to the OpenSSH-format Ed25519 private key")
+    parser.add_argument(
+        "--all", action="store_true",
+        help="Sign every module/pipeline, not just those changed between --before and --after"
+    )
+    parser.add_argument("--before", default=None, help="Git ref to diff from (ignored with --all)")
+    parser.add_argument("--after", default="HEAD", help="Git ref to diff to (ignored with --all; default: HEAD)")
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print which modules/pipelines would be signed without actually signing them"
+    )
+    args = parser.parse_args()
+
+    if args.all:
+        targets = find_manifest_dirs()
+        print(f"Signing all {len(targets)} module(s)/pipeline(s) with a module.json")
+    else:
+        if not args.before:
+            parser.error("--before is required unless --all is passed")
+        targets = changed_manifest_dirs(args.before, args.after)
+        print(f"Signing {len(targets)} module(s)/pipeline(s) changed between {args.before} and {args.after}")
+
+    if not targets:
+        print("Nothing to sign")
+        return 0
+
+    for target in targets:
+        if args.dry_run:
+            print(f"  [dry run] would sign {target}")
+            continue
+        print(f"  Signing {target} ...")
+        sign_manifest_dir(target, args.key)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/sign-modules.yml
+++ b/.github/workflows/sign-modules.yml
@@ -1,0 +1,75 @@
+name: Sign Modules
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sign-modules:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      -
+        name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      -
+        name: Set Up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      -
+        name: Install Sprocket (feat/module-porcelain, pinned commit)
+        # `sprocket dev module sign` is not yet in a released Sprocket
+        # version. This installs from the specific commit on
+        # stjude-rust-labs/sprocket's feat/module-porcelain branch that
+        # WILDS has validated module signing against. Re-pin this SHA
+        # deliberately when picking up upstream changes, and switch to a
+        # tagged release once module signing ships in one.
+        run: |
+          cargo install --git https://github.com/stjude-rust-labs/sprocket \
+            --rev fc251dac5ec354256857385eab64bb94861c93c1 \
+            --locked sprocket
+
+      -
+        name: Write signing key
+        run: |
+          umask 077
+          printf '%s\n' "${{ secrets.WILDS_SIGNING_KEY }}" > /tmp/wilds_signing_key
+          chmod 600 /tmp/wilds_signing_key
+
+      -
+        name: Sign changed modules and pipelines
+        run: |
+          python3 .github/scripts/sign_modules.py \
+            --key /tmp/wilds_signing_key \
+            --before "${{ github.event.before }}" \
+            --after "${{ github.sha }}"
+
+      -
+        name: Remove signing key
+        if: always()
+        run: rm -f /tmp/wilds_signing_key
+
+      -
+        name: Commit updated signatures
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add modules/*/module.sig pipelines/*/module.sig
+          if git diff --cached --quiet; then
+            echo "No signature changes to commit"
+          else
+            git commit -m "Update module signatures [skip ci]"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ cromwell-workflow-logs/
 _LAST
 [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9]_*/
 __pycache__/
+
+# module signing keys (never commit private key material)
+*signing-key*
+*signing_key*
+id_ed25519*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ Sprocket exceptions (from sprocket.toml): TodoComment, ContainerUri, UnusedInput
 ## Module Manifest (module.json)
 Every module/pipeline has a `module.json` following the proposed WDL v1.4 [module manifest spec](https://github.com/openwdl/wdl/pull/765); treat that upstream spec as ground truth for field definitions, not summaries in this repo. WILDS-specific notes: omit it only for brand-new modules if truly necessary (add one anyway when possible), this repo's own `license` is always `"MIT"`, per-tool `tools[].license` needs a current SPDX identifier (use `LicenseRef-*` placeholders for nonstandard licenses and flag them in the PR), and `tools[]` uses `url`/`ids` fields, never legacy `homepage`/`doi`. See `.github/CONTRIBUTING.md` for details and `pipelines/ww-bwa-gatk/module.json` for the dependency-declaration pattern.
 
+## Module Signature (module.sig)
+Every module/pipeline with a `module.json` also has a `module.sig`, an Ed25519 signature over its content hash, produced by `sprocket dev module sign`. CI (`.github/workflows/sign-modules.yml`) re-signs and auto-commits whatever changed on push to `main`; don't hand-edit `module.sig` or worry about signing in a PR. Any change under a module's directory (WDL, README, scripts, anything but `module.json`'s own `module.sig`/`module-lock.json`) invalidates its old signature. `sprocket dev module sign`/`verify` aren't in a released Sprocket version yet; see the pinned commit in the workflow file for what's currently installed.
+
 ## Common Development Pitfalls
 - Docker image version conflicts (especially with complex tools like ColabFold) - always pin versions
 - Test data changes go in the `ww-testdata` module, not individual modules

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,22 @@ lint_module_json: check_name ## Validate module.json manifests, if present (use 
 
 lint: lint_sprocket lint_miniwdl lint_womtool lint_cirro lint_module_json ## Run all linting checks
 
+##@ Signing
+
+sign_modules: ## Sign module.json manifests (use KEY=path/to/private/key, NAME=foo for one item, or ALL=1 for everything; without KEY, does a dry run over everything)
+	@if [ -z "$(KEY)" ]; then \
+		echo "No KEY= given; doing a dry run over all modules/pipelines. Pass KEY=path/to/private/key to actually sign."; \
+		python3 .github/scripts/sign_modules.py --key /dev/null --all --dry-run; \
+	elif [ "$(ALL)" = "1" ]; then \
+		python3 .github/scripts/sign_modules.py --key $(KEY) --all; \
+	elif [ -n "$(NAME)" ] && [ "$(NAME)" != "*" ]; then \
+		sprocket dev module sign --key $(KEY) --manifest-path modules/$(NAME) 2>/dev/null || \
+		sprocket dev module sign --key $(KEY) --manifest-path pipelines/$(NAME); \
+	else \
+		echo "Pass NAME=foo for one module/pipeline, or ALL=1 to sign everything."; \
+		exit 1; \
+	fi
+
 ##@ Run
 
 run_sprocket: check_sprocket check_name ## Run sprocket on testrun WDLs (use NAME=foo, TYPE=modules|pipelines, TARGET=ci|hpc, SPROCKET_CONFIG=path, NUM_RETRIES=N)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Complete analysis workflows combining multiple modules.
 - **Testing**: Integration tests verify modules work together seamlessly
 - **Usage**: Templates for common workflows, learning examples, or production analyses
 
+Every module and pipeline also ships a `module.json` manifest and a `module.sig` signature. These are being added ahead of an upcoming WDL module-management feature in [Sprocket](https://sprocket.bio/) and aren't consumable by any released executor yet, so there's nothing you need to do with them today. See [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md#module-development-guidelines) for details.
+
 ## Quick Start
 
 ### Running Pipelines Directly (No Clone Required)

--- a/modules/ww-annotsv/module.sig
+++ b/modules/ww-annotsv/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "Fy18mlYtysl81umz0/GG1yBhwjfctn6jmU3JmmOJ5/1lNUmNTWQrimnOdhu9VnMHoDXT+fGw+VifhLHdqqNvCA=="
+}

--- a/modules/ww-annovar/module.sig
+++ b/modules/ww-annovar/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "/Bq6SGExRPdWGGUAiyWZ/6BiJ4iwU/TFwgRZys2x/84VV+XYZfghrWRU8PBPhVjajOzrwet65is+/xzV8sg4AQ=="
+}

--- a/modules/ww-aws-sso/module.sig
+++ b/modules/ww-aws-sso/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "V+Y6oYDUey++lWxCmBwUvvOhByChDTffFDm2yHFNBNMo9LqHOq9zUjo5tfvkZd4D5qnEAj2cWVeUQmio3oOBAA=="
+}

--- a/modules/ww-bcftools/module.sig
+++ b/modules/ww-bcftools/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "HKVZuOS+S6Gb5ZL/scZ9XH6MhlinwnEfjSjwBifgDN7cFTP1xPfRTcD9OEdsDb49oqkjbQfLpollwX8PWu5SDg=="
+}

--- a/modules/ww-bedparse/module.sig
+++ b/modules/ww-bedparse/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "snyBja1SM0sJnezOTj7iFCLIGVjIcerBpwFb2J6QsCXuAFULy+Psjsw0js/wIIyiBivHx0aIwgigbe0S/2QcAQ=="
+}

--- a/modules/ww-bedtools/module.sig
+++ b/modules/ww-bedtools/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "tbcWIt9Sdvb3mzkbHom62Qub1sXJKDITyf32ckD3K0gD2V1PxhxX/mffs2/LiD28fhKSP8rY8UKryH9sRaW9DA=="
+}

--- a/modules/ww-bowtie/module.sig
+++ b/modules/ww-bowtie/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "pWTWfXh/ZWozBcWvd24hE4U05tvsTXsDexS8/Fj0771HH4QOng6c8xzA+pxKDEoSFdp/fSOGtsrwu3A5nMPaCw=="
+}

--- a/modules/ww-bowtie2/module.sig
+++ b/modules/ww-bowtie2/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "0/fxJjaZYwolTwYx2sBTQmck52/CieWYmwmYp/akarFz9MHpOBxY0egwVnoDyn+AHp/2WAuylX6nZOIj0UkLCQ=="
+}

--- a/modules/ww-bwa/module.sig
+++ b/modules/ww-bwa/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "e6dFRiFfa4H82olhmtOsv64pTAKDcEfnJgKJ6bO+TWo5JaQr4RGCrZa6ceNrT3rKJ52kC/F/VNh0TXnLBAlwAQ=="
+}

--- a/modules/ww-cellbender/module.sig
+++ b/modules/ww-cellbender/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "YeZcFCUsDzdV7+bzQUgbLd9qkR5A4fYRutx6FjBZnS7V5HwjeyhHEYE1ld0tX6rDoWRLmUkHm2eFCZ3X5hAmDQ=="
+}

--- a/modules/ww-cellranger/module.sig
+++ b/modules/ww-cellranger/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "jvi3Rz28C7DvLPjCqJUMKXQs3BVcvNbG+kBr648clkLavXF9Z8SJToAFmgXmYLBUw0smpuaNDee1vbpwckn2BQ=="
+}

--- a/modules/ww-clair3/module.sig
+++ b/modules/ww-clair3/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "E3i/60fkBhRDJ01q7hUAEU1dlCPJsKqxnBy9JqJKaRwWpuW7UG+4oL3ZTGu/M4IFn9V9y7T0MIFQT7Y7tjrGBQ=="
+}

--- a/modules/ww-cnvkit/module.sig
+++ b/modules/ww-cnvkit/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "EnYBZ2g0ej36dw24YTfNjFVTzI92024JqFJwcxFFXs9MKesATae6QBk8jpyNze7IZcRTHuPNFQyNWoseLT/6Bw=="
+}

--- a/modules/ww-colabfold/module.sig
+++ b/modules/ww-colabfold/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "vWttyNQa6FCd+veFnZGX/BcDksJX8vtFekig5ScTjTzm+T6TVL/G5ufJZWVk2I5WD+ik7KgGnHuWLaqOEzP5Cg=="
+}

--- a/modules/ww-consensus/module.sig
+++ b/modules/ww-consensus/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "lmIJ30lyXxZJYyfHkyTNMfjWsq4YVoONm8iMZQdg6hguzRUbNmh5jM+SAXynDaFjbsDyAwQVeCmlTUw3znY6Aw=="
+}

--- a/modules/ww-deeptools/module.sig
+++ b/modules/ww-deeptools/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "2B0y9AM8hjIyt5NxTYXNBqZWvP1ah/mStUC2nuGqjfQMueg4D98ugyQKATVw3GUmonH2FDOFqaQGbNLAxLw6Bw=="
+}

--- a/modules/ww-deepvariant/module.sig
+++ b/modules/ww-deepvariant/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "fp4VkTuJAjyg93nV/6BQnpNA9NVZYReV5J3JXre/u39XjTLqTjqiuJoyjZjL4OqbjG8K3vE0IJfH7rmTLhMGAg=="
+}

--- a/modules/ww-delly/module.sig
+++ b/modules/ww-delly/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "a/7oML79zrlek/loZRTgGoEul6GWFXmSuU9LRTPLtShzveSYKkgbR5CjDH6JXXIA4QWBn1on+5C23IaI5S3gBg=="
+}

--- a/modules/ww-deseq2/module.sig
+++ b/modules/ww-deseq2/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "HRCPPgynIl3mEc2C/Q0b/mRAnFDjogZqIl3NOZsTqLAgfyCB0YRJzXF2tPnQjecqj4zWXf8MXLnJkwV4WYpSDQ=="
+}

--- a/modules/ww-diamond/module.sig
+++ b/modules/ww-diamond/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "k84yEPfPMUQMwEE+VVXVoxtQ4vem8883DjWKX+o/cizSGhlkHVWkwKXotSpVhZDpzEQzYkflognq3khVSdQnCA=="
+}

--- a/modules/ww-edger/module.sig
+++ b/modules/ww-edger/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "XaM3qbBsi+AIX7qq0PDxqlHN2/GXRwoqiyJzMawsclfuPuykm59IUrZ/hFRCcRTrxFSxi/P2FOV6VcPf8coqDA=="
+}

--- a/modules/ww-ena/module.sig
+++ b/modules/ww-ena/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "O72j0v+mWre87m1+WHZX7lJnbWMdHTtq+2of9DrNaRqWqtdaTVOlOpoZtw68PDZ3TYi8v08bzArGu+pWW607AA=="
+}

--- a/modules/ww-esmfold/module.sig
+++ b/modules/ww-esmfold/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "CUC4VE1hY0f+H7E87wUZeUlrNnPzYHn/Kr6uwg/WCgkvGJ73ogfSBwG4slyZ39/4zLu6l5xVVOtRKxcX+V+4AA=="
+}

--- a/modules/ww-fastp/module.sig
+++ b/modules/ww-fastp/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "C9GCxnrf/H2BU4l2yFOWZcwV2CfJbWEDVvonC4RyNTdUCQRD1ckArOmDu98FZ4Ln4hpprCRsqOYE3RTHmmB0AA=="
+}

--- a/modules/ww-fastqc/module.sig
+++ b/modules/ww-fastqc/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "vLz8juJnn8cadI2lNS6ote/W1/EwUcevZDnxJ60776UEkZHNO5OrF01RgMz9WqRQfaj6rBYGMWShcLYyf/RwBg=="
+}

--- a/modules/ww-gatk/module.sig
+++ b/modules/ww-gatk/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "dAHEvgH/g8AsGRsXbB69jmwfwq3jgbrucKsmq+IrEjXP0ugyorXnF1wC9z81dc9Ux85RvaCc2k3I2a6woLd2BQ=="
+}

--- a/modules/ww-gdc/module.sig
+++ b/modules/ww-gdc/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "oX4DBn1hJHd2FDD8wUkkss/BZWYY9qz5CDtA7F+lu0fkEnlpKXnqfLTZeZiekXapBn25ngpeQFs/aHw4AP8MAg=="
+}

--- a/modules/ww-gffread/module.sig
+++ b/modules/ww-gffread/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "Mi+UwRH6fqinyz7x4ta/wJypXAJZu4zrh9Plprt7xx2WcN2Xh3TXRu2/4YB1L1hd/vqhdY0i5sTfqLp8m3L0AQ=="
+}

--- a/modules/ww-glimpse2/module.sig
+++ b/modules/ww-glimpse2/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "9nrOMDB4QicNBvtJiWmV6OUuuQoXeFqk5qONGgBUExBITKaoCqhFzInCWFbvekJiW9naskkxVWfORDJQURWqCA=="
+}

--- a/modules/ww-ichorcna/module.sig
+++ b/modules/ww-ichorcna/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "p/V2OFXvwuekeqZrQccVHOjb1EdAEjbaTSjcfbCwk56pZJccTtYyM96/E3J+OuSQjT43BsLf4tgvSnQDpcj9AA=="
+}

--- a/modules/ww-jcast/module.sig
+++ b/modules/ww-jcast/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "YJiRUrI4Clb4g2JNWqKPz0oQpMbQcIgoyEqeFrg38wVAdZZvG8+S20coFLfACZLTeMqCk1FajwwJQqOhgYkkAA=="
+}

--- a/modules/ww-manta/module.sig
+++ b/modules/ww-manta/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "6ielmrVugJikj+iBh4jRnCOHQPLIy9EjjkyamOoIKr8WJL54ElGGhtItpfcaBEX91HOa9c2RRPPl978Q8LmrCQ=="
+}

--- a/modules/ww-megahit/module.sig
+++ b/modules/ww-megahit/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "sBA5m02FjxbYP12Q5JDNPdHxrtvk2qbxhbatR3eR3qJPpTP4y8zhMnZtjQSx9zNZxRVE1ibiesDoFodQLn5/Bg=="
+}

--- a/modules/ww-mosdepth/module.sig
+++ b/modules/ww-mosdepth/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "8maG0uzVfHQVyLA2e6CbBg4y1Q90isUF6SR8tQo+C2K4uSdy+iwDZn7Yn5acWHgryvn9WetY92xjER0GePpPAg=="
+}

--- a/modules/ww-multiqc/module.sig
+++ b/modules/ww-multiqc/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "0ubvaC8QQF/8gGd3HXq7ajIvy0RYNslnb0QI73CjOgzKaF6RRDaskpOstwcOEdO/FkrgKJfphecb/OZaEesDBQ=="
+}

--- a/modules/ww-rmats-turbo/module.sig
+++ b/modules/ww-rmats-turbo/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "2+Xx29Ll60gA/znwxLpe3WnCzZfMXvXLszv3GYwjJaw3Uy+uulkN7m+kmvaWZnDAJYs2GPXlPR3kgo5c7mwNCg=="
+}

--- a/modules/ww-rseqc/module.sig
+++ b/modules/ww-rseqc/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "5Cr4BUlxgqu9O0AmIizh84LNnLw9Dx6SRMcAUve9srmUcGSA5FpQpI9LubKBgSRpZD3KgflxYpQKq8HINxEJCA=="
+}

--- a/modules/ww-salmon/module.sig
+++ b/modules/ww-salmon/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "ckTvOVPgS8WNPHTm0thR9zPNi+kEa4yVsJhHbgvyQEF2SdJQJGsvPlxAZHnp/oxknM5BXx51uHHpBnNpjQ2CBg=="
+}

--- a/modules/ww-samtools/module.sig
+++ b/modules/ww-samtools/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "cmQD/S3VbZfArvvOnvt3ckK1h2JQAKXDCKW0WWNy9pkPLANQClEKTpbjTln3eXOKs8cxA8thTqzn3VnyTJCeBQ=="
+}

--- a/modules/ww-seurat/module.sig
+++ b/modules/ww-seurat/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "fvZZZEREdV+9G3CerPX6pJ5VE/yvl5rLMBDzIxjOGQ9q4QM5jy4QFoTQG6xpnK9Z+JqARH7ZQCgwlINokNBvCQ=="
+}

--- a/modules/ww-shapemapper/module.sig
+++ b/modules/ww-shapemapper/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "uj4vkH2QjlWnPHEslKrOKPyP2zpiSYpCKsr0IDgSOOryqkGjh5lCwgNfYDtg1I7qyL95jBQ5vLxUb1JiWpH0BQ=="
+}

--- a/modules/ww-sjl/module.sig
+++ b/modules/ww-sjl/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "rQLdItBNLCpfdd4oZMFrLWAtXOC2yQI/jx/TBCe1eJpRg+Prmxg/dLoFKW/it05fGYUq0s3fZopNDE09tFivDQ=="
+}

--- a/modules/ww-smoove/module.sig
+++ b/modules/ww-smoove/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "i5gGZTuXDcSUc/T51rc0TFZJaPL2bgoCyazh8T2IvOI25xVfbH1ylt0hb5SrvhCBvGKXgqxnquu9v6pmQQlbAQ=="
+}

--- a/modules/ww-sourmash/module.sig
+++ b/modules/ww-sourmash/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "+pYUwk8mzTRQcp70zTxxc7AB9ABpgWn3oYJDeAZHbxcWwj3oa2vGR/mpWcM+csI5bFZnkwyomQlVUx8RtAzBCw=="
+}

--- a/modules/ww-spades/module.sig
+++ b/modules/ww-spades/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "KTIexS5PiM19i+yy77Qfw/XAp3KSaYRXjbyXbbI/ZMnzfV+aF/se1LTUax6feVQPPsxyAe5cOM6Zcn0srYDQBQ=="
+}

--- a/modules/ww-sra/module.sig
+++ b/modules/ww-sra/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "+VulQ6GFNhe1YcGCNQKTv1NYcunfzG6kQzsE9oKXIa7q10DI55lrC30bDimGZ2IRcFEQWDTASKT6EbwTxBZJCw=="
+}

--- a/modules/ww-star/module.sig
+++ b/modules/ww-star/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "GWfIHaQRFnox3X3/c5IY7TssW8S3NaxLZ+n51ROFX/u843Z7YNiqoRdHLbClpJ2oxr8ue9EDrcMOTHcLwRnXDg=="
+}

--- a/modules/ww-starling/module.sig
+++ b/modules/ww-starling/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "AFrhfBbPAIMLdTmDLQo5k6E7EWpyoPklpgNOevtFcSHvMH1RR7Vi8w+tePQ6baSuTI4ciczDG/xO49vUznqKDg=="
+}

--- a/modules/ww-strelka/module.sig
+++ b/modules/ww-strelka/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "XPmZkeqdHGnLY2lgk8A5qFLndf1kyPCAqrbT/KkQZ9s/P3Pa4Pt/9l81tCxUI6eveZQfXbyGln/xWF8NJaRgBw=="
+}

--- a/modules/ww-testdata/module.sig
+++ b/modules/ww-testdata/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "skQW9XTcULSiF/Xd+DPnoNLKcV3DtJU3u9+wknubNnAd/3HEZgx3EezYU1W+pbP1kAGxYi9ZqH7t+uVw8B/yCw=="
+}

--- a/modules/ww-trimgalore/module.sig
+++ b/modules/ww-trimgalore/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "epyj5jd5TurOjDKFFE1zQcz+Cq/uVrQWI/efXG+Nbcz3Rg3Qa2nVQjUYFg278HBkQFcVrfRbJr8OTBrXEF1hAQ=="
+}

--- a/modules/ww-tritonnp/module.sig
+++ b/modules/ww-tritonnp/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "xB5+b8OtiHY7J5wSY8eQMXdtou1DvBLGl6Bi4W0j4Bj7btXXv+VAj2LIMsS7c7LhdpzMZtJ9Q4QUQwLlr25SDQ=="
+}

--- a/modules/ww-umi-tools/module.sig
+++ b/modules/ww-umi-tools/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "xngnMPfqFQ36WSWyevo2MYpA0C/U6OukL9wm0YYoXUsQ5+gxvbh6JG5WJGGd0xNRj+5Og271JnKAlyerE99ECw=="
+}

--- a/modules/ww-varscan/module.sig
+++ b/modules/ww-varscan/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "FHc6m2rxa7q5WmjoZWATyeChquIEi/XmiI5tNRQoPPGxtf7yXf22VP3EjwtxqjkZ5iCx7zSFZdvuddcSAMnJDA=="
+}

--- a/modules/ww-viennarna/module.sig
+++ b/modules/ww-viennarna/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "diH3Lg+HLan2/tAa9nErCwdIGYQ6spxl68yugDEsuWZ2R8vyfb60evGwSx/R8BeNLZ67tHC/CUcVBBx1ABe0BQ=="
+}

--- a/pipelines/ww-bwa-gatk/module.sig
+++ b/pipelines/ww-bwa-gatk/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "yDbLjHA6Cr3xUqMkPhKtcISNUM2wflGESDJTmFd/qvItT/56H7yWSUEsz1IZa6A/ubDOPzyzQnRGsmaw09+ACg=="
+}

--- a/pipelines/ww-bwa-gatk/module.sig
+++ b/pipelines/ww-bwa-gatk/module.sig
@@ -1,4 +1,4 @@
 {
   "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
-  "signature": "yDbLjHA6Cr3xUqMkPhKtcISNUM2wflGESDJTmFd/qvItT/56H7yWSUEsz1IZa6A/ubDOPzyzQnRGsmaw09+ACg=="
+  "signature": "fuQw5xes1Wme2xxUb1vr3bdlEPcCjXr7TpwDevIStgTsM9W+xESZgKB45CI6A1qdbdp9ExRsc5vPCREIqL6eDQ=="
 }

--- a/pipelines/ww-ena-star/module.sig
+++ b/pipelines/ww-ena-star/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "DZ3GOgTPfnIxDtDbbi6XtXGa++0GbxkAoSqsLxTTrEWuS2T4BlqfD0bb7OXl8d6zVi88AtrbCms/oDu3VS6+Cw=="
+}

--- a/pipelines/ww-fastq-to-cram/module.sig
+++ b/pipelines/ww-fastq-to-cram/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "q1Zse4/7eL45TRhECRgvN76eN3tl+Ogb5u8rQCORhFx8FyPN0jg5J66L60+f2V9V2UPlYKs6n9TOiHTZxWcZBQ=="
+}

--- a/pipelines/ww-imputation/module.sig
+++ b/pipelines/ww-imputation/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "DtpRLup6obYZgcrwWwbZ7px9hGNAGhBNFmNrtIVHlyJ2+bbFycaNe9WMPqmjxCI0QoAsehSHOz8DOL7aDbv3DA=="
+}

--- a/pipelines/ww-jetlag/module.sig
+++ b/pipelines/ww-jetlag/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "2tCeGQgZeKXpaW+LcSi0PpQCFTAAAFZ+wklVj/lBRgp5+NMity2lLJrpqtvCoJdnEysg4po9sUcGeUF1j6VbCQ=="
+}

--- a/pipelines/ww-leukemia/module.sig
+++ b/pipelines/ww-leukemia/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "3gz77pkFcIjW5XaGAJm31XvVKQkBwiYq1qp4UGpyCUOJt3wppCNWBOSkOpd56oTw4FlGKsFwNc5zY/Rf2G9BDA=="
+}

--- a/pipelines/ww-proseq/module.sig
+++ b/pipelines/ww-proseq/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "1aQRSiuC81P3fgwb+ROkdwh4swL4IuVhlD2Pa2qvKjEQIQLdUaMaXtP5TaQwYrMy10nmZanzy2UU7Gl+u4RGDw=="
+}

--- a/pipelines/ww-proseq/module.sig
+++ b/pipelines/ww-proseq/module.sig
@@ -1,4 +1,4 @@
 {
   "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
-  "signature": "1aQRSiuC81P3fgwb+ROkdwh4swL4IuVhlD2Pa2qvKjEQIQLdUaMaXtP5TaQwYrMy10nmZanzy2UU7Gl+u4RGDw=="
+  "signature": "suJDv32gfHtI1GVBRf0baHNuqzAkCg2Kt1yRkUF7ixjtwhTwfxVJ9PsR/5rhaZwaQN3Zxa5YMQhdybxVqrL/AQ=="
 }

--- a/pipelines/ww-rnaseq/module.sig
+++ b/pipelines/ww-rnaseq/module.sig
@@ -1,4 +1,4 @@
 {
   "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
-  "signature": "x/BkytnJDUYOmFICOn4BxhiOE1mqQ+D+MLfJEO5cEttZgHoBDCzimNQvSa2HSTfy7udCZR6V1uIoq22x0scOCg=="
+  "signature": "c9AetoOKum8WTTEwMIlqDrYYQspW1+ImWjV3+O/ChrGn/rTwjCHHkQxIPRbYnOb0Ees0c62o0WBTwq1lJ6JmCw=="
 }

--- a/pipelines/ww-rnaseq/module.sig
+++ b/pipelines/ww-rnaseq/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "x/BkytnJDUYOmFICOn4BxhiOE1mqQ+D+MLfJEO5cEttZgHoBDCzimNQvSa2HSTfy7udCZR6V1uIoq22x0scOCg=="
+}

--- a/pipelines/ww-saturation/module.sig
+++ b/pipelines/ww-saturation/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "jhQJGag2B8otNvRswFBXwnQHhtbLlVuFIwewunriZgG9Q4LVOgkijF84Idb6uaB7HPCoLXxW76qsk+vxnRs/BQ=="
+}

--- a/pipelines/ww-splicing-proteomics/module.sig
+++ b/pipelines/ww-splicing-proteomics/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "zCGYCN7Ld4I3GMeCz1k8xecIetgNdjikyoo4ePzcgoClyEZL2xRxC+icMbwrGIy/9fOrlp2lNtGZdzklQzyLBA=="
+}

--- a/pipelines/ww-sra-cellranger/module.sig
+++ b/pipelines/ww-sra-cellranger/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "CEfxN3TXJXVO5nqua27W3YgDt3M8PIxsC/sjZuUYSmo9FxQ7re/y2tPEsRjO8wbQ6AU3mfp3l/hJjNI9k8ERBw=="
+}

--- a/pipelines/ww-sra-cellranger/module.sig
+++ b/pipelines/ww-sra-cellranger/module.sig
@@ -1,4 +1,4 @@
 {
   "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
-  "signature": "CEfxN3TXJXVO5nqua27W3YgDt3M8PIxsC/sjZuUYSmo9FxQ7re/y2tPEsRjO8wbQ6AU3mfp3l/hJjNI9k8ERBw=="
+  "signature": "nOFiRLhUIZF+CwDjh+FaOqNMvxuo0mj6gySpZnQasc7T+m84awKbfWq8AOjjFQhIyJvd13CJC94JjiYFHP6IBA=="
 }

--- a/pipelines/ww-sra-salmon/module.sig
+++ b/pipelines/ww-sra-salmon/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "QKZqmx3tiAXQoazc4e/SIW9ZK97dZZ0RTGVtEUCA8KxEWP///MsCx6JpJo/T7+ziIEBETcSvASYXocgoH5OxBg=="
+}

--- a/pipelines/ww-sra-star/module.sig
+++ b/pipelines/ww-sra-star/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "B4Dyi52Uc0vx4Sh1zXNFx4yr9tXFoZacUPnwbG3zK1/RV7SXntQGtn+DveAYTC34qNxH7qRFBgRP5n0/LXBDDg=="
+}

--- a/pipelines/ww-star-deseq2/module.sig
+++ b/pipelines/ww-star-deseq2/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "G1yIHbHDWtdSCprB3jYsI3eJXt03CiynY3/DyW1CrsuZGe3TpPxAqH3FxdvUpKqKfdNSrtMfFXKH0FUJ3rVLDQ=="
+}

--- a/pipelines/ww-starling-batch/module.sig
+++ b/pipelines/ww-starling-batch/module.sig
@@ -1,0 +1,4 @@
+{
+  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
+  "signature": "JaMsieZfNfUqhngwhSryrPKinFSnp7swPkh/Aw5WGRh1BAbml6oedBz+A37CKwCXtsQaSdUx8pcPDzPB9jnZAA=="
+}


### PR DESCRIPTION
## Type of Change

- New feature (module content signing)
- CI/CD automation
- Documentation update

## Description

Adds cryptographic signing for every WILDS WDL module and pipeline, an Ed25519 signature over each module's deterministic content hash (via `sprocket dev module sign`, part of the same `wdl-modules` module-management tooling underlying the recently-added `module.json` manifests). This lets consumers verify that a module's files haven't been tampered with since WILDS published them.

- **Added an initial `module.sig` for every module and pipeline** that has a `module.json` (70 files), generated locally against a real Ed25519 signing key and verified round-trip with `sprocket dev module verify` before committing.
- **Added `.github/workflows/sign-modules.yml`**, a new CI workflow that triggers on push to `main`. It diffs `github.event.before` against `github.sha` to determine which modules/pipelines actually changed content, re-signs only those (not the whole library on every push, to avoid re-invoking `sprocket dev module sign` across all 70 modules when only a handful changed), and auto-commits the updated `module.sig` files with `[skip ci]`.
  - Installs `sprocket` from a pinned commit (`fc251dac5ec354256857385eab64bb94861c93c1`) on `stjude-rust-labs/sprocket`'s `feat/module-porcelain` branch, since `sprocket dev module sign`/`verify` are not yet in a released Sprocket version. The pin should be revisited once module signing ships in a tagged release.
  - Reads the private signing key from a new `WILDS_SIGNING_KEY` repository secret.
- **Added `.github/scripts/sign_modules.py`**, the actual signing logic (find manifest dirs, diff-scope by directory, invoke `sprocket dev module sign`), following the same pattern as the existing `validate_module_json.py`/`validate_cirro.py` scripts. Supports `--all` (sign everything) and `--dry-run` for local testing without a key.
- **Added `make sign_modules`** for local use: no-arg dry run over everything, `NAME=foo` to sign one module/pipeline, `ALL=1` to sign everything for real (all require `KEY=path/to/private/key` except the dry run).
- **Updated `.github/CONTRIBUTING.md` and `AGENTS.md`** with a new "Module signature (`module.sig`)" section: contributors never create or hand-edit `module.sig` (CI handles it), any change under a module's directory invalidates its old signature (not just WDL edits, README/script changes too), and a note that Ed25519 signing is deterministic (same content + same key always produces the same signature, so an unexpected `module.sig` diff means the signing key changed, not routine churn).
- **Updated `create-module`/`create-pipeline` skills** with an explicit "do NOT create a `module.sig`" note, so an agent scaffolding a new module doesn't try to.
- **Updated `.gitignore`** to exclude local signing-key files (`*signing-key*`, `*signing_key*`, `id_ed25519*`), since test keys were generated in-repo during development of this feature.

## Testing

**How did you test these changes?**
- Generated an Ed25519 test key (`ssh-keygen -t ed25519`), ran `sprocket dev module sign` against `modules/ww-bwa` manually, and confirmed `sprocket dev module verify` passed cleanly.
- Confirmed tampering detection: edited `modules/ww-bwa/README.md` without re-signing, re-ran `verify`, and got a signature-mismatch failure as expected.
- Confirmed Ed25519 signing is deterministic: re-signing identical content with the identical key reproduces byte-identical signature output.
- Ran the real, final signing pass across all 70 modules/pipelines and spot-checked several `module.sig` files for correct structure (`public_key`, `signature`, no leftover `identity` field).
- Tested `.github/scripts/sign_modules.py` locally: `--all --dry-run` correctly lists all 70 manifest directories; diff-scoped mode against real commit ranges correctly narrows to just the directories that changed.
- Tested `make sign_modules` in all three modes (no-arg dry run, missing-args error path, actually invoking `sprocket dev module sign` for a single `NAME=`).

**What workflow engine did you use?**
Sprocket

**Did the tests pass?**
Yes, all manual sign/verify/tamper-detection round trips succeeded as expected, and the `sign_modules.py` dry-run/diff-scoping logic was validated against real git history before being wired into CI.

## Documentation

- [x] I updated the README (if applicable)
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~

## Additional Context

- **CI dependency on an unreleased Sprocket branch**: `sign-modules.yml` builds `sprocket` from a pinned commit on `feat/module-porcelain` via `cargo install --git`, not a tagged release. This is a known, deliberate stopgap, revisit once module signing lands in a released Sprocket version.
- **No `module-lock.json` was added** in this PR, deliberately out of scope for now, since all current `dependencies{}` declarations are same-repo/same-branch and a committed lockfile would go stale on nearly every commit. Revisit only if a module starts depending on a genuinely external, independently-versioned repo.
