### PR TITLE
Pointing recent dev import URL's back to `main`

### DIFF
--- a/modules/ww-edger/ww-edger.wdl
+++ b/modules/ww-edger/ww-edger.wdl
@@ -65,7 +65,7 @@ task run_edger {
     set -eo pipefail
 
     curl -so edger_analysis.R \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-edger-module/modules/ww-edger/edger_analysis.R"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-edger/edger_analysis.R"
 
     Rscript edger_analysis.R \
       --counts_file="~{counts_matrix}" \

--- a/pipelines/ww-rnaseq/ww-rnaseq.wdl
+++ b/pipelines/ww-rnaseq/ww-rnaseq.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-rseqc/ww-rseqc.wdl" as rseqc_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl" as deseq2_tasks
 import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-multiqc/ww-multiqc.wdl" as multiqc_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-gff3-conversion/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-gffread/ww-gffread.wdl" as gffread_tasks
 
 struct RefGenome {
     String name


### PR DESCRIPTION
## Type of Change

- Bug fix

## Description

Both `ww-rnaseq` and `ww-edger` had import/resource URLs left pointing at their original feature-development branches instead of `main`. No functional behavior changes, both modules now correctly reference `main` instead of their now-merged development branches. See GitHub CI/CD test runs below just in case.