### PR TITLE
Fixing the module signature CI/CD action

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -176,6 +176,7 @@ Every module and pipeline with a `module.json` also carries a `module.sig`, an E
 A few things to know:
 
 - **You don't need to sign anything yourself.** CI re-signs any module or pipeline whose directory content changed in a push to `main` (see `.github/workflows/sign-modules.yml` and `.github/scripts/sign_modules.py`) and commits the updated `module.sig` automatically. Don't hand-edit `module.sig` files or worry about them in your PR.
+- **CI pushes those updated `module.sig` files using a GitHub App token, not the default `GITHUB_TOKEN`**, since branch protection on `main` requires a PR and only the App is permitted to bypass that for this automated commit.
 - **Any change to a module's directory invalidates its old signature**, not just WDL edits: a README tweak, a fixed typo, a new test fixture, anything under `modules/ww-toolname/` or `pipelines/ww-pipeline-name/` changes the content hash CI signs.
 - **Ed25519 signatures are deterministic**: signing the same content with the same key always produces the same signature bytes. If `module.sig` changes with no apparent change to the module's content, the key used to sign it changed instead (e.g. after rotating the signing key).
 - **The signing key is a standard Ed25519 SSH key** (the kind `ssh-keygen -t ed25519` produces), in OpenSSH format. `sprocket dev module sign` and `sprocket dev module verify` are not yet in a released Sprocket version; see the pinned commit in `.github/workflows/sign-modules.yml` for what CI currently installs.

--- a/.github/workflows/sign-modules.yml
+++ b/.github/workflows/sign-modules.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-sign-modules-app-token # TEMPORARY: remove before merging, testing only
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sign-modules.yml
+++ b/.github/workflows/sign-modules.yml
@@ -11,12 +11,23 @@ permissions:
 jobs:
   sign-modules:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
+      -
+        name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       -
         name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
 
       -
         name: Set up Python
@@ -64,7 +75,7 @@ jobs:
       -
         name: Commit updated signatures
         run: |
-          git config user.name "github-actions[bot]"
+          git config user.name "WILDS WDL Library Automation[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add modules/*/module.sig pipelines/*/module.sig
           if git diff --cached --quiet; then

--- a/.github/workflows/sign-modules.yml
+++ b/.github/workflows/sign-modules.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - fix-sign-modules-app-token # TEMPORARY: remove before merging, testing only
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -60,12 +62,20 @@ jobs:
           chmod 600 /tmp/wilds_signing_key
 
       -
-        name: Sign changed modules and pipelines
+        name: Sign modules and pipelines
+        # Manual runs (workflow_dispatch) always sign everything
+        # Automatic runs (push to main) only sign what changed
         run: |
-          python3 .github/scripts/sign_modules.py \
-            --key /tmp/wilds_signing_key \
-            --before "${{ github.event.before }}" \
-            --after "${{ github.sha }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            python3 .github/scripts/sign_modules.py \
+              --key /tmp/wilds_signing_key \
+              --all
+          else
+            python3 .github/scripts/sign_modules.py \
+              --key /tmp/wilds_signing_key \
+              --before "${{ github.event.before }}" \
+              --after "${{ github.sha }}"
+          fi
 
       -
         name: Remove signing key

--- a/modules/ww-edger/README.md
+++ b/modules/ww-edger/README.md
@@ -221,3 +221,4 @@ If you would like to contribute to this WILDS WDL module, please see our [contri
 ## License
 
 Distributed under the MIT License. See `LICENSE` for details.
+

--- a/modules/ww-edger/module.sig
+++ b/modules/ww-edger/module.sig
@@ -1,4 +1,0 @@
-{
-  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
-  "signature": "9nq85xL+yVXSCKEFwxKiT7wS1wLvIMjiv1LWe7iGUZmopzB2zXJYwMJmmeWBzKFuZ4XVYShHthpjhdozv9FiCw=="
-}

--- a/modules/ww-edger/module.sig
+++ b/modules/ww-edger/module.sig
@@ -1,4 +1,4 @@
 {
   "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
-  "signature": "XaM3qbBsi+AIX7qq0PDxqlHN2/GXRwoqiyJzMawsclfuPuykm59IUrZ/hFRCcRTrxFSxi/P2FOV6VcPf8coqDA=="
+  "signature": "9nq85xL+yVXSCKEFwxKiT7wS1wLvIMjiv1LWe7iGUZmopzB2zXJYwMJmmeWBzKFuZ4XVYShHthpjhdozv9FiCw=="
 }

--- a/pipelines/ww-rnaseq/README.md
+++ b/pipelines/ww-rnaseq/README.md
@@ -320,3 +320,4 @@ If you would like to contribute to this WILDS WDL pipeline, please see our [cont
 
 Distributed under the MIT License. See `LICENSE` for details.
 
+

--- a/pipelines/ww-rnaseq/module.sig
+++ b/pipelines/ww-rnaseq/module.sig
@@ -1,4 +1,4 @@
 {
   "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
-  "signature": "dJIZzF9tDeFBaNCOZUnnxBRclLtDrXk4rBOJQ0ewXua7boKisj/qCSIgsOjY+P7oPqhUciYUxZ545UPtXO/iBw=="
+  "signature": "Q0jU/GJP01lZ05w0NKrkoGKoBrDLO2XPnk6YZHpM5ltkNXA0BiSaBKidTZLo6kUl63TzvL25DTe6ZJxkh8fpCA=="
 }

--- a/pipelines/ww-rnaseq/module.sig
+++ b/pipelines/ww-rnaseq/module.sig
@@ -1,4 +1,4 @@
 {
   "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
-  "signature": "c9AetoOKum8WTTEwMIlqDrYYQspW1+ImWjV3+O/ChrGn/rTwjCHHkQxIPRbYnOb0Ees0c62o0WBTwq1lJ6JmCw=="
+  "signature": "dJIZzF9tDeFBaNCOZUnnxBRclLtDrXk4rBOJQ0ewXua7boKisj/qCSIgsOjY+P7oPqhUciYUxZ545UPtXO/iBw=="
 }

--- a/pipelines/ww-rnaseq/module.sig
+++ b/pipelines/ww-rnaseq/module.sig
@@ -1,4 +1,0 @@
-{
-  "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC3sRRBlhTgqxLuh5LVHMlnX9sHPzS4CEPLugl+y2HBY",
-  "signature": "Q0jU/GJP01lZ05w0NKrkoGKoBrDLO2XPnk6YZHpM5ltkNXA0BiSaBKidTZLo6kUl63TzvL25DTe6ZJxkh8fpCA=="
-}


### PR DESCRIPTION
## Type of Change

- Bug fix
- CI/CD automation
- Documentation update

## Description

Fixes the `Sign Modules` CI workflow (`.github/workflows/sign-modules.yml`), which failed on its first real run after #381 merged. The workflow tried to `git push` its auto-generated `module.sig` commit directly to `main` using the default `GITHUB_TOKEN`, but branch protection on `main` requires a PR for any change, including from CI, so the push was rejected and the run failed.

- **Switched `sign-modules.yml` to authenticate with a GitHub App token instead of the default `GITHUB_TOKEN`**, using `actions/create-github-app-token@v1` with `APP_ID`/`APP_PRIVATE_KEY` secrets, mirroring the pattern already proven out for CVE-report commits in [`wilds-docker-library`](https://github.com/getwilds/wilds-docker-library)'s `docker-update.yml`.
- **Added a `workflow_dispatch` trigger** so the signing workflow can be run on demand (e.g. after a key rotation, or to spot-check signatures) without needing a real push to `main`.
- **Deleted `modules/ww-edger/module.sig` and `pipelines/ww-rnaseq/module.sig`**, along with a trivial one-line README addition to each, so that merging this PR forces a real push-triggered signing run (not just `workflow_dispatch`) to regenerate them for real, as a final live end-to-end confirmation that the App-token push path works correctly on `main` itself.
- **Added a one-line note to `.github/CONTRIBUTING.md`**'s "Module signature" section.

## Testing

**How did you test these changes?**
- Confirmed the root cause by inspecting the failed workflow run: the push step failed against branch protection on `main`.
- Temporarily added this branch to the workflow's `push` trigger and pushed real commits to it, exercising the exact App-token checkout/sign/commit/push path end-to-end on a real branch before ever touching `main`.
  - Once secrets were in place, the workflow successfully generated an App token, checked out, ran `sprocket dev module sign`, and pushed a real `Update module signatures [skip ci]` commit to this branch, confirming the fix works.
- Removed the temporary branch from the `push` trigger once confirmed working, leaving only `main` + `workflow_dispatch`.
- Deliberately deleted `module.sig` for `modules/ww-edger` and `pipelines/ww-rnaseq` (plus a trivial README touch on each) at the end of this branch's work, specifically so merging this PR triggers a real push-based signing run on `main` as one more confirmation, rather than relying solely on the branch-level test above.

**What workflow engine did you use?**
Sprocket for module signing/verification.

**Did the tests pass?**
Yes, the App-token push succeeded on a live test branch, producing a real signed commit. The final state of this PR intentionally leaves two `module.sig` files deleted so the merge itself serves as the last confirmation on `main`.

## Documentation

- [x] I updated the README (if applicable)
- [x] ~~I added/updated parameter descriptions in the WDL (if applicable)~~
- [x] ~~I ran `make docs` to check documentation rendering (if applicable)~~