### PR TITLE
Adding initial draft of `ww-dropletutils` WILDS WDL Module

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -356,6 +356,22 @@ tools:
       branches:
         - main
 
+  - name: ww-dropletutils
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-dropletutils/ww-dropletutils.wdl
+    readMePath: /modules/ww-dropletutils/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for loading 10x Genomics matrices and calling cells from empty droplets using Bioconductor DropletUtils
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-ena
     subclass: WDL
     primaryDescriptorPath: /modules/ww-ena/ww-ena.wdl

--- a/modules/ww-dropletutils/README.md
+++ b/modules/ww-dropletutils/README.md
@@ -171,3 +171,4 @@ For questions about this module or to report issues:
 - **[WILDS Documentation](https://getwilds.org/)**: Comprehensive guides and best practices
 - **[WDL Specification](https://openwdl.org/)**: Official WDL language documentation
 - **[OSCA Book](https://bioconductor.org/books/release/OSCA/)**: Orchestrating Single-Cell Analysis with Bioconductor, the reference workflow this module chain follows
+

--- a/modules/ww-dropletutils/README.md
+++ b/modules/ww-dropletutils/README.md
@@ -1,0 +1,173 @@
+# ww-dropletutils Module
+
+[![Project Status: Prototype – Useable, some support, open to feedback, unstable API.](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for loading 10x Genomics feature-barcode matrices and calling real cells from empty droplets using the Bioconductor [DropletUtils](https://bioconductor.org/packages/DropletUtils/) package. This is the first module in the standard single-cell post-processing chain (load matrix -> QC filter -> normalize -> HVG -> PCA -> neighbors -> UMAP -> clustering -> marker genes), producing a `SingleCellExperiment` object ready for downstream Bioconductor modules such as `ww-scran`, `ww-scater`, and `ww-singler`.
+
+## Overview
+
+Cell Ranger's `count` pipeline outputs raw and filtered feature-barcode matrices, but distinguishing real cells from empty droplets containing only ambient RNA is a standard first QC step before any downstream analysis. This module wraps two DropletUtils operations:
+
+- Loading a 10x HDF5 matrix directly into a `SingleCellExperiment` object (for already-filtered matrices)
+- Calling real cells from a raw, unfiltered matrix using the `emptyDrops` statistical test, along with a barcode-rank QC plot
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and follows the standard WILDS module structure:
+
+- **Main WDL file**: `ww-dropletutils.wdl` - Contains task definitions for the module
+- **Test workflow**: `testrun.wdl` - Demonstration workflow for testing and examples
+- **Documentation**: This README with usage examples and parameter descriptions
+
+## Available Tasks
+
+### `read10x_counts`
+
+Loads a 10x Genomics feature-barcode matrix (H5 format) into a `SingleCellExperiment` object using `DropletUtils::read10xCounts`. Use this for matrices that are already filtered (e.g. Cell Ranger's `filtered_feature_bc_matrix.h5`).
+
+**Inputs:**
+- `h5_matrix` (File): 10x Genomics feature-barcode matrix in HDF5 format (filtered or raw)
+- `sample_name` (String): Sample name used as output file prefix and SCE column metadata
+- `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
+- `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String, default=`getwilds/dropletutils:1.32.0`): Docker image to use for this task
+
+**Outputs:**
+- `sce_rds` (File): `SingleCellExperiment` object (RDS) containing the loaded counts, gene, and barcode metadata
+
+### `empty_drops_filter`
+
+Calls real cells from a raw (unfiltered) 10x feature-barcode matrix using `DropletUtils::emptyDrops`, filters the `SingleCellExperiment` to called cells, and produces a barcode-rank QC plot. Use this for raw matrices (e.g. Cell Ranger's `raw_feature_bc_matrix.h5`) that include all detected barcodes, including empty droplets.
+
+**Inputs:**
+- `raw_h5_matrix` (File): Raw (unfiltered) 10x Genomics feature-barcode matrix in HDF5 format, containing all detected barcodes
+- `sample_name` (String): Sample name used as output file prefix and SCE column metadata
+- `fdr_threshold` (Float, default=0.01): False discovery rate threshold below which a barcode is called a real cell
+- `lower_umi_threshold` (Int, default=100): UMI count threshold below which barcodes are assumed to be empty droplets and used to estimate the ambient RNA profile
+- `random_seed` (Int, default=100): Random seed for emptyDrops Monte Carlo p-value computation, for reproducibility
+- `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
+- `memory_gb` (Int, default=8): Memory allocated for the task in GB
+- `docker_image` (String, default=`getwilds/dropletutils:1.32.0`): Docker image to use for this task
+
+**Outputs:**
+- `filtered_sce_rds` (File): `SingleCellExperiment` object (RDS) filtered to barcodes called as cells by `emptyDrops`
+- `empty_drops_csv` (File): Per-barcode `emptyDrops` statistics (Total, LogProb, PValue, FDR) for all tested barcodes
+- `barcode_rank_pdf` (File): Barcode-rank plot (log-log UMI count vs. rank) with knee and inflection points marked
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-dropletutils/ww-dropletutils.wdl" as dropletutils_tasks
+
+workflow my_analysis_pipeline {
+  input {
+    File raw_h5_matrix
+    String sample_name
+  }
+
+  call dropletutils_tasks.empty_drops_filter {
+    input:
+      raw_h5_matrix = raw_h5_matrix,
+      sample_name = sample_name
+  }
+
+  output {
+    File filtered_sce_rds = empty_drops_filter.filtered_sce_rds
+  }
+}
+```
+
+### Advanced Usage Examples
+
+**Custom resource allocation and thresholds:**
+```wdl
+call dropletutils_tasks.empty_drops_filter {
+  input:
+    raw_h5_matrix = large_raw_matrix,
+    sample_name = "large_sample",
+    fdr_threshold = 0.001,
+    lower_umi_threshold = 200,
+    cpu_cores = 4,
+    memory_gb = 16
+}
+```
+
+**Loading an already-filtered matrix (skip emptyDrops):**
+```wdl
+call dropletutils_tasks.read10x_counts {
+  input:
+    h5_matrix = filtered_matrix,
+    sample_name = "prefiltered_sample"
+}
+```
+
+### Integration Examples
+
+This module integrates seamlessly with other WILDS components:
+- **ww-testdata**: Automatic provisioning of 10x filtered and raw H5 test matrices for demonstrations
+- **ww-cellbender**: Can be used upstream of or alongside `ww-cellbender` for ambient RNA removal; `emptyDrops` filtering and CellBender's `remove-background` both accept the same raw feature-barcode matrix
+- **Downstream Bioconductor modules**: The `SingleCellExperiment` RDS output is intended as input for `ww-scran` (normalization, HVG selection, clustering), `ww-scater` (QC metrics, PCA/UMAP), and `ww-singler` (cell-type annotation)
+
+## Testing the Module
+
+The module includes a test workflow (`testrun.wdl`) that can be run independently:
+
+```bash
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl
+
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+```
+
+### Automatic Demo Mode
+
+The test workflow automatically:
+1. Downloads a filtered 10x H5 matrix and a raw 10x H5 matrix using `ww-testdata`
+2. Loads the filtered matrix directly into a `SingleCellExperiment` with `read10x_counts`
+3. Calls real cells from the raw matrix with `empty_drops_filter`, demonstrating both module tasks in a realistic workflow context
+
+## Docker Container
+
+This module uses the `getwilds/dropletutils:1.32.0` container image, which includes:
+- Bioconductor DropletUtils (version 1.32.0)
+- R and required Bioconductor/CRAN dependencies (SingleCellExperiment, Matrix, HDF5Array, etc.)
+- All necessary system dependencies for reading 10x HDF5 matrices
+
+## Citation
+
+> Lun, A.T.L., Riesenfeld, S., Andrews, T. et al.
+> EmptyDrops: distinguishing cells from empty droplets in droplet-based single-cell RNA sequencing data.
+> Genome Biology 20, 63 (2019).
+> DOI: [10.1186/s13059-019-1662-y](https://doi.org/10.1186/s13059-019-1662-y)
+
+## Parameters and Resource Requirements
+
+### Default Resources
+- **CPU**: 2 cores
+- **Memory**: 8 GB
+- **Runtime**: A few minutes per sample for demo data; scales with matrix size and number of barcodes tested by `emptyDrops`
+
+### Resource Scaling
+- `cpu_cores`: DropletUtils itself is largely single-threaded per sample; increase mainly to accommodate HDF5Array I/O parallelism or to scatter across more samples concurrently
+- `memory_gb`: Increase for matrices with very large numbers of raw barcodes (e.g. >1M droplets) or high gene counts
+
+## Support and Feedback
+
+For questions about this module or to report issues:
+- Open an issue in the [WILDS WDL Library repository](https://github.com/getwilds/wilds-wdl-library/issues)
+- Contact the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org
+- See the library's [Contributor Guide](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for detailed guidelines
+
+## Related Resources
+
+- **[WILDS Docker Library](https://github.com/getwilds/wilds-docker-library)**: Container images used by WDL workflows
+- **[WILDS Documentation](https://getwilds.org/)**: Comprehensive guides and best practices
+- **[WDL Specification](https://openwdl.org/)**: Official WDL language documentation
+- **[OSCA Book](https://bioconductor.org/books/release/OSCA/)**: Orchestrating Single-Cell Analysis with Bioconductor, the reference workflow this module chain follows

--- a/modules/ww-dropletutils/README.md
+++ b/modules/ww-dropletutils/README.md
@@ -156,7 +156,7 @@ This module uses the `getwilds/dropletutils:1.32.0` container image, which inclu
 
 ### Resource Scaling
 - `cpu_cores`: DropletUtils itself is largely single-threaded per sample; increase mainly to accommodate HDF5Array I/O parallelism or to scatter across more samples concurrently
-- `memory_gb`: Increase for matrices with very large numbers of raw barcodes (e.g. >1M droplets) or high gene counts
+- `memory_gb`: Both tasks realize the full sparse count matrix in memory before writing the output RDS (`SingleCellExperiment` objects backed by on-disk HDF5Array cannot be serialized directly with `saveRDS`), so increase for matrices with very large numbers of raw barcodes (e.g. >1M droplets) or high gene counts
 
 ## Support and Feedback
 

--- a/modules/ww-dropletutils/README.md
+++ b/modules/ww-dropletutils/README.md
@@ -44,7 +44,7 @@ Calls real cells from a raw (unfiltered) 10x feature-barcode matrix using `Dropl
 - `raw_h5_matrix` (File): Raw (unfiltered) 10x Genomics feature-barcode matrix in HDF5 format, containing all detected barcodes
 - `sample_name` (String): Sample name used as output file prefix and SCE column metadata
 - `fdr_threshold` (Float, default=0.01): False discovery rate threshold below which a barcode is called a real cell
-- `lower_umi_threshold` (Int, default=100): UMI count threshold below which barcodes are assumed to be empty droplets and used to estimate the ambient RNA profile
+- `lower_umi_threshold` (Int, default=500): UMI count threshold below which barcodes are assumed to be empty droplets and used to estimate the ambient RNA profile. Also controls how many barcodes above this threshold get tested by `emptyDrops`'s Monte Carlo procedure; raising it reduces runtime on matrices with a large raw barcode population at the cost of testing fewer ambiguous barcodes
 - `random_seed` (Int, default=100): Random seed for emptyDrops Monte Carlo p-value computation, for reproducibility
 - `cpu_cores` (Int, default=2): Number of CPU cores allocated for the task
 - `memory_gb` (Int, default=8): Memory allocated for the task in GB

--- a/modules/ww-dropletutils/README.md
+++ b/modules/ww-dropletutils/README.md
@@ -155,8 +155,8 @@ This module uses the `getwilds/dropletutils:1.32.0` container image, which inclu
 - **Runtime**: A few minutes per sample for demo data; scales with matrix size and number of barcodes tested by `emptyDrops`
 
 ### Resource Scaling
-- `cpu_cores`: DropletUtils itself is largely single-threaded per sample; increase mainly to accommodate HDF5Array I/O parallelism or to scatter across more samples concurrently
-- `memory_gb`: Both tasks realize the full sparse count matrix in memory before writing the output RDS (`SingleCellExperiment` objects backed by on-disk HDF5Array cannot be serialized directly with `saveRDS`), so increase for matrices with very large numbers of raw barcodes (e.g. >1M droplets) or high gene counts
+- `cpu_cores`: DropletUtils itself is largely single-threaded per sample; increase mainly to scatter across more samples concurrently
+- `memory_gb`: Both tasks load the full count matrix into memory right after `read10xCounts` (needed for `saveRDS` and for `emptyDrops` performance), so increase for matrices with very large numbers of raw barcodes (e.g. >1M droplets) or high gene counts
 
 ## Support and Feedback
 

--- a/modules/ww-dropletutils/module.json
+++ b/modules/ww-dropletutils/module.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-dropletutils",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for loading 10x Genomics feature-barcode matrices and calling real cells from empty droplets using Bioconductor DropletUtils",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-dropletutils.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "dropletutils",
+      "version": "1.32.0",
+      "license": "GPL-3.0-only",
+      "url": "https://bioconductor.org/packages/DropletUtils/",
+      "ids": [
+        "doi:10.1186/s13059-019-1662-y"
+      ]
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-dropletutils/testrun.wdl
+++ b/modules/ww-dropletutils/testrun.wdl
@@ -1,0 +1,33 @@
+version 1.0
+
+# Import module in question as well as the testdata module for automatic demo functionality
+import "./ww-dropletutils.wdl" as ww_dropletutils
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+
+#### TEST WORKFLOW DEFINITION ####
+# Define test workflow to demonstrate module functionality
+
+workflow dropletutils_example {
+  # Auto-download test data for testing purposes
+  call ww_testdata.download_10x_h5_data as download_filtered_matrix { }
+  call ww_testdata.download_10x_raw_h5_data as download_raw_matrix { }
+
+  # Load a filtered feature-barcode matrix directly into a SingleCellExperiment
+  call ww_dropletutils.read10x_counts { input:
+      h5_matrix = download_filtered_matrix.h5_matrix,
+      sample_name = "demo_filtered_sample"
+  }
+
+  # Call real cells from a raw feature-barcode matrix using emptyDrops
+  call ww_dropletutils.empty_drops_filter { input:
+      raw_h5_matrix = download_raw_matrix.raw_h5_matrix,
+      sample_name = "demo_raw_sample"
+  }
+
+  output {
+    File sce_rds = read10x_counts.sce_rds
+    File filtered_sce_rds = empty_drops_filter.filtered_sce_rds
+    File empty_drops_csv = empty_drops_filter.empty_drops_csv
+    File barcode_rank_pdf = empty_drops_filter.barcode_rank_pdf
+  }
+}

--- a/modules/ww-dropletutils/ww-dropletutils.wdl
+++ b/modules/ww-dropletutils/ww-dropletutils.wdl
@@ -10,8 +10,8 @@ version 1.0
 
 task read10x_counts {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Load a 10x Genomics feature-barcode matrix (H5 format) into a SingleCellExperiment object using DropletUtils::read10xCounts"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-dropletutils/ww-dropletutils.wdl"
     outputs: {
@@ -71,8 +71,8 @@ task read10x_counts {
 
 task empty_drops_filter {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Call real cells from a raw (unfiltered) 10x feature-barcode matrix using DropletUtils::emptyDrops, filter the SingleCellExperiment to called cells, and produce a barcode-rank QC plot"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-dropletutils/ww-dropletutils.wdl"
     outputs: {

--- a/modules/ww-dropletutils/ww-dropletutils.wdl
+++ b/modules/ww-dropletutils/ww-dropletutils.wdl
@@ -1,0 +1,157 @@
+## WILDS WDL Module: ww-dropletutils
+## Description: Module for loading 10x Genomics feature-barcode matrices and calling
+## real cells from empty droplets using Bioconductor DropletUtils. Produces a
+## SingleCellExperiment object (RDS) suitable as input to downstream modules such as
+## ww-scran, ww-scater, and ww-singler.
+
+version 1.0
+
+#### TASK DEFINITIONS ####
+
+task read10x_counts {
+  meta {
+    author: "WILDS Team"
+    email: "wilds@fredhutch.org"
+    description: "Load a 10x Genomics feature-barcode matrix (H5 format) into a SingleCellExperiment object using DropletUtils::read10xCounts"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-dropletutils/ww-dropletutils.wdl"
+    outputs: {
+        sce_rds: "SingleCellExperiment object (RDS) containing the loaded counts, gene, and barcode metadata"
+    }
+    topic: "transcriptomics,single_cell"
+    species: "human,mouse,eukaryote"
+    operation: "data_loading"
+    input_sample_required: "h5_matrix:gene_expression_matrix:h5"
+    input_sample_optional: "none"
+    input_reference_required: "none"
+    input_reference_optional: "none"
+    output_sample: "sce_rds:gene_expression_matrix:rds"
+    output_reference: "none"
+  }
+
+  parameter_meta {
+    h5_matrix: "10x Genomics feature-barcode matrix in HDF5 format (filtered or raw)"
+    sample_name: "Sample name used as output file prefix and SCE column metadata"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    File h5_matrix
+    String sample_name
+    Int cpu_cores = 2
+    Int memory_gb = 8
+    String docker_image = "getwilds/dropletutils:1.32.0"
+  }
+
+  command <<<
+    set -euo pipefail
+
+    Rscript -e '
+      library(DropletUtils)
+
+      sce <- read10xCounts("~{h5_matrix}", col.names = TRUE)
+      sce$Sample <- "~{sample_name}"
+
+      saveRDS(sce, file = "~{sample_name}.sce.rds")
+    '
+  >>>
+
+  output {
+    File sce_rds = "~{sample_name}.sce.rds"
+  }
+
+  runtime {
+    docker: docker_image
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}
+
+task empty_drops_filter {
+  meta {
+    author: "WILDS Team"
+    email: "wilds@fredhutch.org"
+    description: "Call real cells from a raw (unfiltered) 10x feature-barcode matrix using DropletUtils::emptyDrops, filter the SingleCellExperiment to called cells, and produce a barcode-rank QC plot"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-dropletutils/ww-dropletutils.wdl"
+    outputs: {
+        filtered_sce_rds: "SingleCellExperiment object (RDS) filtered to barcodes called as cells by emptyDrops",
+        empty_drops_csv: "Per-barcode emptyDrops statistics (Total, LogProb, PValue, FDR) for all tested barcodes",
+        barcode_rank_pdf: "Barcode-rank plot (log-log UMI count vs. rank) with knee and inflection points marked"
+    }
+    topic: "transcriptomics,single_cell"
+    species: "human,mouse,eukaryote"
+    operation: "data_handling"
+    input_sample_required: "raw_h5_matrix:gene_expression_matrix:h5"
+    input_sample_optional: "none"
+    input_reference_required: "none"
+    input_reference_optional: "none"
+    output_sample: "filtered_sce_rds:gene_expression_matrix:rds,empty_drops_csv:gene_report:csv,barcode_rank_pdf:plot:pdf"
+    output_reference: "none"
+  }
+
+  parameter_meta {
+    raw_h5_matrix: "Raw (unfiltered) 10x Genomics feature-barcode matrix in HDF5 format, containing all detected barcodes"
+    sample_name: "Sample name used as output file prefix and SCE column metadata"
+    fdr_threshold: "False discovery rate threshold below which a barcode is called a real cell"
+    lower_umi_threshold: "UMI count threshold below which barcodes are assumed to be empty droplets and used to estimate the ambient RNA profile"
+    random_seed: "Random seed for emptyDrops Monte Carlo p-value computation, for reproducibility"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    memory_gb: "Memory allocated for the task in GB"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    File raw_h5_matrix
+    String sample_name
+    Float fdr_threshold = 0.01
+    Int lower_umi_threshold = 100
+    Int random_seed = 100
+    Int cpu_cores = 2
+    Int memory_gb = 8
+    String docker_image = "getwilds/dropletutils:1.32.0"
+  }
+
+  command <<<
+    set -euo pipefail
+
+    Rscript -e '
+      library(DropletUtils)
+
+      set.seed(~{random_seed})
+
+      sce <- read10xCounts("~{raw_h5_matrix}", col.names = TRUE)
+      sce$Sample <- "~{sample_name}"
+
+      ranks <- barcodeRanks(counts(sce))
+      pdf("~{sample_name}.barcode_rank.pdf")
+      plot(ranks$rank, ranks$total, log = "xy", xlab = "Rank", ylab = "Total UMI count",
+           main = "~{sample_name} Barcode Rank Plot")
+      abline(h = metadata(ranks)$knee, col = "dodgerblue", lty = 2)
+      abline(h = metadata(ranks)$inflection, col = "forestgreen", lty = 2)
+      legend("bottomleft", legend = c("Knee", "Inflection"),
+             col = c("dodgerblue", "forestgreen"), lty = 2)
+      dev.off()
+
+      empty <- emptyDrops(counts(sce), lower = ~{lower_umi_threshold})
+      write.csv(as.data.frame(empty), file = "~{sample_name}.empty_drops.csv", row.names = TRUE)
+
+      is_cell <- which(empty$FDR <= ~{fdr_threshold})
+      filtered_sce <- sce[, is_cell]
+
+      saveRDS(filtered_sce, file = "~{sample_name}.filtered_sce.rds")
+    '
+  >>>
+
+  output {
+    File filtered_sce_rds = "~{sample_name}.filtered_sce.rds"
+    File empty_drops_csv = "~{sample_name}.empty_drops.csv"
+    File barcode_rank_pdf = "~{sample_name}.barcode_rank.pdf"
+  }
+
+  runtime {
+    docker: docker_image
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/modules/ww-dropletutils/ww-dropletutils.wdl
+++ b/modules/ww-dropletutils/ww-dropletutils.wdl
@@ -123,6 +123,7 @@ task empty_drops_filter {
 
       sce <- read10xCounts("~{raw_h5_matrix}", col.names = TRUE)
       sce$Sample <- "~{sample_name}"
+      counts(sce) <- as(counts(sce), "CsparseMatrix")
 
       ranks <- barcodeRanks(counts(sce))
       pdf("~{sample_name}.barcode_rank.pdf")
@@ -139,7 +140,6 @@ task empty_drops_filter {
 
       is_cell <- which(empty$FDR <= ~{fdr_threshold})
       filtered_sce <- sce[, is_cell]
-      counts(filtered_sce) <- as(counts(filtered_sce), "CsparseMatrix")
 
       saveRDS(filtered_sce, file = "~{sample_name}.filtered_sce.rds")
     '

--- a/modules/ww-dropletutils/ww-dropletutils.wdl
+++ b/modules/ww-dropletutils/ww-dropletutils.wdl
@@ -52,6 +52,7 @@ task read10x_counts {
 
       sce <- read10xCounts("~{h5_matrix}", col.names = TRUE)
       sce$Sample <- "~{sample_name}"
+      counts(sce) <- as(counts(sce), "CsparseMatrix")
 
       saveRDS(sce, file = "~{sample_name}.sce.rds")
     '
@@ -138,6 +139,7 @@ task empty_drops_filter {
 
       is_cell <- which(empty$FDR <= ~{fdr_threshold})
       filtered_sce <- sce[, is_cell]
+      counts(filtered_sce) <- as(counts(filtered_sce), "CsparseMatrix")
 
       saveRDS(filtered_sce, file = "~{sample_name}.filtered_sce.rds")
     '

--- a/modules/ww-dropletutils/ww-dropletutils.wdl
+++ b/modules/ww-dropletutils/ww-dropletutils.wdl
@@ -24,7 +24,7 @@ task read10x_counts {
     input_sample_optional: "none"
     input_reference_required: "none"
     input_reference_optional: "none"
-    output_sample: "sce_rds:gene_expression_matrix:rds"
+    output_sample: "sce_rds:gene_expression_matrix:binary_format"
     output_reference: "none"
   }
 
@@ -87,7 +87,7 @@ task empty_drops_filter {
     input_sample_optional: "none"
     input_reference_required: "none"
     input_reference_optional: "none"
-    output_sample: "filtered_sce_rds:gene_expression_matrix:rds,empty_drops_csv:gene_report:csv,barcode_rank_pdf:plot:pdf"
+    output_sample: "filtered_sce_rds:gene_expression_matrix:binary_format,empty_drops_csv:gene_report:csv,barcode_rank_pdf:plot:pdf"
     output_reference: "none"
   }
 

--- a/modules/ww-dropletutils/ww-dropletutils.wdl
+++ b/modules/ww-dropletutils/ww-dropletutils.wdl
@@ -118,6 +118,7 @@ task empty_drops_filter {
 
     Rscript -e '
       library(DropletUtils)
+      library(BiocParallel)
 
       set.seed(~{random_seed})
 
@@ -134,7 +135,8 @@ task empty_drops_filter {
              col = c("dodgerblue", "forestgreen"), lty = 2)
       dev.off()
 
-      empty <- emptyDrops(counts(sce), lower = ~{lower_umi_threshold})
+      bpparam <- MulticoreParam(workers = ~{cpu_cores})
+      empty <- emptyDrops(counts(sce), lower = ~{lower_umi_threshold}, BPPARAM = bpparam)
       write.csv(as.data.frame(empty), file = "~{sample_name}.empty_drops.csv", row.names = TRUE)
 
       is_cell <- which(empty$FDR <= ~{fdr_threshold})

--- a/modules/ww-dropletutils/ww-dropletutils.wdl
+++ b/modules/ww-dropletutils/ww-dropletutils.wdl
@@ -106,7 +106,7 @@ task empty_drops_filter {
     File raw_h5_matrix
     String sample_name
     Float fdr_threshold = 0.01
-    Int lower_umi_threshold = 100
+    Int lower_umi_threshold = 500
     Int random_seed = 100
     Int cpu_cores = 2
     Int memory_gb = 8
@@ -118,7 +118,6 @@ task empty_drops_filter {
 
     Rscript -e '
       library(DropletUtils)
-      library(BiocParallel)
 
       set.seed(~{random_seed})
 
@@ -135,8 +134,7 @@ task empty_drops_filter {
              col = c("dodgerblue", "forestgreen"), lty = 2)
       dev.off()
 
-      bpparam <- MulticoreParam(workers = ~{cpu_cores})
-      empty <- emptyDrops(counts(sce), lower = ~{lower_umi_threshold}, BPPARAM = bpparam)
+      empty <- emptyDrops(counts(sce), lower = ~{lower_umi_threshold})
       write.csv(as.data.frame(empty), file = "~{sample_name}.empty_drops.csv", row.names = TRUE)
 
       is_cell <- which(empty$FDR <= ~{fdr_threshold})


### PR DESCRIPTION
## Type of Change

- New module

## Description

Adds the `ww-dropletutils` module, wrapping the Bioconductor [DropletUtils](https://bioconductor.org/packages/DropletUtils/) package for loading 10x Genomics feature-barcode matrices and calling real cells from empty droplets. This is the first module in the standard single-cell post-processing chain proposed in #333 (load matrix -> QC filter -> normalize -> HVG -> PCA -> neighbors -> UMAP -> clustering -> marker genes), producing a `SingleCellExperiment` object (RDS) intended as input for the planned `ww-scran`, `ww-scater`, and `ww-singler` modules.

Two tasks:
- `read10x_counts`: loads an already-filtered 10x H5 matrix directly into a `SingleCellExperiment`
- `empty_drops_filter`: runs `emptyDrops` on a raw (unfiltered) 10x H5 matrix to call real cells, filters the SCE accordingly, and emits a barcode-rank QC plot alongside per-barcode `emptyDrops` statistics

Uses the new `getwilds/dropletutils:1.32.0` Docker image.

## Related Issue

Related to #333

## Testing

**How did you test these changes?**
Ran `testrun.wdl` end-to-end on Fred Hutch HPC via PROOF against real 10x test data (filtered and raw feature-barcode matrices from `ww-testdata`).

**What workflow engine did you use?**
Sprocket for local linting/validation and Cromwell/PROOF on Fred Hutch HPC for test run execution.
All three in CI/CD test runs below as well.

**Did the tests pass?**
Yes.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- New Docker image: [`getwilds/dropletutils:1.32.0` (Bioconductor DropletUtils)](https://github.com/getwilds/wilds-docker-library/pull/373/changes), added to the `getwilds/` Docker Hub namespace.
- Registered in `.dockstore.yml` under `tools:` (alphabetically between `ww-diamond` and `ww-ena`).
- This is intended as the first of several modules from #333 (Bioconductor single-cell stack: `ww-scran`, `ww-scater`, `ww-singler`, plus a composing `ww-bioc-sc` pipeline). Following per-tool Docker image convention rather than one bundled image for the whole stack.