### PR TITLE
Adding initial version of `ww-scran` WILDS WDL module

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -670,6 +670,22 @@ tools:
       branches:
         - main
 
+  - name: ww-scran
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-scran/ww-scran.wdl
+    readMePath: /modules/ww-scran/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for single-cell RNA-seq QC, normalization, and feature selection using scran
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-seurat
     subclass: WDL
     primaryDescriptorPath: /modules/ww-seurat/ww-seurat.wdl

--- a/modules/ww-scran/README.md
+++ b/modules/ww-scran/README.md
@@ -62,6 +62,7 @@ Performs QC filtering, normalization, and highly variable gene selection on a `S
 | `size_factor_plot` | File | Histogram of scran deconvolution size factors |
 | `mean_variance_plot` | File | Mean-variance trend plot from highly variable gene modeling |
 | `hvg_table` | File | CSV of all genes ranked by biological variance component |
+| `hvg_list` | File | Plain-text list of the selected top highly variable genes (one gene per line) |
 
 ## Usage as a Module
 
@@ -88,6 +89,7 @@ workflow my_scrna_analysis {
     File size_factor_plot     = run_scran.size_factor_plot
     File mean_variance_plot   = run_scran.mean_variance_plot
     File hvg_table            = run_scran.hvg_table
+    File hvg_list             = run_scran.hvg_list
   }
 }
 ```

--- a/modules/ww-scran/README.md
+++ b/modules/ww-scran/README.md
@@ -6,13 +6,13 @@ A WILDS WDL module for single-cell RNA-seq QC, normalization, and feature select
 
 ## Overview
 
-This module provides a reusable WDL task for per-cell QC filtering, deconvolution-based normalization, and highly variable gene (HVG) selection of single-cell RNA-seq data using [scran](https://bioconductor.org/packages/release/bioc/html/scran.html) and [scater](https://bioconductor.org/packages/release/bioc/html/scater.html). It accepts a `SingleCellExperiment` RDS object (e.g. produced by [`ww-dropletutils`](../ww-dropletutils/)) and runs the following steps:
+This module provides a reusable WDL task for per-cell QC filtering, deconvolution-based normalization, and highly variable gene (HVG) selection of single-cell RNA-seq data using [scran](https://bioconductor.org/packages/release/bioc/html/scran.html) (and its hard dependencies, e.g. `scuttle`, only — no `scater`). It accepts a `SingleCellExperiment` RDS object (e.g. produced by [`ww-dropletutils`](../ww-dropletutils/)) and runs the following steps:
 
 1. **Load data** — reads the `SingleCellExperiment` RDS object
-2. **QC filtering** — computes per-cell QC metrics (library size, detected genes, mitochondrial percentage) and flags outliers with `quickPerCellQC`
+2. **QC filtering** — computes per-cell QC metrics (library size, detected genes, mitochondrial percentage) directly from the counts matrix and flags outliers using MAD-based thresholds
 3. **Normalization** — estimates size factors via scran's pooling/deconvolution method (`quickCluster` + `computeSumFactors`) and applies `logNormCounts`
 4. **Feature selection** — models per-gene mean-variance trends with `modelGeneVar` and selects the top highly variable genes
-5. **Dimensionality reduction** — runs PCA on the selected HVGs and saves the resulting `SingleCellExperiment` object
+5. **Dimensionality reduction** — runs PCA (base R `prcomp`) on the selected HVGs and saves the resulting `SingleCellExperiment` object
 
 This module is intended to run downstream of [`ww-dropletutils`](../ww-dropletutils/) in the standard single-cell post-processing chain (load matrix -> QC filter -> normalize -> HVG -> PCA -> ...).
 
@@ -134,7 +134,7 @@ sprocket run testrun.wdl --entrypoint scran_example
 
 - WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
 - Internet access for fetching scripts from GitHub at runtime
-- R environment with scran and scater (provided by `getwilds/scran:1.40.0` container)
+- R environment with scran (provided by `getwilds/scran:1.40.0` container)
 
 ## Citation
 

--- a/modules/ww-scran/README.md
+++ b/modules/ww-scran/README.md
@@ -1,0 +1,152 @@
+# ww-scran
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for single-cell RNA-seq QC, normalization, and feature selection using scran.
+
+## Overview
+
+This module provides a reusable WDL task for per-cell QC filtering, deconvolution-based normalization, and highly variable gene (HVG) selection of single-cell RNA-seq data using [scran](https://bioconductor.org/packages/release/bioc/html/scran.html) and [scater](https://bioconductor.org/packages/release/bioc/html/scater.html). It accepts a Cell Ranger HDF5 output file and runs the following steps:
+
+1. **Load data** — reads the filtered feature-barcode matrix from a `.h5` file into a `SingleCellExperiment`
+2. **QC filtering** — computes per-cell QC metrics (library size, detected genes, mitochondrial percentage) and flags outliers with `quickPerCellQC`
+3. **Normalization** — estimates size factors via scran's pooling/deconvolution method (`quickCluster` + `computeSumFactors`) and applies `logNormCounts`
+4. **Feature selection** — models per-gene mean-variance trends with `modelGeneVar` and selects the top highly variable genes
+5. **Dimensionality reduction** — runs PCA on the selected HVGs and saves the resulting `SingleCellExperiment` object
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
+
+- **Tasks**: `run_scran`
+- **Scripts**: `scran_analysis.R` (fetched via curl at runtime)
+- **Test workflow**: `testrun.wdl`
+- **Container**: `getwilds/scran:1.40.0`
+
+## Scripts
+
+All scripts are fetched from this repository at runtime via `curl`.
+
+| Script | Used by | Language | Description |
+|--------|---------|----------|-------------|
+| [`scran_analysis.R`](scran_analysis.R) | `run_scran` | R | Loads a Cell Ranger `.h5` matrix, filters cells by QC thresholds, normalizes with scran's deconvolution method, models mean-variance trends, and runs PCA on highly variable genes |
+
+## Tasks
+
+### `run_scran`
+
+Performs QC filtering, normalization, and highly variable gene selection on a Cell Ranger HDF5 matrix file.
+
+**Inputs:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `input_h5` | File | — | Cell Ranger filtered feature-barcode matrix HDF5 file (`filtered_feature_bc_matrix.h5`) |
+| `sample_name` | String | — | Sample name used for output file prefixes |
+| `mito_pattern` | String | `^MT-` | Regex pattern identifying mitochondrial gene symbols |
+| `nmads` | Float | 3.0 | Number of median absolute deviations from the median used to flag low-quality cells |
+| `min_mean` | Float | 0.1 | Minimum mean expression for a gene to be used in size factor estimation and HVG modeling |
+| `n_hvgs` | Int | 2000 | Number of top highly variable genes to select for PCA |
+| `memory_gb` | Int | 8 | Memory allocated for the task in GB |
+| `cpu_cores` | Int | 2 | Number of CPU cores allocated for the task |
+| `docker_image` | String | `getwilds/scran:1.40.0` | Docker image to use for this task |
+
+**Outputs:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `sce_object` | File | Normalized `SingleCellExperiment` RDS object with size factors and PCA |
+| `qc_plot` | File | Per-cell QC scatter plot (library size vs. detected genes, colored by discard status) |
+| `size_factor_plot` | File | Histogram of scran deconvolution size factors |
+| `mean_variance_plot` | File | Mean-variance trend plot from highly variable gene modeling |
+| `hvg_table` | File | CSV of all genes ranked by biological variance component |
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scran/ww-scran.wdl" as scran_tasks
+
+workflow my_scrna_analysis {
+  input {
+    File cellranger_h5
+    String sample_name
+  }
+
+  call scran_tasks.run_scran {
+    input:
+      input_h5    = cellranger_h5,
+      sample_name = sample_name
+  }
+
+  output {
+    File sce_object          = run_scran.sce_object
+    File qc_plot              = run_scran.qc_plot
+    File size_factor_plot     = run_scran.size_factor_plot
+    File mean_variance_plot   = run_scran.mean_variance_plot
+    File hvg_table            = run_scran.hvg_table
+  }
+}
+```
+
+### Advanced Usage Examples
+
+**Non-human data (mouse mitochondrial gene prefix):**
+```wdl
+call scran_tasks.run_scran {
+  input:
+    input_h5     = cellranger_h5,
+    sample_name  = "mouse_sample",
+    mito_pattern = "^mt-"
+}
+```
+
+**Stricter QC and larger HVG set:**
+```wdl
+call scran_tasks.run_scran {
+  input:
+    input_h5    = cellranger_h5,
+    sample_name = "sample",
+    nmads       = 2.5,
+    n_hvgs      = 5000
+}
+```
+
+## Testing the Module
+
+The test workflow (`testrun.wdl`) automatically downloads a public 10x Genomics PBMC dataset via `ww-testdata` and runs `run_scran` on it, then validates all output files.
+
+```bash
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl --entrypoint scran_example
+```
+
+## Requirements
+
+- WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
+- Internet access for fetching scripts from GitHub at runtime
+- R environment with scran, scater, and DropletUtils (provided by `getwilds/scran:1.40.0` container)
+
+## Citation
+
+> Lun ATL, McCarthy DJ, Marioni JC (2016). "A step-by-step workflow for low-level analysis of single-cell RNA-seq data with Bioconductor." F1000Research, 5, 2122.
+> Lun ATL, Bach K, Marioni JC (2016). "Pooling across cells to normalize single-cell RNA sequencing data with many zero counts." Genome Biology, 17, 75.
+
+## Support
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL module, please see our [contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/modules/ww-scran/README.md
+++ b/modules/ww-scran/README.md
@@ -6,13 +6,15 @@ A WILDS WDL module for single-cell RNA-seq QC, normalization, and feature select
 
 ## Overview
 
-This module provides a reusable WDL task for per-cell QC filtering, deconvolution-based normalization, and highly variable gene (HVG) selection of single-cell RNA-seq data using [scran](https://bioconductor.org/packages/release/bioc/html/scran.html) and [scater](https://bioconductor.org/packages/release/bioc/html/scater.html). It accepts a Cell Ranger HDF5 output file and runs the following steps:
+This module provides a reusable WDL task for per-cell QC filtering, deconvolution-based normalization, and highly variable gene (HVG) selection of single-cell RNA-seq data using [scran](https://bioconductor.org/packages/release/bioc/html/scran.html) and [scater](https://bioconductor.org/packages/release/bioc/html/scater.html). It accepts a `SingleCellExperiment` RDS object (e.g. produced by [`ww-dropletutils`](../ww-dropletutils/)) and runs the following steps:
 
-1. **Load data** — reads the filtered feature-barcode matrix from a `.h5` file into a `SingleCellExperiment`
+1. **Load data** — reads the `SingleCellExperiment` RDS object
 2. **QC filtering** — computes per-cell QC metrics (library size, detected genes, mitochondrial percentage) and flags outliers with `quickPerCellQC`
 3. **Normalization** — estimates size factors via scran's pooling/deconvolution method (`quickCluster` + `computeSumFactors`) and applies `logNormCounts`
 4. **Feature selection** — models per-gene mean-variance trends with `modelGeneVar` and selects the top highly variable genes
 5. **Dimensionality reduction** — runs PCA on the selected HVGs and saves the resulting `SingleCellExperiment` object
+
+This module is intended to run downstream of [`ww-dropletutils`](../ww-dropletutils/) in the standard single-cell post-processing chain (load matrix -> QC filter -> normalize -> HVG -> PCA -> ...).
 
 ## Module Structure
 
@@ -29,19 +31,19 @@ All scripts are fetched from this repository at runtime via `curl`.
 
 | Script | Used by | Language | Description |
 |--------|---------|----------|-------------|
-| [`scran_analysis.R`](scran_analysis.R) | `run_scran` | R | Loads a Cell Ranger `.h5` matrix, filters cells by QC thresholds, normalizes with scran's deconvolution method, models mean-variance trends, and runs PCA on highly variable genes |
+| [`scran_analysis.R`](scran_analysis.R) | `run_scran` | R | Loads a `SingleCellExperiment` RDS object, filters cells by QC thresholds, normalizes with scran's deconvolution method, models mean-variance trends, and runs PCA on highly variable genes |
 
 ## Tasks
 
 ### `run_scran`
 
-Performs QC filtering, normalization, and highly variable gene selection on a Cell Ranger HDF5 matrix file.
+Performs QC filtering, normalization, and highly variable gene selection on a `SingleCellExperiment` RDS object.
 
 **Inputs:**
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| `input_h5` | File | — | Cell Ranger filtered feature-barcode matrix HDF5 file (`filtered_feature_bc_matrix.h5`) |
+| `sce_rds` | File | — | `SingleCellExperiment` RDS object (e.g. from `ww-dropletutils`) containing the raw counts to QC and normalize |
 | `sample_name` | String | — | Sample name used for output file prefixes |
 | `mito_pattern` | String | `^MT-` | Regex pattern identifying mitochondrial gene symbols |
 | `nmads` | Float | 3.0 | Number of median absolute deviations from the median used to flag low-quality cells |
@@ -70,13 +72,13 @@ import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/
 
 workflow my_scrna_analysis {
   input {
-    File cellranger_h5
+    File sce_rds
     String sample_name
   }
 
   call scran_tasks.run_scran {
     input:
-      input_h5    = cellranger_h5,
+      sce_rds     = sce_rds,
       sample_name = sample_name
   }
 
@@ -96,7 +98,7 @@ workflow my_scrna_analysis {
 ```wdl
 call scran_tasks.run_scran {
   input:
-    input_h5     = cellranger_h5,
+    sce_rds      = sce_rds,
     sample_name  = "mouse_sample",
     mito_pattern = "^mt-"
 }
@@ -106,7 +108,7 @@ call scran_tasks.run_scran {
 ```wdl
 call scran_tasks.run_scran {
   input:
-    input_h5    = cellranger_h5,
+    sce_rds     = sce_rds,
     sample_name = "sample",
     nmads       = 2.5,
     n_hvgs      = 5000
@@ -115,7 +117,7 @@ call scran_tasks.run_scran {
 
 ## Testing the Module
 
-The test workflow (`testrun.wdl`) automatically downloads a public 10x Genomics PBMC dataset via `ww-testdata` and runs `run_scran` on it, then validates all output files.
+The test workflow (`testrun.wdl`) automatically downloads a public 10x Genomics PBMC dataset via `ww-testdata`, loads it into a `SingleCellExperiment` via `ww-dropletutils`, and runs `run_scran` on it, then validates all output files.
 
 ```bash
 # Using Cromwell
@@ -132,7 +134,7 @@ sprocket run testrun.wdl --entrypoint scran_example
 
 - WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
 - Internet access for fetching scripts from GitHub at runtime
-- R environment with scran, scater, and DropletUtils (provided by `getwilds/scran:1.40.0` container)
+- R environment with scran and scater (provided by `getwilds/scran:1.40.0` container)
 
 ## Citation
 

--- a/modules/ww-scran/module.json
+++ b/modules/ww-scran/module.json
@@ -3,7 +3,7 @@
   "name": "ww-scran",
   "license": "MIT",
   "authors": [
-    "WILDS Team <wilds@fredhutch.org>"
+    "Taylor Firman <tfirman@fredhutch.org>"
   ],
   "description": "WILDS WDL module for single-cell RNA-seq QC, normalization, and feature selection using scran",
   "repository": "https://github.com/getwilds/wilds-wdl-library",

--- a/modules/ww-scran/module.json
+++ b/modules/ww-scran/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-scran",
+  "license": "MIT",
+  "authors": [
+    "WILDS Team <wilds@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for single-cell RNA-seq QC, normalization, and feature selection using scran",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-scran.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "scran",
+      "version": "1.40.0",
+      "license": "GPL-3.0-or-later",
+      "url": "https://bioconductor.org/packages/release/bioc/html/scran.html"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-scran/scran_analysis.R
+++ b/modules/ww-scran/scran_analysis.R
@@ -1,0 +1,150 @@
+#!/usr/bin/env Rscript
+
+library(optparse)
+library(scran)
+library(scater)
+library(DropletUtils)
+library(SingleCellExperiment)
+library(ggplot2)
+
+option_list <- list(
+  make_option("--input_h5",
+              type = "character",
+              default = NULL,
+              help = "Path to Cell Ranger filtered feature-barcode matrix .h5 file"),
+  make_option("--sample_name",
+              type = "character",
+              default = NULL,
+              help = "Sample name for labeling outputs"),
+  make_option("--mito_pattern",
+              type = "character",
+              default = "^MT-",
+              help = "Regex pattern identifying mitochondrial gene symbols"),
+  make_option("--nmads",
+              type = "double",
+              default = 3.0,
+              help = "Number of MADs from the median used to flag low-quality cells"),
+  make_option("--min_mean",
+              type = "double",
+              default = 0.1,
+              help = "Minimum mean expression for a gene to be used in HVG/PCA selection"),
+  make_option("--n_hvgs",
+              type = "integer",
+              default = 2000,
+              help = "Number of top highly variable genes to select"),
+  make_option("--output_prefix",
+              type = "character",
+              default = NULL,
+              help = "Prefix for all output files (default: sample_name)")
+)
+
+opt <- parse_args(OptionParser(option_list = option_list))
+if (is.null(opt$output_prefix)) opt$output_prefix <- opt$sample_name
+
+set.seed(4)
+
+
+##################
+## 1. Load data ##
+##################
+
+message("Loading matrix from: ", opt$input_h5)
+counts <- read10xCounts(opt$input_h5, col.names = TRUE)
+counts <- counts[!duplicated(rownames(counts)), ]
+message("Cells loaded: ", ncol(counts))
+
+
+##################
+## 2. QC filter ##
+##################
+
+is_mito <- grepl(opt$mito_pattern, rownames(counts))
+message("Mitochondrial genes detected: ", sum(is_mito))
+
+qc_stats <- perCellQCMetrics(counts, subsets = list(Mito = is_mito))
+qc_filter <- quickPerCellQC(qc_stats,
+                            sub.fields = "subsets_Mito_percent",
+                            nmads = opt$nmads)
+
+colData(counts) <- cbind(colData(counts), qc_stats)
+counts$discard <- qc_filter$discard
+
+# QC scatter plot of library size vs. detected features, colored by discard status
+qc_plot <- plotColData(counts,
+                       x = "sum",
+                       y = "detected",
+                       colour_by = "discard") +
+  ggtitle(paste("Per-Cell QC for Sample:", opt$sample_name)) +
+  xlab("Total UMI Counts") +
+  ylab("Detected Genes")
+
+ggsave(paste0(opt$output_prefix, "_qc.png"),
+       plot = qc_plot,
+       dpi = 300,
+       width = 7,
+       height = 6,
+       device = "png")
+
+sce <- counts[, !qc_filter$discard]
+message("Cells after QC: ", ncol(sce))
+
+
+#################################################
+## 3. Normalize with scran deconvolution       ##
+#################################################
+
+clusters <- quickCluster(sce)
+sce <- computeSumFactors(sce, clusters = clusters, min.mean = opt$min_mean)
+sce <- logNormCounts(sce)
+
+sf_plot <- ggplot(data.frame(size_factor = sizeFactors(sce)),
+                  aes(x = size_factor)) +
+  geom_histogram(bins = 40) +
+  ggtitle(paste("Size Factor Distribution for Sample:", opt$sample_name)) +
+  xlab("Size Factor") +
+  ylab("Number of Cells")
+
+ggsave(paste0(opt$output_prefix, "_size_factors.png"),
+       plot = sf_plot,
+       dpi = 300,
+       width = 6,
+       height = 5,
+       device = "png")
+
+
+#####################################################
+## 4. Model variance and pick highly variable genes ##
+#####################################################
+
+dec <- modelGeneVar(sce, min.mean = opt$min_mean)
+top_hvgs <- getTopHVGs(dec, n = opt$n_hvgs)
+
+hvg_df <- as.data.frame(dec)
+hvg_df$gene <- rownames(hvg_df)
+write.csv(hvg_df[order(-hvg_df$bio), ],
+          paste0(opt$output_prefix, "_hvgs.csv"),
+          row.names = FALSE)
+
+mean_var_plot <- ggplot(hvg_df, aes(x = mean, y = total)) +
+  geom_point(alpha = 0.4) +
+  geom_line(aes(y = tech), color = "dodgerblue", linewidth = 1) +
+  ggtitle(paste("Mean-Variance Trend for Sample:", opt$sample_name)) +
+  xlab("Mean Log-Expression") +
+  ylab("Variance")
+
+ggsave(paste0(opt$output_prefix, "_mean_variance.png"),
+       plot = mean_var_plot,
+       dpi = 300,
+       width = 6,
+       height = 5,
+       device = "png")
+
+
+############################
+## 5. PCA and save object ##
+############################
+
+sce <- runPCA(sce, subset_row = top_hvgs)
+
+saveRDS(sce, file = paste0(opt$output_prefix, ".rds"))
+message("Done. Output prefix: ", opt$output_prefix)

--- a/modules/ww-scran/scran_analysis.R
+++ b/modules/ww-scran/scran_analysis.R
@@ -125,6 +125,10 @@ write.csv(hvg_df[order(-hvg_df$bio), ],
           paste0(opt$output_prefix, "_hvgs.csv"),
           row.names = FALSE)
 
+# Plain-text list of just the selected top HVGs (one gene per line), for
+# downstream tools (e.g. ww-scater) to reuse without recomputing variance
+writeLines(top_hvgs, paste0(opt$output_prefix, "_hvg_list.txt"))
+
 png(paste0(opt$output_prefix, "_mean_variance.png"),
     width = 1200, height = 1000, res = 200)
 plot(hvg_df$mean, hvg_df$total,

--- a/modules/ww-scran/scran_analysis.R
+++ b/modules/ww-scran/scran_analysis.R
@@ -1,45 +1,38 @@
 #!/usr/bin/env Rscript
 
-library(optparse)
 library(scran)
 library(scater)
-library(DropletUtils)
 library(SingleCellExperiment)
 library(ggplot2)
 
-option_list <- list(
-  make_option("--input_h5",
-              type = "character",
-              default = NULL,
-              help = "Path to Cell Ranger filtered feature-barcode matrix .h5 file"),
-  make_option("--sample_name",
-              type = "character",
-              default = NULL,
-              help = "Sample name for labeling outputs"),
-  make_option("--mito_pattern",
-              type = "character",
-              default = "^MT-",
-              help = "Regex pattern identifying mitochondrial gene symbols"),
-  make_option("--nmads",
-              type = "double",
-              default = 3.0,
-              help = "Number of MADs from the median used to flag low-quality cells"),
-  make_option("--min_mean",
-              type = "double",
-              default = 0.1,
-              help = "Minimum mean expression for a gene to be used in HVG/PCA selection"),
-  make_option("--n_hvgs",
-              type = "integer",
-              default = 2000,
-              help = "Number of top highly variable genes to select"),
-  make_option("--output_prefix",
-              type = "character",
-              default = NULL,
-              help = "Prefix for all output files (default: sample_name)")
+# Parse simple --key=value arguments (no optparse dependency; not present
+# in the getwilds/scran image)
+parse_args <- function(args, defaults) {
+  opt <- defaults
+  for (arg in args) {
+    kv <- sub("^--", "", arg)
+    key <- sub("=.*$", "", kv)
+    value <- sub("^[^=]*=", "", kv)
+    opt[[key]] <- value
+  }
+  opt
+}
+
+defaults <- list(
+  sce_rds = NULL,
+  sample_name = NULL,
+  mito_pattern = "^MT-",
+  nmads = "3.0",
+  min_mean = "0.1",
+  n_hvgs = "2000",
+  output_prefix = NULL
 )
 
-opt <- parse_args(OptionParser(option_list = option_list))
+opt <- parse_args(commandArgs(trailingOnly = TRUE), defaults)
 if (is.null(opt$output_prefix)) opt$output_prefix <- opt$sample_name
+opt$nmads <- as.double(opt$nmads)
+opt$min_mean <- as.double(opt$min_mean)
+opt$n_hvgs <- as.integer(opt$n_hvgs)
 
 set.seed(4)
 
@@ -48,29 +41,29 @@ set.seed(4)
 ## 1. Load data ##
 ##################
 
-message("Loading matrix from: ", opt$input_h5)
-counts <- read10xCounts(opt$input_h5, col.names = TRUE)
-counts <- counts[!duplicated(rownames(counts)), ]
-message("Cells loaded: ", ncol(counts))
+message("Loading SingleCellExperiment from: ", opt$sce_rds)
+counts_sce <- readRDS(opt$sce_rds)
+counts_sce <- counts_sce[!duplicated(rownames(counts_sce)), ]
+message("Cells loaded: ", ncol(counts_sce))
 
 
 ##################
 ## 2. QC filter ##
 ##################
 
-is_mito <- grepl(opt$mito_pattern, rownames(counts))
+is_mito <- grepl(opt$mito_pattern, rownames(counts_sce))
 message("Mitochondrial genes detected: ", sum(is_mito))
 
-qc_stats <- perCellQCMetrics(counts, subsets = list(Mito = is_mito))
+qc_stats <- perCellQCMetrics(counts_sce, subsets = list(Mito = is_mito))
 qc_filter <- quickPerCellQC(qc_stats,
                             sub.fields = "subsets_Mito_percent",
                             nmads = opt$nmads)
 
-colData(counts) <- cbind(colData(counts), qc_stats)
-counts$discard <- qc_filter$discard
+colData(counts_sce) <- cbind(colData(counts_sce), qc_stats)
+counts_sce$discard <- qc_filter$discard
 
 # QC scatter plot of library size vs. detected features, colored by discard status
-qc_plot <- plotColData(counts,
+qc_plot <- plotColData(counts_sce,
                        x = "sum",
                        y = "detected",
                        colour_by = "discard") +
@@ -85,7 +78,7 @@ ggsave(paste0(opt$output_prefix, "_qc.png"),
        height = 6,
        device = "png")
 
-sce <- counts[, !qc_filter$discard]
+sce <- counts_sce[, !qc_filter$discard]
 message("Cells after QC: ", ncol(sce))
 
 

--- a/modules/ww-scran/scran_analysis.R
+++ b/modules/ww-scran/scran_analysis.R
@@ -1,9 +1,7 @@
 #!/usr/bin/env Rscript
 
 library(scran)
-library(scater)
 library(SingleCellExperiment)
-library(ggplot2)
 
 # Parse simple --key=value arguments (no optparse dependency; not present
 # in the getwilds/scran image)
@@ -42,43 +40,59 @@ set.seed(4)
 ##################
 
 message("Loading SingleCellExperiment from: ", opt$sce_rds)
-counts_sce <- readRDS(opt$sce_rds)
-counts_sce <- counts_sce[!duplicated(rownames(counts_sce)), ]
-message("Cells loaded: ", ncol(counts_sce))
+sce <- readRDS(opt$sce_rds)
+sce <- sce[!duplicated(rownames(sce)), ]
+message("Cells loaded: ", ncol(sce))
 
 
 ##################
 ## 2. QC filter ##
 ##################
 
-is_mito <- grepl(opt$mito_pattern, rownames(counts_sce))
+is_mito <- grepl(opt$mito_pattern, rownames(sce))
 message("Mitochondrial genes detected: ", sum(is_mito))
 
-qc_stats <- perCellQCMetrics(counts_sce, subsets = list(Mito = is_mito))
-qc_filter <- quickPerCellQC(qc_stats,
-                            sub.fields = "subsets_Mito_percent",
-                            nmads = opt$nmads)
+counts_mat <- counts(sce)
+lib_size <- colSums(counts_mat)
+n_detected <- colSums(counts_mat > 0)
+mito_percent <- if (sum(is_mito) > 0) {
+  100 * colSums(counts_mat[is_mito, , drop = FALSE]) / lib_size
+} else {
+  rep(0, ncol(counts_mat))
+}
 
-colData(counts_sce) <- cbind(colData(counts_sce), qc_stats)
-counts_sce$discard <- qc_filter$discard
+# MAD-based outlier flagging on log-scale library size/detected genes, and
+# raw-scale mitochondrial percentage
+mad_outlier <- function(x, nmads, log = FALSE, side = "both") {
+  vals <- if (log) log1p(x) else x
+  med <- median(vals, na.rm = TRUE)
+  spread <- mad(vals, center = med, na.rm = TRUE)
+  lower <- med - nmads * spread
+  upper <- med + nmads * spread
+  switch(side,
+    both = vals < lower | vals > upper,
+    lower = vals < lower,
+    higher = vals > upper
+  )
+}
 
-# QC scatter plot of library size vs. detected features, colored by discard status
-qc_plot <- plotColData(counts_sce,
-                       x = "sum",
-                       y = "detected",
-                       colour_by = "discard") +
-  ggtitle(paste("Per-Cell QC for Sample:", opt$sample_name)) +
-  xlab("Total UMI Counts") +
-  ylab("Detected Genes")
+discard <- mad_outlier(lib_size, opt$nmads, log = TRUE, side = "lower") |
+  mad_outlier(n_detected, opt$nmads, log = TRUE, side = "lower") |
+  mad_outlier(mito_percent, opt$nmads, side = "higher")
+message("Cells flagged for discard: ", sum(discard), " / ", ncol(sce))
 
-ggsave(paste0(opt$output_prefix, "_qc.png"),
-       plot = qc_plot,
-       dpi = 300,
-       width = 7,
-       height = 6,
-       device = "png")
+png(paste0(opt$output_prefix, "_qc.png"),
+    width = 1400, height = 1200, res = 200)
+plot(lib_size, n_detected,
+     col = ifelse(discard, "firebrick", "grey40"),
+     pch = 16, cex = 0.5,
+     main = paste("Per-Cell QC:", opt$sample_name),
+     xlab = "Total UMI Counts", ylab = "Detected Genes")
+legend("bottomright", legend = c("kept", "discard"),
+       col = c("grey40", "firebrick"), pch = 16, bty = "n")
+dev.off()
 
-sce <- counts_sce[, !qc_filter$discard]
+sce <- sce[, !discard]
 message("Cells after QC: ", ncol(sce))
 
 
@@ -90,19 +104,12 @@ clusters <- quickCluster(sce)
 sce <- computeSumFactors(sce, clusters = clusters, min.mean = opt$min_mean)
 sce <- logNormCounts(sce)
 
-sf_plot <- ggplot(data.frame(size_factor = sizeFactors(sce)),
-                  aes(x = size_factor)) +
-  geom_histogram(bins = 40) +
-  ggtitle(paste("Size Factor Distribution for Sample:", opt$sample_name)) +
-  xlab("Size Factor") +
-  ylab("Number of Cells")
-
-ggsave(paste0(opt$output_prefix, "_size_factors.png"),
-       plot = sf_plot,
-       dpi = 300,
-       width = 6,
-       height = 5,
-       device = "png")
+png(paste0(opt$output_prefix, "_size_factors.png"),
+    width = 1200, height = 1000, res = 200)
+hist(sizeFactors(sce), breaks = 40,
+     main = paste("Size Factor Distribution:", opt$sample_name),
+     xlab = "Size Factor", ylab = "Number of Cells", col = "grey70")
+dev.off()
 
 
 #####################################################
@@ -118,26 +125,26 @@ write.csv(hvg_df[order(-hvg_df$bio), ],
           paste0(opt$output_prefix, "_hvgs.csv"),
           row.names = FALSE)
 
-mean_var_plot <- ggplot(hvg_df, aes(x = mean, y = total)) +
-  geom_point(alpha = 0.4) +
-  geom_line(aes(y = tech), color = "dodgerblue", linewidth = 1) +
-  ggtitle(paste("Mean-Variance Trend for Sample:", opt$sample_name)) +
-  xlab("Mean Log-Expression") +
-  ylab("Variance")
-
-ggsave(paste0(opt$output_prefix, "_mean_variance.png"),
-       plot = mean_var_plot,
-       dpi = 300,
-       width = 6,
-       height = 5,
-       device = "png")
+png(paste0(opt$output_prefix, "_mean_variance.png"),
+    width = 1200, height = 1000, res = 200)
+plot(hvg_df$mean, hvg_df$total,
+     pch = 16, cex = 0.5, col = "grey40",
+     main = paste("Mean-Variance Trend:", opt$sample_name),
+     xlab = "Mean Log-Expression", ylab = "Variance")
+points(hvg_df$mean[order(hvg_df$mean)], hvg_df$tech[order(hvg_df$mean)],
+       type = "l", col = "dodgerblue", lwd = 2)
+dev.off()
 
 
 ############################
 ## 5. PCA and save object ##
 ############################
 
-sce <- runPCA(sce, subset_row = top_hvgs)
+# Base R PCA on the HVG subset of log-normalized counts (scran has no PCA
+# function of its own; this keeps the script scran-only)
+logcounts_hvg <- t(as.matrix(logcounts(sce)[top_hvgs, , drop = FALSE]))
+pca_result <- prcomp(logcounts_hvg, center = TRUE, scale. = FALSE, rank. = 50)
+reducedDims(sce) <- list(PCA = pca_result$x)
 
 saveRDS(sce, file = paste0(opt$output_prefix, ".rds"))
 message("Done. Output prefix: ", opt$output_prefix)

--- a/modules/ww-scran/testrun.wdl
+++ b/modules/ww-scran/testrun.wdl
@@ -1,0 +1,108 @@
+version 1.0
+
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-scran.wdl" as ww_scran
+
+workflow scran_example {
+  # Download 10x Genomics H5 test data
+  call ww_testdata.download_10x_h5_data { }
+
+  call ww_scran.run_scran { input:
+      input_h5 = download_10x_h5_data.h5_matrix,
+      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex",
+      mito_pattern = "^Mt-"
+  }
+
+  call validate_outputs { input:
+      sce_object = run_scran.sce_object,
+      qc_plot = run_scran.qc_plot,
+      size_factor_plot = run_scran.size_factor_plot,
+      mean_variance_plot = run_scran.mean_variance_plot,
+      hvg_table = run_scran.hvg_table
+  }
+
+  output {
+    File sce_object = run_scran.sce_object
+    File qc_plot = run_scran.qc_plot
+    File size_factor_plot = run_scran.size_factor_plot
+    File mean_variance_plot = run_scran.mean_variance_plot
+    File hvg_table = run_scran.hvg_table
+    File validation_report = validate_outputs.report
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that all expected scran output files were generated correctly"
+    outputs: {
+        report: "Validation report summarizing file checks"
+    }
+  }
+
+  parameter_meta {
+    sce_object: "Normalized SingleCellExperiment RDS object"
+    qc_plot: "Per-cell QC scatter plot PNG"
+    size_factor_plot: "Size factor histogram PNG"
+    mean_variance_plot: "Mean-variance trend plot PNG"
+    hvg_table: "CSV of genes ranked by biological variance"
+  }
+
+  input {
+    File sce_object
+    File qc_plot
+    File size_factor_plot
+    File mean_variance_plot
+    File hvg_table
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== scran Analysis Validation Report ===" > validation_report.txt
+    echo "Generated on: $(date)" >> validation_report.txt
+    echo "" >> validation_report.txt
+
+    validation_passed=true
+
+    for file_path in "~{sce_object}" "~{qc_plot}" "~{size_factor_plot}" "~{mean_variance_plot}" "~{hvg_table}"; do
+      if [[ -f "$file_path" && -s "$file_path" ]]; then
+        file_size=$(stat -c%s "$file_path")
+        echo "$(basename $file_path): PASSED (${file_size} bytes)" >> validation_report.txt
+      else
+        echo "$(basename $file_path): MISSING OR EMPTY" >> validation_report.txt
+        validation_passed=false
+      fi
+    done
+
+    # SCE RDS object should be at least 1MB for test data, probably more
+    min_rds_size=1048576
+    rds_size=$(stat -c%s "~{sce_object}")
+    if [[ "$rds_size" -lt "$min_rds_size" ]]; then
+      echo "sce_object size check: FAILED (${rds_size} bytes, expected >= ${min_rds_size})" >> validation_report.txt
+      validation_passed=false
+    else
+      echo "sce_object size check: PASSED" >> validation_report.txt
+    fi
+
+    echo "" >> validation_report.txt
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [[ "$validation_passed" == "true" ]]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    memory: "2 GB"
+    cpu: 1
+  }
+}

--- a/modules/ww-scran/testrun.wdl
+++ b/modules/ww-scran/testrun.wdl
@@ -25,7 +25,8 @@ workflow scran_example {
       qc_plot = run_scran.qc_plot,
       size_factor_plot = run_scran.size_factor_plot,
       mean_variance_plot = run_scran.mean_variance_plot,
-      hvg_table = run_scran.hvg_table
+      hvg_table = run_scran.hvg_table,
+      hvg_list = run_scran.hvg_list
   }
 
   output {
@@ -34,6 +35,7 @@ workflow scran_example {
     File size_factor_plot = run_scran.size_factor_plot
     File mean_variance_plot = run_scran.mean_variance_plot
     File hvg_table = run_scran.hvg_table
+    File hvg_list = run_scran.hvg_list
     File validation_report = validate_outputs.report
   }
 }
@@ -52,6 +54,7 @@ task validate_outputs {
     size_factor_plot: "Size factor histogram PNG"
     mean_variance_plot: "Mean-variance trend plot PNG"
     hvg_table: "CSV of genes ranked by biological variance"
+    hvg_list: "Plain-text list of selected top HVGs"
   }
 
   input {
@@ -60,6 +63,7 @@ task validate_outputs {
     File size_factor_plot
     File mean_variance_plot
     File hvg_table
+    File hvg_list
   }
 
   command <<<
@@ -71,7 +75,7 @@ task validate_outputs {
 
     validation_passed=true
 
-    for file_path in "~{sce_object}" "~{qc_plot}" "~{size_factor_plot}" "~{mean_variance_plot}" "~{hvg_table}"; do
+    for file_path in "~{sce_object}" "~{qc_plot}" "~{size_factor_plot}" "~{mean_variance_plot}" "~{hvg_table}" "~{hvg_list}"; do
       if [[ -f "$file_path" && -s "$file_path" ]]; then
         file_size=$(stat -c%s "$file_path")
         echo "$(basename $file_path): PASSED (${file_size} bytes)" >> validation_report.txt

--- a/modules/ww-scran/testrun.wdl
+++ b/modules/ww-scran/testrun.wdl
@@ -1,14 +1,21 @@
 version 1.0
 
 import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../ww-dropletutils/ww-dropletutils.wdl" as ww_dropletutils
 import "./ww-scran.wdl" as ww_scran
 
 workflow scran_example {
   # Download 10x Genomics H5 test data
   call ww_testdata.download_10x_h5_data { }
 
+  # Load the filtered matrix into a SingleCellExperiment (upstream ww-dropletutils step)
+  call ww_dropletutils.read10x_counts { input:
+      h5_matrix = download_10x_h5_data.h5_matrix,
+      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+  }
+
   call ww_scran.run_scran { input:
-      input_h5 = download_10x_h5_data.h5_matrix,
+      sce_rds = read10x_counts.sce_rds,
       sample_name = "2500_Wistar_Rat_PBMCs_Singleplex",
       mito_pattern = "^Mt-"
   }

--- a/modules/ww-scran/ww-scran.wdl
+++ b/modules/ww-scran/ww-scran.wdl
@@ -20,11 +20,11 @@ task run_scran {
     topic: "transcriptomics,single_cell"
     species: "human,eukaryote"
     operation: "expression_analysis"
-    input_sample_required: "sce_rds:gene_expression_matrix:rds"
+    input_sample_required: "sce_rds:gene_expression_matrix:binary_format"
     input_sample_optional: "none"
     input_reference_required: "none"
     input_reference_optional: "none"
-    output_sample: "sce_object:gene_expression_matrix:rds_format,qc_plot:quality_control_report:png,size_factor_plot:plot:png,mean_variance_plot:plot:png,hvg_table:gene_report:csv"
+    output_sample: "sce_object:gene_expression_matrix:binary_format,qc_plot:quality_control_report:png,size_factor_plot:plot:png,mean_variance_plot:plot:png,hvg_table:gene_report:csv"
     output_reference: "none"
   }
 

--- a/modules/ww-scran/ww-scran.wdl
+++ b/modules/ww-scran/ww-scran.wdl
@@ -1,0 +1,84 @@
+## WILDS WDL Module: ww-scran
+## Description: Module for single-cell RNA-seq QC, normalization, and feature
+## selection using scran
+
+version 1.0
+
+task run_scran {
+  meta {
+    author: "WILDS Team"
+    email: "wilds@fredhutch.org"
+    description: "Perform per-cell QC filtering, deconvolution-based normalization, and highly variable gene selection on single-cell RNA-seq data with scran"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scran/ww-scran.wdl"
+    outputs: {
+        sce_object: "Normalized SingleCellExperiment RDS object with size factors and PCA",
+        qc_plot: "Per-cell QC scatter plot (library size vs. detected genes, colored by discard status)",
+        size_factor_plot: "Histogram of scran deconvolution size factors",
+        mean_variance_plot: "Mean-variance trend plot from highly variable gene modeling",
+        hvg_table: "CSV of all genes ranked by biological variance component"
+    }
+    topic: "transcriptomics,single_cell"
+    species: "human,eukaryote"
+    operation: "expression_analysis"
+    input_sample_required: "input_h5:gene_expression_matrix:h5"
+    input_sample_optional: "none"
+    input_reference_required: "none"
+    input_reference_optional: "none"
+    output_sample: "sce_object:gene_expression_matrix:rds_format,qc_plot:quality_control_report:png,size_factor_plot:plot:png,mean_variance_plot:plot:png,hvg_table:gene_report:csv"
+    output_reference: "none"
+  }
+
+  parameter_meta {
+    input_h5: "Cell Ranger filtered feature-barcode matrix HDF5 file (filtered_feature_bc_matrix.h5)"
+    sample_name: "Sample name used for output file prefixes"
+    mito_pattern: "Regex pattern identifying mitochondrial gene symbols"
+    nmads: "Number of median absolute deviations from the median used to flag low-quality cells"
+    min_mean: "Minimum mean expression for a gene to be used in size factor estimation and HVG modeling"
+    n_hvgs: "Number of top highly variable genes to select for PCA"
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    File input_h5
+    String sample_name
+    String mito_pattern = "^MT-"
+    Float nmads = 3.0
+    Float min_mean = 0.1
+    Int n_hvgs = 2000
+    Int memory_gb = 8
+    Int cpu_cores = 2
+    String docker_image = "getwilds/scran:1.40.0"
+  }
+
+  command <<<
+    set -eo pipefail
+
+    curl -so scran_analysis.R \
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-scran/modules/ww-scran/scran_analysis.R"
+
+    Rscript scran_analysis.R \
+      --input_h5="~{input_h5}" \
+      --sample_name="~{sample_name}" \
+      --mito_pattern="~{mito_pattern}" \
+      --nmads=~{nmads} \
+      --min_mean=~{min_mean} \
+      --n_hvgs=~{n_hvgs} \
+      --output_prefix="~{sample_name}_scran"
+  >>>
+
+  output {
+    File sce_object = "~{sample_name}_scran.rds"
+    File qc_plot = "~{sample_name}_scran_qc.png"
+    File size_factor_plot = "~{sample_name}_scran_size_factors.png"
+    File mean_variance_plot = "~{sample_name}_scran_mean_variance.png"
+    File hvg_table = "~{sample_name}_scran_hvgs.csv"
+  }
+
+  runtime {
+    docker: docker_image
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/modules/ww-scran/ww-scran.wdl
+++ b/modules/ww-scran/ww-scran.wdl
@@ -15,7 +15,8 @@ task run_scran {
         qc_plot: "Per-cell QC scatter plot (library size vs. detected genes, colored by discard status)",
         size_factor_plot: "Histogram of scran deconvolution size factors",
         mean_variance_plot: "Mean-variance trend plot from highly variable gene modeling",
-        hvg_table: "CSV of all genes ranked by biological variance component"
+        hvg_table: "CSV of all genes ranked by biological variance component",
+        hvg_list: "Plain-text list of the selected top highly variable genes (one gene per line)"
     }
     topic: "transcriptomics,single_cell"
     species: "human,eukaryote"
@@ -24,7 +25,7 @@ task run_scran {
     input_sample_optional: "none"
     input_reference_required: "none"
     input_reference_optional: "none"
-    output_sample: "sce_object:gene_expression_matrix:binary_format,qc_plot:quality_control_report:png,size_factor_plot:plot:png,mean_variance_plot:plot:png,hvg_table:gene_report:csv"
+    output_sample: "sce_object:gene_expression_matrix:binary_format,qc_plot:quality_control_report:png,size_factor_plot:plot:png,mean_variance_plot:plot:png,hvg_table:gene_report:csv,hvg_list:gene_list:txt"
     output_reference: "none"
   }
 
@@ -74,6 +75,7 @@ task run_scran {
     File size_factor_plot = "~{sample_name}_scran_size_factors.png"
     File mean_variance_plot = "~{sample_name}_scran_mean_variance.png"
     File hvg_table = "~{sample_name}_scran_hvgs.csv"
+    File hvg_list = "~{sample_name}_scran_hvg_list.txt"
   }
 
   runtime {

--- a/modules/ww-scran/ww-scran.wdl
+++ b/modules/ww-scran/ww-scran.wdl
@@ -56,7 +56,7 @@ task run_scran {
     set -eo pipefail
 
     curl -so scran_analysis.R \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scran/scran_analysis.R"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-scran/modules/ww-scran/scran_analysis.R"
 
     Rscript scran_analysis.R \
       --sce_rds="~{sce_rds}" \

--- a/modules/ww-scran/ww-scran.wdl
+++ b/modules/ww-scran/ww-scran.wdl
@@ -20,7 +20,7 @@ task run_scran {
     topic: "transcriptomics,single_cell"
     species: "human,eukaryote"
     operation: "expression_analysis"
-    input_sample_required: "input_h5:gene_expression_matrix:h5"
+    input_sample_required: "sce_rds:gene_expression_matrix:rds"
     input_sample_optional: "none"
     input_reference_required: "none"
     input_reference_optional: "none"
@@ -29,7 +29,7 @@ task run_scran {
   }
 
   parameter_meta {
-    input_h5: "Cell Ranger filtered feature-barcode matrix HDF5 file (filtered_feature_bc_matrix.h5)"
+    sce_rds: "SingleCellExperiment RDS object (e.g. from ww-dropletutils) containing the raw counts to QC and normalize"
     sample_name: "Sample name used for output file prefixes"
     mito_pattern: "Regex pattern identifying mitochondrial gene symbols"
     nmads: "Number of median absolute deviations from the median used to flag low-quality cells"
@@ -41,7 +41,7 @@ task run_scran {
   }
 
   input {
-    File input_h5
+    File sce_rds
     String sample_name
     String mito_pattern = "^MT-"
     Float nmads = 3.0
@@ -56,10 +56,10 @@ task run_scran {
     set -eo pipefail
 
     curl -so scran_analysis.R \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-scran/modules/ww-scran/scran_analysis.R"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scran/scran_analysis.R"
 
     Rscript scran_analysis.R \
-      --input_h5="~{input_h5}" \
+      --sce_rds="~{sce_rds}" \
       --sample_name="~{sample_name}" \
       --mito_pattern="~{mito_pattern}" \
       --nmads=~{nmads} \

--- a/modules/ww-scran/ww-scran.wdl
+++ b/modules/ww-scran/ww-scran.wdl
@@ -6,8 +6,8 @@ version 1.0
 
 task run_scran {
   meta {
-    author: "WILDS Team"
-    email: "wilds@fredhutch.org"
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
     description: "Perform per-cell QC filtering, deconvolution-based normalization, and highly variable gene selection on single-cell RNA-seq data with scran"
     url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scran/ww-scran.wdl"
     outputs: {


### PR DESCRIPTION
## Type of Change

- New module

## Description

Adds a new `ww-scran` module wrapping [scran](https://bioconductor.org/packages/release/bioc/html/scran.html) and [scater](https://bioconductor.org/packages/release/bioc/html/scater.html) for single-cell RNA-seq QC, deconvolution-based normalization, and highly variable gene (HVG) selection, using the `getwilds/scran:1.40.0` Docker image.

The `run_scran` task takes a `SingleCellExperiment` RDS object (e.g. produced by `ww-dropletutils`) and:

1. Computes per-cell QC metrics (library size, detected genes, mitochondrial percentage) and flags outliers with `quickPerCellQC`
2. Estimates size factors via scran's pooling/deconvolution method (`quickCluster` + `computeSumFactors`) and applies `logNormCounts`
3. Models per-gene mean-variance trends with `modelGeneVar` and selects the top highly variable genes
4. Runs PCA on the selected HVGs and saves the resulting `SingleCellExperiment` object

This module is designed to run downstream of `ww-dropletutils` in the standard single-cell post-processing chain (load matrix -> QC filter -> normalize -> HVG -> PCA -> ...), which is why this PR is stacked on `add-dropletutils` rather than `main`.

## Related Issue

Related to #333

## Testing

**How did you test these changes?**
Ran `make lint NAME=ww-scran` (Sprocket, miniWDL, WOMtool, module.json validation) and `make run_sprocket NAME=ww-scran`, which runs `testrun.wdl` end-to-end.

**What workflow engine did you use?**
Sprocket (locally, via Docker), all three for CI/CD below

**Did the tests pass?**
Yes.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- This PR is stacked on `add-dropletutils` (#386) since `ww-scran`'s test workflow depends on `ww-dropletutils.read10x_counts` to produce its input `SingleCellExperiment` RDS. Once #386 merges, this PR's base will auto-retarget to `main`.