### PR TITLE
Adding initial version of `ww-scater` WILDS WDL module

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -670,6 +670,22 @@ tools:
       branches:
         - main
 
+  - name: ww-scater
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-scater/ww-scater.wdl
+    readMePath: /modules/ww-scater/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for single-cell RNA-seq dimensionality reduction and QC visualization using scater
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-scran
     subclass: WDL
     primaryDescriptorPath: /modules/ww-scran/ww-scran.wdl

--- a/modules/ww-scater/README.md
+++ b/modules/ww-scater/README.md
@@ -1,0 +1,140 @@
+# ww-scater
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for single-cell RNA-seq dimensionality reduction and QC visualization using scater.
+
+## Overview
+
+This module provides a reusable WDL task for PCA and UMAP dimensionality reduction, plus QC and reduced-dimension diagnostic plotting, of single-cell RNA-seq data using [scater](https://bioconductor.org/packages/release/bioc/html/scater.html) only (no `scran`). It accepts a normalized `SingleCellExperiment` RDS object with a `logcounts` assay (e.g. produced by [`ww-scran`](../ww-scran/)) and runs the following steps:
+
+1. **Load data** — reads the `SingleCellExperiment` RDS object and checks for a `logcounts` assay
+2. **Feature selection** — ranks genes by variance of log-expression and selects the top highly variable genes for dimensionality reduction
+3. **Dimensionality reduction** — runs PCA (`runPCA`) on the selected genes, then UMAP (`runUMAP`) on the resulting PCA embedding
+4. **QC metrics** — computes per-cell QC metrics with `perCellQCMetrics`
+5. **Visualization** — generates PCA, UMAP, and per-cell QC scatter plots with `plotReducedDim`/`plotColData`, and saves the updated `SingleCellExperiment` object
+
+This module is intended to run downstream of [`ww-scran`](../ww-scran/) in the standard single-cell post-processing chain (load matrix -> QC filter -> normalize -> HVG -> PCA -> UMAP -> ...).
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
+
+- **Tasks**: `run_scater`
+- **Scripts**: `scater_analysis.R` (fetched via curl at runtime)
+- **Test workflow**: `testrun.wdl`
+- **Container**: `getwilds/scater:1.40.2`
+
+## Scripts
+
+All scripts are fetched from this repository at runtime via `curl`.
+
+| Script | Used by | Language | Description |
+|--------|---------|----------|-------------|
+| [`scater_analysis.R`](scater_analysis.R) | `run_scater` | R | Loads a normalized `SingleCellExperiment` RDS object, selects highly variable genes, runs PCA and UMAP, computes per-cell QC metrics, and generates diagnostic plots |
+
+## Tasks
+
+### `run_scater`
+
+Performs PCA and UMAP dimensionality reduction and QC/reduced-dimension visualization on a normalized `SingleCellExperiment` RDS object.
+
+**Inputs:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `sce_rds` | File | — | Normalized `SingleCellExperiment` RDS object (e.g. from `ww-scran`) containing a `logcounts` assay |
+| `sample_name` | String | — | Sample name used for output file prefixes |
+| `n_pcs` | Int | 50 | Number of principal components to compute |
+| `n_hvgs` | Int | 2000 | Number of most variable genes (by log-expression variance) to use for PCA |
+| `random_seed` | Int | 100 | Random seed for UMAP, for reproducibility |
+| `memory_gb` | Int | 8 | Memory allocated for the task in GB |
+| `cpu_cores` | Int | 2 | Number of CPU cores allocated for the task |
+| `docker_image` | String | `getwilds/scater:1.40.2` | Docker image to use for this task |
+
+**Outputs:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `sce_object` | File | `SingleCellExperiment` RDS object with PCA and UMAP embeddings and per-cell QC metrics |
+| `pca_plot` | File | Scatter plot of the first two PCA components |
+| `umap_plot` | File | Scatter plot of the UMAP embedding |
+| `qc_plot` | File | Per-cell QC scatter plot (library size vs. detected genes, colored by total counts) |
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scater/ww-scater.wdl" as scater_tasks
+
+workflow my_scrna_analysis {
+  input {
+    File sce_rds
+    String sample_name
+  }
+
+  call scater_tasks.run_scater {
+    input:
+      sce_rds     = sce_rds,
+      sample_name = sample_name
+  }
+
+  output {
+    File sce_object = run_scater.sce_object
+    File pca_plot    = run_scater.pca_plot
+    File umap_plot   = run_scater.umap_plot
+    File qc_plot     = run_scater.qc_plot
+  }
+}
+```
+
+### Advanced Usage Examples
+
+**More principal components and a larger HVG set:**
+```wdl
+call scater_tasks.run_scater {
+  input:
+    sce_rds     = sce_rds,
+    sample_name = "sample",
+    n_pcs       = 30,
+    n_hvgs      = 5000
+}
+```
+
+## Testing the Module
+
+The test workflow (`testrun.wdl`) automatically downloads a public 10x Genomics PBMC dataset via `ww-testdata`, loads it into a `SingleCellExperiment` via `ww-dropletutils`, normalizes it with `ww-scran`, and runs `run_scater` on it, then validates all output files.
+
+```bash
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl --entrypoint scater_example
+```
+
+## Requirements
+
+- WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
+- Internet access for fetching scripts from GitHub at runtime
+- R environment with scater (provided by `getwilds/scater:1.40.2` container)
+
+## Citation
+
+> McCarthy DJ, Campbell KR, Lun ATL, Wills QF (2017). "Scater: pre-processing, quality control, normalization and visualization of single-cell RNA-seq data in R." Bioinformatics, 33(8), 1179-1186.
+
+## Support
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL module, please see our [contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/modules/ww-scater/README.md
+++ b/modules/ww-scater/README.md
@@ -9,7 +9,7 @@ A WILDS WDL module for single-cell RNA-seq dimensionality reduction and QC visua
 This module provides a reusable WDL task for PCA and UMAP dimensionality reduction, plus QC and reduced-dimension diagnostic plotting, of single-cell RNA-seq data using [scater](https://bioconductor.org/packages/release/bioc/html/scater.html) only (no `scran`). It accepts a normalized `SingleCellExperiment` RDS object with a `logcounts` assay (e.g. produced by [`ww-scran`](../ww-scran/)) and runs the following steps:
 
 1. **Load data** — reads the `SingleCellExperiment` RDS object and checks for a `logcounts` assay
-2. **Feature selection** — ranks genes by variance of log-expression and selects the top highly variable genes for dimensionality reduction
+2. **Feature selection** — uses an optional upstream HVG list (e.g. `ww-scran`'s `hvg_list` output) if provided, otherwise ranks genes by variance of log-expression and selects the top highly variable genes for dimensionality reduction
 3. **Dimensionality reduction** — runs PCA (`runPCA`) on the selected genes, then UMAP (`runUMAP`) on the resulting PCA embedding
 4. **QC metrics** — computes per-cell QC metrics with `perCellQCMetrics`
 5. **Visualization** — generates PCA, UMAP, and per-cell QC scatter plots with `plotReducedDim`/`plotColData`, and saves the updated `SingleCellExperiment` object
@@ -45,8 +45,9 @@ Performs PCA and UMAP dimensionality reduction and QC/reduced-dimension visualiz
 |------|------|---------|-------------|
 | `sce_rds` | File | — | Normalized `SingleCellExperiment` RDS object (e.g. from `ww-scran`) containing a `logcounts` assay |
 | `sample_name` | String | — | Sample name used for output file prefixes |
+| `hvg_list` | File? | — | Optional plain-text list of highly variable genes to use for PCA (e.g. `ww-scran`'s `hvg_list` output), one gene per line. If omitted, HVGs are selected by log-expression variance |
 | `n_pcs` | Int | 50 | Number of principal components to compute |
-| `n_hvgs` | Int | 2000 | Number of most variable genes (by log-expression variance) to use for PCA |
+| `n_hvgs` | Int | 2000 | Number of most variable genes (by log-expression variance) to use for PCA, when `hvg_list` is not provided |
 | `random_seed` | Int | 100 | Random seed for UMAP, for reproducibility |
 | `memory_gb` | Int | 8 | Memory allocated for the task in GB |
 | `cpu_cores` | Int | 2 | Number of CPU cores allocated for the task |
@@ -102,9 +103,19 @@ call scater_tasks.run_scater {
 }
 ```
 
+**Reusing an upstream HVG selection (e.g. from `ww-scran`):**
+```wdl
+call scater_tasks.run_scater {
+  input:
+    sce_rds     = run_scran.sce_object,
+    hvg_list    = run_scran.hvg_list,
+    sample_name = "sample"
+}
+```
+
 ## Testing the Module
 
-The test workflow (`testrun.wdl`) automatically downloads a public 10x Genomics PBMC dataset via `ww-testdata`, loads it into a `SingleCellExperiment` via `ww-dropletutils`, normalizes it with `ww-scran`, and runs `run_scater` on it, then validates all output files.
+The test workflow (`testrun.wdl`) automatically downloads a public 10x Genomics PBMC dataset via `ww-testdata`, loads it into a `SingleCellExperiment` via `ww-dropletutils`, normalizes it with `ww-scran`, and runs `run_scater` on it (reusing `ww-scran`'s HVG selection via the `hvg_list` input), then validates all output files.
 
 ```bash
 # Using Cromwell

--- a/modules/ww-scater/module.json
+++ b/modules/ww-scater/module.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-scater",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for single-cell RNA-seq dimensionality reduction (PCA, UMAP) and QC/reduced-dimension visualization using scater",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-scater.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "scater",
+      "version": "1.40.2",
+      "license": "GPL-3.0-or-later",
+      "url": "https://bioconductor.org/packages/release/bioc/html/scater.html"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-scater/scater_analysis.R
+++ b/modules/ww-scater/scater_analysis.R
@@ -1,0 +1,93 @@
+#!/usr/bin/env Rscript
+
+library(scater)
+library(SingleCellExperiment)
+library(ggplot2)
+
+# Parse simple --key=value arguments (no optparse dependency; not present
+# in the getwilds/scater image)
+parse_args <- function(args, defaults) {
+  opt <- defaults
+  for (arg in args) {
+    kv <- sub("^--", "", arg)
+    key <- sub("=.*$", "", kv)
+    value <- sub("^[^=]*=", "", kv)
+    opt[[key]] <- value
+  }
+  opt
+}
+
+defaults <- list(
+  sce_rds = NULL,
+  sample_name = NULL,
+  n_pcs = "50",
+  n_hvgs = "2000",
+  random_seed = "100",
+  output_prefix = NULL
+)
+
+opt <- parse_args(commandArgs(trailingOnly = TRUE), defaults)
+if (is.null(opt$output_prefix)) opt$output_prefix <- opt$sample_name
+opt$n_pcs <- as.integer(opt$n_pcs)
+opt$n_hvgs <- as.integer(opt$n_hvgs)
+opt$random_seed <- as.integer(opt$random_seed)
+
+set.seed(opt$random_seed)
+
+
+##################
+## 1. Load data ##
+##################
+
+message("Loading SingleCellExperiment from: ", opt$sce_rds)
+sce <- readRDS(opt$sce_rds)
+message("Cells loaded: ", ncol(sce))
+
+if (!"logcounts" %in% assayNames(sce)) {
+  stop("Input SingleCellExperiment has no logcounts assay; ",
+       "normalize (e.g. with ww-scran) before running scater")
+}
+
+
+########################################################
+## 2. Highly variable genes for dimensionality reduction ##
+########################################################
+
+# Rank genes by variance of log-expression to pick the top HVGs
+# (self-contained: does not assume upstream HVG selection, e.g. scran's)
+gene_var <- apply(logcounts(sce), 1, var)
+n_hvgs <- min(opt$n_hvgs, length(gene_var))
+top_hvgs <- names(sort(gene_var, decreasing = TRUE))[seq_len(n_hvgs)]
+message("HVGs used for dimensionality reduction: ", length(top_hvgs))
+
+
+############################################
+## 3. PCA, UMAP, and QC/reduced-dim plots ##
+############################################
+
+sce <- runPCA(sce, subset_row = top_hvgs, ncomponents = opt$n_pcs)
+sce <- runUMAP(sce, dimred = "PCA")
+
+pca_plot <- plotReducedDim(sce, dimred = "PCA") +
+  ggtitle(paste("PCA:", opt$sample_name))
+ggsave(paste0(opt$output_prefix, "_pca.png"),
+       plot = pca_plot, dpi = 300, width = 6, height = 5, device = "png")
+
+umap_plot <- plotReducedDim(sce, dimred = "UMAP") +
+  ggtitle(paste("UMAP:", opt$sample_name))
+ggsave(paste0(opt$output_prefix, "_umap.png"),
+       plot = umap_plot, dpi = 300, width = 6, height = 5, device = "png")
+
+qc_metrics <- perCellQCMetrics(sce)
+colData(sce) <- cbind(colData(sce), qc_metrics)
+
+qc_plot <- plotColData(sce, x = "sum", y = "detected",
+                        colour_by = "total") +
+  ggtitle(paste("Per-Cell QC:", opt$sample_name)) +
+  xlab("Total UMI Counts") +
+  ylab("Detected Genes")
+ggsave(paste0(opt$output_prefix, "_qc.png"),
+       plot = qc_plot, dpi = 300, width = 7, height = 6, device = "png")
+
+saveRDS(sce, file = paste0(opt$output_prefix, ".rds"))
+message("Done. Output prefix: ", opt$output_prefix)

--- a/modules/ww-scater/scater_analysis.R
+++ b/modules/ww-scater/scater_analysis.R
@@ -20,6 +20,7 @@ parse_args <- function(args, defaults) {
 defaults <- list(
   sce_rds = NULL,
   sample_name = NULL,
+  hvg_list = "",
   n_pcs = "50",
   n_hvgs = "2000",
   random_seed = "100",
@@ -53,11 +54,18 @@ if (!"logcounts" %in% assayNames(sce)) {
 ## 2. Highly variable genes for dimensionality reduction ##
 ########################################################
 
-# Rank genes by variance of log-expression to pick the top HVGs
-# (self-contained: does not assume upstream HVG selection, e.g. scran's)
-gene_var <- apply(logcounts(sce), 1, var)
-n_hvgs <- min(opt$n_hvgs, length(gene_var))
-top_hvgs <- names(sort(gene_var, decreasing = TRUE))[seq_len(n_hvgs)]
+if (nzchar(opt$hvg_list)) {
+  # Reuse an upstream HVG selection (e.g. ww-scran's hvg_list output)
+  # instead of recomputing it from scratch
+  message("Loading HVG list from: ", opt$hvg_list)
+  top_hvgs <- readLines(opt$hvg_list)
+  top_hvgs <- intersect(top_hvgs, rownames(sce))
+} else {
+  # Rank genes by variance of log-expression to pick the top HVGs
+  gene_var <- apply(logcounts(sce), 1, var)
+  n_hvgs <- min(opt$n_hvgs, length(gene_var))
+  top_hvgs <- names(sort(gene_var, decreasing = TRUE))[seq_len(n_hvgs)]
+}
 message("HVGs used for dimensionality reduction: ", length(top_hvgs))
 
 

--- a/modules/ww-scater/testrun.wdl
+++ b/modules/ww-scater/testrun.wdl
@@ -1,0 +1,118 @@
+version 1.0
+
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../ww-dropletutils/ww-dropletutils.wdl" as ww_dropletutils
+import "../ww-scran/ww-scran.wdl" as ww_scran
+import "./ww-scater.wdl" as ww_scater
+
+workflow scater_example {
+  # Download 10x Genomics H5 test data
+  call ww_testdata.download_10x_h5_data { }
+
+  # Load the filtered matrix into a SingleCellExperiment (upstream ww-dropletutils step)
+  call ww_dropletutils.read10x_counts { input:
+      h5_matrix = download_10x_h5_data.h5_matrix,
+      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+  }
+
+  # Normalize with scran (upstream ww-scran step)
+  call ww_scran.run_scran { input:
+      sce_rds = read10x_counts.sce_rds,
+      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex",
+      mito_pattern = "^Mt-"
+  }
+
+  call ww_scater.run_scater { input:
+      sce_rds = run_scran.sce_object,
+      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+  }
+
+  call validate_outputs { input:
+      sce_object = run_scater.sce_object,
+      pca_plot = run_scater.pca_plot,
+      umap_plot = run_scater.umap_plot,
+      qc_plot = run_scater.qc_plot
+  }
+
+  output {
+    File sce_object = run_scater.sce_object
+    File pca_plot = run_scater.pca_plot
+    File umap_plot = run_scater.umap_plot
+    File qc_plot = run_scater.qc_plot
+    File validation_report = validate_outputs.report
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that all expected scater output files were generated correctly"
+    outputs: {
+        report: "Validation report summarizing file checks"
+    }
+  }
+
+  parameter_meta {
+    sce_object: "SingleCellExperiment RDS object with PCA and UMAP embeddings"
+    pca_plot: "PCA scatter plot PNG"
+    umap_plot: "UMAP scatter plot PNG"
+    qc_plot: "Per-cell QC scatter plot PNG"
+  }
+
+  input {
+    File sce_object
+    File pca_plot
+    File umap_plot
+    File qc_plot
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== scater Analysis Validation Report ===" > validation_report.txt
+    echo "Generated on: $(date)" >> validation_report.txt
+    echo "" >> validation_report.txt
+
+    validation_passed=true
+
+    for file_path in "~{sce_object}" "~{pca_plot}" "~{umap_plot}" "~{qc_plot}"; do
+      if [[ -f "$file_path" && -s "$file_path" ]]; then
+        file_size=$(stat -c%s "$file_path")
+        echo "$(basename $file_path): PASSED (${file_size} bytes)" >> validation_report.txt
+      else
+        echo "$(basename $file_path): MISSING OR EMPTY" >> validation_report.txt
+        validation_passed=false
+      fi
+    done
+
+    # SCE RDS object should be at least 1MB for test data, probably more
+    min_rds_size=1048576
+    rds_size=$(stat -c%s "~{sce_object}")
+    if [[ "$rds_size" -lt "$min_rds_size" ]]; then
+      echo "sce_object size check: FAILED (${rds_size} bytes, expected >= ${min_rds_size})" >> validation_report.txt
+      validation_passed=false
+    else
+      echo "sce_object size check: PASSED" >> validation_report.txt
+    fi
+
+    echo "" >> validation_report.txt
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [[ "$validation_passed" == "true" ]]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    memory: "2 GB"
+    cpu: 1
+  }
+}

--- a/modules/ww-scater/testrun.wdl
+++ b/modules/ww-scater/testrun.wdl
@@ -22,8 +22,10 @@ workflow scater_example {
       mito_pattern = "^Mt-"
   }
 
+  # Reuse ww-scran's HVG selection instead of recomputing it
   call ww_scater.run_scater { input:
       sce_rds = run_scran.sce_object,
+      hvg_list = run_scran.hvg_list,
       sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
   }
 

--- a/modules/ww-scater/ww-scater.wdl
+++ b/modules/ww-scater/ww-scater.wdl
@@ -20,7 +20,7 @@ task run_scater {
     species: "human,eukaryote"
     operation: "dimensionality_reduction"
     input_sample_required: "sce_rds:gene_expression_matrix:binary_format"
-    input_sample_optional: "none"
+    input_sample_optional: "hvg_list:gene_list:txt"
     input_reference_required: "none"
     input_reference_optional: "none"
     output_sample: "sce_object:gene_expression_matrix:binary_format,pca_plot:plot:png,umap_plot:plot:png,qc_plot:quality_control_report:png"
@@ -30,8 +30,9 @@ task run_scater {
   parameter_meta {
     sce_rds: "Normalized SingleCellExperiment RDS object (e.g. from ww-scran) containing a logcounts assay"
     sample_name: "Sample name used for output file prefixes"
+    hvg_list: "Optional plain-text list of highly variable genes to use for PCA (e.g. ww-scran's hvg_list output), one gene per line. If omitted, HVGs are selected by log-expression variance"
     n_pcs: "Number of principal components to compute"
-    n_hvgs: "Number of most variable genes (by log-expression variance) to use for PCA"
+    n_hvgs: "Number of most variable genes (by log-expression variance) to use for PCA, when hvg_list is not provided"
     random_seed: "Random seed for UMAP, for reproducibility"
     memory_gb: "Memory allocated for the task in GB"
     cpu_cores: "Number of CPU cores allocated for the task"
@@ -41,6 +42,7 @@ task run_scater {
   input {
     File sce_rds
     String sample_name
+    File? hvg_list
     Int n_pcs = 50
     Int n_hvgs = 2000
     Int random_seed = 100
@@ -58,6 +60,7 @@ task run_scater {
     Rscript scater_analysis.R \
       --sce_rds="~{sce_rds}" \
       --sample_name="~{sample_name}" \
+      --hvg_list="~{default="" hvg_list}" \
       --n_pcs=~{n_pcs} \
       --n_hvgs=~{n_hvgs} \
       --random_seed=~{random_seed} \

--- a/modules/ww-scater/ww-scater.wdl
+++ b/modules/ww-scater/ww-scater.wdl
@@ -53,7 +53,7 @@ task run_scater {
     set -eo pipefail
 
     curl -so scater_analysis.R \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scater/scater_analysis.R"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-scater/modules/ww-scater/scater_analysis.R"
 
     Rscript scater_analysis.R \
       --sce_rds="~{sce_rds}" \

--- a/modules/ww-scater/ww-scater.wdl
+++ b/modules/ww-scater/ww-scater.wdl
@@ -1,0 +1,79 @@
+## WILDS WDL Module: ww-scater
+## Description: Module for single-cell RNA-seq dimensionality reduction (PCA, UMAP)
+## and QC/reduced-dimension visualization using scater
+
+version 1.0
+
+task run_scater {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Perform PCA and UMAP dimensionality reduction on a normalized SingleCellExperiment object and generate QC and reduced-dimension diagnostic plots with scater"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scater/ww-scater.wdl"
+    outputs: {
+        sce_object: "SingleCellExperiment RDS object with PCA and UMAP embeddings and per-cell QC metrics",
+        pca_plot: "Scatter plot of the first two PCA components",
+        umap_plot: "Scatter plot of the UMAP embedding",
+        qc_plot: "Per-cell QC scatter plot (library size vs. detected genes, colored by total counts)"
+    }
+    topic: "transcriptomics,single_cell"
+    species: "human,eukaryote"
+    operation: "dimensionality_reduction"
+    input_sample_required: "sce_rds:gene_expression_matrix:rds"
+    input_sample_optional: "none"
+    input_reference_required: "none"
+    input_reference_optional: "none"
+    output_sample: "sce_object:gene_expression_matrix:rds_format,pca_plot:plot:png,umap_plot:plot:png,qc_plot:quality_control_report:png"
+    output_reference: "none"
+  }
+
+  parameter_meta {
+    sce_rds: "Normalized SingleCellExperiment RDS object (e.g. from ww-scran) containing a logcounts assay"
+    sample_name: "Sample name used for output file prefixes"
+    n_pcs: "Number of principal components to compute"
+    n_hvgs: "Number of most variable genes (by log-expression variance) to use for PCA"
+    random_seed: "Random seed for UMAP, for reproducibility"
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    File sce_rds
+    String sample_name
+    Int n_pcs = 50
+    Int n_hvgs = 2000
+    Int random_seed = 100
+    Int memory_gb = 8
+    Int cpu_cores = 2
+    String docker_image = "getwilds/scater:1.40.2"
+  }
+
+  command <<<
+    set -eo pipefail
+
+    curl -so scater_analysis.R \
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scater/scater_analysis.R"
+
+    Rscript scater_analysis.R \
+      --sce_rds="~{sce_rds}" \
+      --sample_name="~{sample_name}" \
+      --n_pcs=~{n_pcs} \
+      --n_hvgs=~{n_hvgs} \
+      --random_seed=~{random_seed} \
+      --output_prefix="~{sample_name}_scater"
+  >>>
+
+  output {
+    File sce_object = "~{sample_name}_scater.rds"
+    File pca_plot = "~{sample_name}_scater_pca.png"
+    File umap_plot = "~{sample_name}_scater_umap.png"
+    File qc_plot = "~{sample_name}_scater_qc.png"
+  }
+
+  runtime {
+    docker: docker_image
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/modules/ww-scater/ww-scater.wdl
+++ b/modules/ww-scater/ww-scater.wdl
@@ -19,11 +19,11 @@ task run_scater {
     topic: "transcriptomics,single_cell"
     species: "human,eukaryote"
     operation: "dimensionality_reduction"
-    input_sample_required: "sce_rds:gene_expression_matrix:rds"
+    input_sample_required: "sce_rds:gene_expression_matrix:binary_format"
     input_sample_optional: "none"
     input_reference_required: "none"
     input_reference_optional: "none"
-    output_sample: "sce_object:gene_expression_matrix:rds_format,pca_plot:plot:png,umap_plot:plot:png,qc_plot:quality_control_report:png"
+    output_sample: "sce_object:gene_expression_matrix:binary_format,pca_plot:plot:png,umap_plot:plot:png,qc_plot:quality_control_report:png"
     output_reference: "none"
   }
 


### PR DESCRIPTION
## Type of Change

- New module

## Description

Adds `ww-scater`, a new WILDS WDL module wrapping the Bioconductor [scater](https://bioconductor.org/packages/release/bioc/html/scater.html) package for single-cell RNA-seq dimensionality reduction and visualization.

The module's `run_scater` task:
1. Loads a normalized `SingleCellExperiment` RDS object (expects a `logcounts` assay)
2. Selects the top highly variable genes by log-expression variance
3. Runs PCA (`runPCA`) and UMAP (`runUMAP`) dimensionality reduction
4. Computes per-cell QC metrics (`perCellQCMetrics`)
5. Generates PCA, UMAP, and per-cell QC diagnostic plots (`plotReducedDim`, `plotColData`)
6. Saves the updated `SingleCellExperiment` object with embeddings and QC metrics

This module is intentionally scoped to `scater` functionality only (no `scran`), so it composes cleanly as a standalone step downstream of `ww-scran` in the standard single-cell post-processing chain: load matrix -> QC filter -> normalize -> HVG -> PCA -> UMAP -> ...

Uses the `getwilds/scater:1.40.2` Docker image, pinned to an exact version tag.

**Note:** This branch (`add-scater`) is stacked on top of `add-scran` (not yet merged to `main`), since `ww-scater`'s test workflow chains off `ww-scran`'s output. This PR should merge after (or be rebased once) `add-scran` lands on `main`.

## Related Issue

- Related to #333

## Testing

**How did you test these changes?**
Ran `make lint NAME=ww-scater`, CI/CD test run execution below.

**What workflow engine did you use?**
All three, Sprocket, Cromwell, and miniwdl.

**Did the tests pass?**
Yes.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [ ] I ran `make docs` to check documentation rendering (if applicable)

## Additional Context

- `ggplot2` is used for plotting (`ggtitle`, `ggsave`, etc.) but not separately installed — it's a hard `Depends` of `scater` itself, so it's guaranteed to be present in the `getwilds/scater` image and attached automatically via `library(scater)`.
- `testrun.wdl` chains `ww-testdata` -> `ww-dropletutils` -> `ww-scran` -> `ww-scater` to exercise the module against a realistic normalized `SingleCellExperiment`.
- Registered in `.dockstore.yml` under `tools:`, alphabetically between `ww-samtools` and `ww-scran`.
- `module.json`'s `tools[]` entry pins `scater` version `1.40.2` matching the Docker tag, license `GPL-3.0-or-later`.