### PR TITLE
Adding initial version of `ww-singler` WILDS WDL module

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -734,6 +734,22 @@ tools:
       branches:
         - main
 
+  - name: ww-singler
+    subclass: WDL
+    primaryDescriptorPath: /modules/ww-singler/ww-singler.wdl
+    readMePath: /modules/ww-singler/README.md
+    authors:
+      - name: Taylor Firman
+        email: tfirman@fredhutch.org
+        role: Research Informatics Data Scientist
+        affiliation: Fred Hutch Cancer Center
+        orcid: 0009-0002-2052-1084
+    topic: WDL module for single-cell RNA-seq clustering, marker gene identification, and cell-type annotation using scran and SingleR
+    enableAutoDois: true
+    filters:
+      branches:
+        - main
+
   - name: ww-sjl
     subclass: WDL
     primaryDescriptorPath: /modules/ww-sjl/ww-sjl.wdl

--- a/modules/ww-singler/README.md
+++ b/modules/ww-singler/README.md
@@ -46,6 +46,7 @@ Performs clustering, marker gene identification, and cell-type annotation on a d
 | `sample_name` | String | — | Sample name used for output file prefixes |
 | `reference_rds` | File? | — | Optional custom reference `SingleCellExperiment` RDS object with labeled cell types. If omitted, a celldex reference dataset is fetched by name |
 | `reference_dataset` | String | `HumanPrimaryCellAtlasData` | Name of the celldex reference dataset function to fetch (e.g. `HumanPrimaryCellAtlasData`, `MouseRNAseqData`), used when `reference_rds` is not provided |
+| `reference_ensembl` | Boolean | `true` | Fetch the celldex reference with Ensembl gene IDs instead of gene symbols, to match 10x Cell Ranger output |
 | `label_column` | String | `label.main` | Column name in the reference object's colData containing cell-type labels |
 | `n_top_markers` | Int | 10 | Number of top marker genes to report per cluster |
 | `random_seed` | Int | 100 | Random seed for clustering, for reproducibility |
@@ -115,7 +116,7 @@ call singler_tasks.run_singler {
 
 ## Testing the Module
 
-The test workflow (`testrun.wdl`) automatically downloads a public 10x Genomics PBMC dataset via `ww-testdata`, loads it into a `SingleCellExperiment` via `ww-dropletutils`, normalizes it with `ww-scran`, runs dimensionality reduction with `ww-scater`, and runs `run_singler` on it, then validates all output files. Note that the demo dataset is rat PBMCs annotated against the default human reference (`HumanPrimaryCellAtlasData`), so predicted labels are not biologically meaningful for this test data — the test only validates that the pipeline runs end-to-end and produces well-formed outputs.
+The test workflow (`testrun.wdl`) automatically downloads a raw 10x Genomics human PBMC dataset via `ww-testdata`, calls real cells and loads them into a `SingleCellExperiment` via `ww-dropletutils`, normalizes with `ww-scran`, runs dimensionality reduction with `ww-scater`, and runs `run_singler` on it against the default human reference (`HumanPrimaryCellAtlasData`), then validates all output files.
 
 ```bash
 # Using Cromwell

--- a/modules/ww-singler/README.md
+++ b/modules/ww-singler/README.md
@@ -1,0 +1,152 @@
+# ww-singler
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL module for single-cell RNA-seq clustering, marker gene identification, and cell-type annotation using scran and SingleR.
+
+## Overview
+
+This module provides a reusable WDL task for graph-based clustering, per-cluster marker gene identification, and reference-based cell-type annotation of single-cell RNA-seq data using [scran](https://bioconductor.org/packages/release/bioc/html/scran.html) (`clusterCells`, `findMarkers`) and [SingleR](https://bioconductor.org/packages/release/bioc/html/SingleR.html), with reference datasets from [celldex](https://bioconductor.org/packages/release/bioc/html/celldex.html). It accepts a dimensionality-reduced `SingleCellExperiment` RDS object with a PCA embedding (e.g. produced by [`ww-scater`](../ww-scater/)) and runs the following steps:
+
+1. **Load data** — reads the `SingleCellExperiment` RDS object and checks for a `logcounts` assay and a `PCA` reducedDim
+2. **Clustering** — assigns cells to clusters with `scran::clusterCells` using the PCA embedding
+3. **Marker gene identification** — finds per-cluster marker genes with `scran::findMarkers`
+4. **Cell-type annotation** — annotates each cluster with `SingleR`, using either a named [celldex](https://bioconductor.org/packages/release/bioc/html/celldex.html) reference dataset (default) or a user-supplied reference `SingleCellExperiment`, and saves the updated object
+
+This module is intended to run downstream of [`ww-scater`](../ww-scater/) in the standard single-cell post-processing chain (load matrix -> QC filter -> normalize -> HVG -> PCA -> UMAP -> clustering -> marker genes -> cell-type annotation).
+
+## Module Structure
+
+This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
+
+- **Tasks**: `run_singler`
+- **Scripts**: `singler_analysis.R` (fetched via curl at runtime)
+- **Test workflow**: `testrun.wdl`
+- **Container**: `getwilds/singler:2.14.1`
+
+## Scripts
+
+All scripts are fetched from this repository at runtime via `curl`.
+
+| Script | Used by | Language | Description |
+|--------|---------|----------|-------------|
+| [`singler_analysis.R`](singler_analysis.R) | `run_singler` | R | Loads a dimensionality-reduced `SingleCellExperiment` RDS object, clusters cells, identifies per-cluster marker genes, and annotates cell types with SingleR |
+
+## Tasks
+
+### `run_singler`
+
+Performs clustering, marker gene identification, and cell-type annotation on a dimensionality-reduced `SingleCellExperiment` RDS object.
+
+**Inputs:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `sce_rds` | File | — | Dimensionality-reduced `SingleCellExperiment` RDS object (e.g. from `ww-scater`) containing a PCA reducedDim |
+| `sample_name` | String | — | Sample name used for output file prefixes |
+| `reference_rds` | File? | — | Optional custom reference `SingleCellExperiment` RDS object with labeled cell types. If omitted, a celldex reference dataset is fetched by name |
+| `reference_dataset` | String | `HumanPrimaryCellAtlasData` | Name of the celldex reference dataset function to fetch (e.g. `HumanPrimaryCellAtlasData`, `MouseRNAseqData`), used when `reference_rds` is not provided |
+| `label_column` | String | `label.main` | Column name in the reference object's colData containing cell-type labels |
+| `n_top_markers` | Int | 10 | Number of top marker genes to report per cluster |
+| `random_seed` | Int | 100 | Random seed for clustering, for reproducibility |
+| `memory_gb` | Int | 16 | Memory allocated for the task in GB |
+| `cpu_cores` | Int | 2 | Number of CPU cores allocated for the task |
+| `docker_image` | String | `getwilds/singler:2.14.1` | Docker image to use for this task |
+
+**Outputs:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `sce_object` | File | `SingleCellExperiment` RDS object with cluster assignments and predicted cell types |
+| `cluster_table` | File | CSV mapping each cell barcode to its assigned cluster |
+| `marker_table` | File | CSV of top marker genes per cluster |
+| `prediction_table` | File | CSV of SingleR cell-type predictions and scores per cluster |
+
+## Usage as a Module
+
+### Importing into Your Workflow
+
+```wdl
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-singler/ww-singler.wdl" as singler_tasks
+
+workflow my_scrna_analysis {
+  input {
+    File sce_rds
+    String sample_name
+  }
+
+  call singler_tasks.run_singler {
+    input:
+      sce_rds     = sce_rds,
+      sample_name = sample_name
+  }
+
+  output {
+    File sce_object      = run_singler.sce_object
+    File cluster_table    = run_singler.cluster_table
+    File marker_table     = run_singler.marker_table
+    File prediction_table = run_singler.prediction_table
+  }
+}
+```
+
+### Advanced Usage Examples
+
+**Mouse reference dataset:**
+```wdl
+call singler_tasks.run_singler {
+  input:
+    sce_rds            = sce_rds,
+    sample_name        = "mouse_sample",
+    reference_dataset  = "MouseRNAseqData"
+}
+```
+
+**Custom reference SingleCellExperiment:**
+```wdl
+call singler_tasks.run_singler {
+  input:
+    sce_rds        = sce_rds,
+    sample_name    = "sample",
+    reference_rds  = custom_reference_sce,
+    label_column   = "cell_type"
+}
+```
+
+## Testing the Module
+
+The test workflow (`testrun.wdl`) automatically downloads a public 10x Genomics PBMC dataset via `ww-testdata`, loads it into a `SingleCellExperiment` via `ww-dropletutils`, normalizes it with `ww-scran`, runs dimensionality reduction with `ww-scater`, and runs `run_singler` on it, then validates all output files. Note that the demo dataset is rat PBMCs annotated against the default human reference (`HumanPrimaryCellAtlasData`), so predicted labels are not biologically meaningful for this test data — the test only validates that the pipeline runs end-to-end and produces well-formed outputs.
+
+```bash
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl --entrypoint singler_example
+```
+
+## Requirements
+
+- WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
+- Internet access for fetching scripts from GitHub and reference datasets from celldex at runtime
+- R environment with scran, SingleR, and celldex (provided by `getwilds/singler:2.14.1` container)
+
+## Citation
+
+> Aran D, Looney AP, Liu L, Wu E, Fong V, Hsu A, Chak S, et al. (2019). "Reference-based analysis of lung single-cell sequencing reveals a transitional profibrotic macrophage." Nature Immunology, 20(2), 163-172.
+> Lun ATL, McCarthy DJ, Marioni JC (2016). "A step-by-step workflow for low-level analysis of single-cell RNA-seq data with Bioconductor." F1000Research, 5, 2122.
+
+## Support
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL module, please see our [contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/modules/ww-singler/module.json
+++ b/modules/ww-singler/module.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-singler",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL module for single-cell RNA-seq clustering, marker gene identification, and cell-type annotation using scran and SingleR",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-singler.wdl",
+  "readme": "README.md",
+  "tools": [
+    {
+      "name": "singler",
+      "version": "2.14.1",
+      "license": "GPL-3.0-or-later",
+      "url": "https://bioconductor.org/packages/release/bioc/html/SingleR.html"
+    },
+    {
+      "name": "scran",
+      "version": "1.40.0",
+      "license": "GPL-3.0-or-later",
+      "url": "https://bioconductor.org/packages/release/bioc/html/scran.html"
+    },
+    {
+      "name": "celldex",
+      "version": "1.22.0",
+      "license": "GPL-3.0-or-later",
+      "url": "https://bioconductor.org/packages/release/bioc/html/celldex.html"
+    }
+  ],
+  "dependencies": {}
+}

--- a/modules/ww-singler/singler_analysis.R
+++ b/modules/ww-singler/singler_analysis.R
@@ -57,9 +57,9 @@ if (!"PCA" %in% reducedDimNames(sce)) {
 }
 
 
-#####################
+######################
 ## 2. Cluster cells ##
-#####################
+######################
 
 clusters <- clusterCells(sce, use.dimred = "PCA")
 sce$cluster <- clusters
@@ -69,9 +69,9 @@ write.csv(data.frame(barcode = colnames(sce), cluster = sce$cluster),
           row.names = FALSE)
 
 
-##############################
+#################################
 ## 3. Per-cluster marker genes ##
-##############################
+#################################
 
 markers <- findMarkers(sce, groups = sce$cluster)
 
@@ -90,9 +90,9 @@ write.csv(marker_df,
           row.names = FALSE)
 
 
-######################################
+##########################################
 ## 4. Cell-type annotation with SingleR ##
-######################################
+##########################################
 
 if (nzchar(opt$reference_rds)) {
   message("Loading reference SingleCellExperiment from: ", opt$reference_rds)

--- a/modules/ww-singler/singler_analysis.R
+++ b/modules/ww-singler/singler_analysis.R
@@ -23,6 +23,7 @@ defaults <- list(
   sample_name = NULL,
   reference_rds = "",
   reference_dataset = "HumanPrimaryCellAtlasData",
+  reference_ensembl = "true",
   label_column = "label.main",
   n_top_markers = "10",
   random_seed = "100",
@@ -33,6 +34,7 @@ opt <- parse_args(commandArgs(trailingOnly = TRUE), defaults)
 if (is.null(opt$output_prefix)) opt$output_prefix <- opt$sample_name
 opt$n_top_markers <- as.integer(opt$n_top_markers)
 opt$random_seed <- as.integer(opt$random_seed)
+opt$reference_ensembl <- as.logical(opt$reference_ensembl)
 
 set.seed(opt$random_seed)
 
@@ -96,8 +98,13 @@ if (nzchar(opt$reference_rds)) {
   message("Loading reference SingleCellExperiment from: ", opt$reference_rds)
   reference <- readRDS(opt$reference_rds)
 } else {
-  message("Fetching reference dataset from celldex: ", opt$reference_dataset)
-  reference <- do.call(opt$reference_dataset, list())
+  # 10x Cell Ranger output (the typical upstream source for sce) uses
+  # Ensembl gene IDs as rownames, not gene symbols, so the celldex
+  # reference is fetched in the matching ID space by default
+  message("Fetching reference dataset from celldex: ", opt$reference_dataset,
+          " (ensembl = ", opt$reference_ensembl, ")")
+  reference <- do.call(opt$reference_dataset,
+                        list(ensembl = opt$reference_ensembl))
 }
 
 predictions <- SingleR(test = sce, ref = reference,

--- a/modules/ww-singler/singler_analysis.R
+++ b/modules/ww-singler/singler_analysis.R
@@ -1,0 +1,114 @@
+#!/usr/bin/env Rscript
+
+library(scran)
+library(SingleR)
+library(celldex)
+library(SingleCellExperiment)
+
+# Parse simple --key=value arguments (no optparse dependency; not present
+# in the getwilds/singler image)
+parse_args <- function(args, defaults) {
+  opt <- defaults
+  for (arg in args) {
+    kv <- sub("^--", "", arg)
+    key <- sub("=.*$", "", kv)
+    value <- sub("^[^=]*=", "", kv)
+    opt[[key]] <- value
+  }
+  opt
+}
+
+defaults <- list(
+  sce_rds = NULL,
+  sample_name = NULL,
+  reference_rds = "",
+  reference_dataset = "HumanPrimaryCellAtlasData",
+  label_column = "label.main",
+  n_top_markers = "10",
+  random_seed = "100",
+  output_prefix = NULL
+)
+
+opt <- parse_args(commandArgs(trailingOnly = TRUE), defaults)
+if (is.null(opt$output_prefix)) opt$output_prefix <- opt$sample_name
+opt$n_top_markers <- as.integer(opt$n_top_markers)
+opt$random_seed <- as.integer(opt$random_seed)
+
+set.seed(opt$random_seed)
+
+
+##################
+## 1. Load data ##
+##################
+
+message("Loading SingleCellExperiment from: ", opt$sce_rds)
+sce <- readRDS(opt$sce_rds)
+message("Cells loaded: ", ncol(sce))
+
+if (!"logcounts" %in% assayNames(sce)) {
+  stop("Input SingleCellExperiment has no logcounts assay; ",
+       "normalize (e.g. with ww-scran) before running singler")
+}
+if (!"PCA" %in% reducedDimNames(sce)) {
+  stop("Input SingleCellExperiment has no PCA reducedDim; run ",
+       "dimensionality reduction (e.g. with ww-scater) before running singler")
+}
+
+
+#####################
+## 2. Cluster cells ##
+#####################
+
+clusters <- clusterCells(sce, use.dimred = "PCA")
+sce$cluster <- clusters
+message("Clusters identified: ", length(unique(clusters)))
+write.csv(data.frame(barcode = colnames(sce), cluster = sce$cluster),
+          paste0(opt$output_prefix, "_clusters.csv"),
+          row.names = FALSE)
+
+
+##############################
+## 3. Per-cluster marker genes ##
+##############################
+
+markers <- findMarkers(sce, groups = sce$cluster)
+
+# markers[[cluster]] is pre-sorted by ascending Top (best rank across all
+# pairwise comparisons against other clusters); take the top N genes.
+# Per-cluster tables have different logFC.<other cluster> columns, so only
+# the shared summary columns are kept for the combined table
+summary_cols <- c("Top", "p.value", "FDR", "summary.logFC")
+marker_df <- do.call(rbind, lapply(names(markers), function(cluster_id) {
+  top <- as.data.frame(markers[[cluster_id]])[, summary_cols]
+  top <- head(top, opt$n_top_markers)
+  data.frame(cluster = cluster_id, gene = rownames(top), top)
+}))
+write.csv(marker_df,
+          paste0(opt$output_prefix, "_markers.csv"),
+          row.names = FALSE)
+
+
+######################################
+## 4. Cell-type annotation with SingleR ##
+######################################
+
+if (nzchar(opt$reference_rds)) {
+  message("Loading reference SingleCellExperiment from: ", opt$reference_rds)
+  reference <- readRDS(opt$reference_rds)
+} else {
+  message("Fetching reference dataset from celldex: ", opt$reference_dataset)
+  reference <- do.call(opt$reference_dataset, list())
+}
+
+predictions <- SingleR(test = sce, ref = reference,
+                       labels = reference[[opt$label_column]],
+                       clusters = sce$cluster)
+
+sce$cell_type <- predictions$labels[match(sce$cluster, rownames(predictions))]
+
+write.csv(as.data.frame(predictions),
+          paste0(opt$output_prefix, "_predictions.csv"),
+          row.names = TRUE)
+
+saveRDS(sce, file = paste0(opt$output_prefix, ".rds"))
+message("Done. Output prefix: ", opt$output_prefix)

--- a/modules/ww-singler/testrun.wdl
+++ b/modules/ww-singler/testrun.wdl
@@ -7,31 +7,31 @@ import "../ww-scater/ww-scater.wdl" as ww_scater
 import "./ww-singler.wdl" as ww_singler
 
 workflow singler_example {
-  # Download 10x Genomics H5 test data
-  call ww_testdata.download_10x_h5_data { }
+  # Download a raw (unfiltered) 10x Genomics H5 matrix of human PBMCs
+  call ww_testdata.download_10x_raw_h5_data { }
 
-  # Load the filtered matrix into a SingleCellExperiment (upstream ww-dropletutils step)
-  call ww_dropletutils.read10x_counts { input:
-      h5_matrix = download_10x_h5_data.h5_matrix,
-      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+  # Call real cells from the raw matrix (upstream ww-dropletutils step)
+  call ww_dropletutils.empty_drops_filter { input:
+      raw_h5_matrix = download_10x_raw_h5_data.raw_h5_matrix,
+      sample_name = "pbmc_10k_v3"
   }
 
   # Normalize with scran (upstream ww-scran step)
   call ww_scran.run_scran { input:
-      sce_rds = read10x_counts.sce_rds,
-      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex",
-      mito_pattern = "^Mt-"
+      sce_rds = empty_drops_filter.filtered_sce_rds,
+      sample_name = "pbmc_10k_v3",
+      mito_pattern = "^MT-"
   }
 
   # Dimensionality reduction with scater (upstream ww-scater step)
   call ww_scater.run_scater { input:
       sce_rds = run_scran.sce_object,
-      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+      sample_name = "pbmc_10k_v3"
   }
 
   call ww_singler.run_singler { input:
       sce_rds = run_scater.sce_object,
-      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+      sample_name = "pbmc_10k_v3"
   }
 
   call validate_outputs { input:

--- a/modules/ww-singler/testrun.wdl
+++ b/modules/ww-singler/testrun.wdl
@@ -1,0 +1,125 @@
+version 1.0
+
+import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+import "../ww-dropletutils/ww-dropletutils.wdl" as ww_dropletutils
+import "../ww-scran/ww-scran.wdl" as ww_scran
+import "../ww-scater/ww-scater.wdl" as ww_scater
+import "./ww-singler.wdl" as ww_singler
+
+workflow singler_example {
+  # Download 10x Genomics H5 test data
+  call ww_testdata.download_10x_h5_data { }
+
+  # Load the filtered matrix into a SingleCellExperiment (upstream ww-dropletutils step)
+  call ww_dropletutils.read10x_counts { input:
+      h5_matrix = download_10x_h5_data.h5_matrix,
+      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+  }
+
+  # Normalize with scran (upstream ww-scran step)
+  call ww_scran.run_scran { input:
+      sce_rds = read10x_counts.sce_rds,
+      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex",
+      mito_pattern = "^Mt-"
+  }
+
+  # Dimensionality reduction with scater (upstream ww-scater step)
+  call ww_scater.run_scater { input:
+      sce_rds = run_scran.sce_object,
+      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+  }
+
+  call ww_singler.run_singler { input:
+      sce_rds = run_scater.sce_object,
+      sample_name = "2500_Wistar_Rat_PBMCs_Singleplex"
+  }
+
+  call validate_outputs { input:
+      sce_object = run_singler.sce_object,
+      cluster_table = run_singler.cluster_table,
+      marker_table = run_singler.marker_table,
+      prediction_table = run_singler.prediction_table
+  }
+
+  output {
+    File sce_object = run_singler.sce_object
+    File cluster_table = run_singler.cluster_table
+    File marker_table = run_singler.marker_table
+    File prediction_table = run_singler.prediction_table
+    File validation_report = validate_outputs.report
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that all expected singler output files were generated correctly"
+    outputs: {
+        report: "Validation report summarizing file checks"
+    }
+  }
+
+  parameter_meta {
+    sce_object: "SingleCellExperiment RDS object with cluster assignments and predicted cell types"
+    cluster_table: "Per-cell cluster assignment CSV"
+    marker_table: "Per-cluster marker gene CSV"
+    prediction_table: "Per-cluster SingleR prediction CSV"
+  }
+
+  input {
+    File sce_object
+    File cluster_table
+    File marker_table
+    File prediction_table
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== singler Analysis Validation Report ===" > validation_report.txt
+    echo "Generated on: $(date)" >> validation_report.txt
+    echo "" >> validation_report.txt
+
+    validation_passed=true
+
+    for file_path in "~{sce_object}" "~{cluster_table}" "~{marker_table}" "~{prediction_table}"; do
+      if [[ -f "$file_path" && -s "$file_path" ]]; then
+        file_size=$(stat -c%s "$file_path")
+        echo "$(basename $file_path): PASSED (${file_size} bytes)" >> validation_report.txt
+      else
+        echo "$(basename $file_path): MISSING OR EMPTY" >> validation_report.txt
+        validation_passed=false
+      fi
+    done
+
+    # SCE RDS object should be at least 1MB for test data, probably more
+    min_rds_size=1048576
+    rds_size=$(stat -c%s "~{sce_object}")
+    if [[ "$rds_size" -lt "$min_rds_size" ]]; then
+      echo "sce_object size check: FAILED (${rds_size} bytes, expected >= ${min_rds_size})" >> validation_report.txt
+      validation_passed=false
+    else
+      echo "sce_object size check: PASSED" >> validation_report.txt
+    fi
+
+    echo "" >> validation_report.txt
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [[ "$validation_passed" == "true" ]]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    memory: "2 GB"
+    cpu: 1
+  }
+}

--- a/modules/ww-singler/ww-singler.wdl
+++ b/modules/ww-singler/ww-singler.wdl
@@ -1,0 +1,85 @@
+## WILDS WDL Module: ww-singler
+## Description: Module for single-cell RNA-seq clustering, marker gene identification,
+## and cell-type annotation using scran and SingleR
+
+version 1.0
+
+task run_singler {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Cluster cells, identify per-cluster marker genes, and annotate cell types on a dimensionality-reduced SingleCellExperiment object using scran and SingleR"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-singler/ww-singler.wdl"
+    outputs: {
+        sce_object: "SingleCellExperiment RDS object with cluster assignments and predicted cell types",
+        cluster_table: "CSV mapping each cell barcode to its assigned cluster",
+        marker_table: "CSV of top marker genes per cluster",
+        prediction_table: "CSV of SingleR cell-type predictions and scores per cluster"
+    }
+    topic: "transcriptomics,single_cell"
+    species: "human,eukaryote"
+    operation: "annotation"
+    input_sample_required: "sce_rds:gene_expression_matrix:rds"
+    input_sample_optional: "reference_rds:gene_expression_matrix:rds"
+    input_reference_required: "none"
+    input_reference_optional: "none"
+    output_sample: "sce_object:gene_expression_matrix:rds_format,cluster_table:gene_report:csv,marker_table:gene_report:csv,prediction_table:gene_report:csv"
+    output_reference: "none"
+  }
+
+  parameter_meta {
+    sce_rds: "Dimensionality-reduced SingleCellExperiment RDS object (e.g. from ww-scater) containing a PCA reducedDim"
+    sample_name: "Sample name used for output file prefixes"
+    reference_rds: "Optional custom reference SingleCellExperiment RDS object with labeled cell types. If omitted, a celldex reference dataset is fetched by name"
+    reference_dataset: "Name of the celldex reference dataset function to fetch (e.g. HumanPrimaryCellAtlasData, MouseRNAseqData), used when reference_rds is not provided"
+    label_column: "Column name in the reference object's colData containing cell-type labels"
+    n_top_markers: "Number of top marker genes to report per cluster"
+    random_seed: "Random seed for clustering, for reproducibility"
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    File sce_rds
+    String sample_name
+    File? reference_rds
+    String reference_dataset = "HumanPrimaryCellAtlasData"
+    String label_column = "label.main"
+    Int n_top_markers = 10
+    Int random_seed = 100
+    Int memory_gb = 16
+    Int cpu_cores = 2
+    String docker_image = "getwilds/singler:2.14.1"
+  }
+
+  command <<<
+    set -eo pipefail
+
+    curl -so singler_analysis.R \
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-singler/modules/ww-singler/singler_analysis.R"
+
+    Rscript singler_analysis.R \
+      --sce_rds="~{sce_rds}" \
+      --sample_name="~{sample_name}" \
+      --reference_rds="~{default="" reference_rds}" \
+      --reference_dataset="~{reference_dataset}" \
+      --label_column="~{label_column}" \
+      --n_top_markers=~{n_top_markers} \
+      --random_seed=~{random_seed} \
+      --output_prefix="~{sample_name}_singler"
+  >>>
+
+  output {
+    File sce_object = "~{sample_name}_singler.rds"
+    File cluster_table = "~{sample_name}_singler_clusters.csv"
+    File marker_table = "~{sample_name}_singler_markers.csv"
+    File prediction_table = "~{sample_name}_singler_predictions.csv"
+  }
+
+  runtime {
+    docker: docker_image
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}

--- a/modules/ww-singler/ww-singler.wdl
+++ b/modules/ww-singler/ww-singler.wdl
@@ -19,11 +19,11 @@ task run_singler {
     topic: "transcriptomics,single_cell"
     species: "human,eukaryote"
     operation: "annotation"
-    input_sample_required: "sce_rds:gene_expression_matrix:rds"
-    input_sample_optional: "reference_rds:gene_expression_matrix:rds"
+    input_sample_required: "sce_rds:gene_expression_matrix:binary_format"
+    input_sample_optional: "none"
     input_reference_required: "none"
-    input_reference_optional: "none"
-    output_sample: "sce_object:gene_expression_matrix:rds_format,cluster_table:gene_report:csv,marker_table:gene_report:csv,prediction_table:gene_report:csv"
+    input_reference_optional: "reference_rds:gene_expression_matrix:binary_format"
+    output_sample: "sce_object:gene_expression_matrix:binary_format,cluster_table:gene_report:csv,marker_table:gene_report:csv,prediction_table:gene_report:csv"
     output_reference: "none"
   }
 

--- a/modules/ww-singler/ww-singler.wdl
+++ b/modules/ww-singler/ww-singler.wdl
@@ -32,6 +32,7 @@ task run_singler {
     sample_name: "Sample name used for output file prefixes"
     reference_rds: "Optional custom reference SingleCellExperiment RDS object with labeled cell types. If omitted, a celldex reference dataset is fetched by name"
     reference_dataset: "Name of the celldex reference dataset function to fetch (e.g. HumanPrimaryCellAtlasData, MouseRNAseqData), used when reference_rds is not provided"
+    reference_ensembl: "Fetch the celldex reference with Ensembl gene IDs instead of gene symbols, to match 10x Cell Ranger output"
     label_column: "Column name in the reference object's colData containing cell-type labels"
     n_top_markers: "Number of top marker genes to report per cluster"
     random_seed: "Random seed for clustering, for reproducibility"
@@ -45,6 +46,7 @@ task run_singler {
     String sample_name
     File? reference_rds
     String reference_dataset = "HumanPrimaryCellAtlasData"
+    Boolean reference_ensembl = true
     String label_column = "label.main"
     Int n_top_markers = 10
     Int random_seed = 100
@@ -64,6 +66,7 @@ task run_singler {
       --sample_name="~{sample_name}" \
       --reference_rds="~{default="" reference_rds}" \
       --reference_dataset="~{reference_dataset}" \
+      --reference_ensembl=~{reference_ensembl} \
       --label_column="~{label_column}" \
       --n_top_markers=~{n_top_markers} \
       --random_seed=~{random_seed} \


### PR DESCRIPTION
## Type of Change

- New module

## Description

Adds `ww-singler`, a new WILDS WDL module wrapping [scran](https://bioconductor.org/packages/release/bioc/html/scran.html) (`clusterCells`, `findMarkers`) and [SingleR](https://bioconductor.org/packages/release/bioc/html/SingleR.html) for single-cell RNA-seq clustering, marker gene identification, and cell-type annotation.

This is the fourth and final per-tool module in the Bioconductor/OSCA single-cell chain scoped in issue #333 (`ww-dropletutils` -> `ww-scran` -> `ww-scater` -> `ww-singler`), covering the "clustering -> marker genes -> cell-type annotation" tail end of the v1 workflow: load matrix -> QC filter -> normalize -> HVG -> PCA -> neighbors -> UMAP -> clustering -> marker genes -> (cell-type annotation).

The module's `run_singler` task:
1. Loads a dimensionality-reduced `SingleCellExperiment` RDS object (expects a `logcounts` assay and a `PCA` reducedDim, e.g. from `ww-scater`)
2. Clusters cells with `scran::clusterCells` using the PCA embedding
3. Identifies per-cluster marker genes with `scran::findMarkers`
4. Annotates each cluster's cell type with `SingleR`, using either a named [celldex](https://bioconductor.org/packages/release/bioc/html/celldex.html) reference dataset (default: `HumanPrimaryCellAtlasData`) or a user-supplied reference `SingleCellExperiment`
5. Saves the updated `SingleCellExperiment` object with cluster assignments and predicted cell types, plus CSV tables for clusters, markers, and predictions

Clustering and marker-gene identification were deliberately bundled into this module rather than `ww-scran`, since `ww-scran` is scoped narrowly to QC/normalize/HVG (see the earlier `ww-scran`/`ww-scater` isolation work), and both `clusterCells`/`findMarkers` are needed as direct inputs to cell-type annotation anyway.

## Related Issue

Related to #333

## Testing

**How did you test these changes?**
Ran `make lint NAME=ww-singler`, plus the CI/CD `testrun.wdl` execution triggered by this PR.

**What workflow engine did you use?**
Sprocket, Cromwell, and miniwdl

**Did the tests pass?**
Yes, linting and the CI/CD test run both pass.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [ ] I ran `make docs` to check documentation rendering (if applicable)