### PR TITLE
Adding initial draft of `ww-bioc-sc` WILDS WDL pipeline

### DIFF
--- a/pipelines/ww-bioc-sc/README.md
+++ b/pipelines/ww-bioc-sc/README.md
@@ -1,0 +1,230 @@
+# ww-bioc-sc Pipeline
+[![Project Status: Experimental – Useable, some support, not open to feedback, unstable API.](https://getwilds.org/badges/badges/experimental.svg)](https://getwilds.org/badges/#experimental)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A WILDS WDL pipeline for standard single-cell RNA-seq post-processing using the Bioconductor/OSCA (Orchestrating Single-Cell Analysis) ecosystem.
+
+## Overview
+
+This pipeline combines four Bioconductor-based WILDS modules to take 10x Genomics feature-barcode matrices from raw counts to annotated cell types: `ww-dropletutils`, `ww-scran`, `ww-scater`, and `ww-singler`. It follows the standard OSCA single-cell post-processing chain: load matrix -> QC filter -> normalize -> HVG -> PCA -> UMAP -> clustering -> marker genes -> cell-type annotation.
+
+This pipeline serves as both a functional workflow and a demonstration of modular WDL design patterns within the WILDS ecosystem, including reuse of an upstream module's intermediate output (`ww-scran`'s highly variable gene list) by a downstream module (`ww-scater`) to avoid redundant computation.
+
+**Complexity level:** Intermediate (4 modules)
+
+## Pipeline Structure
+
+This pipeline is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and demonstrates:
+
+- **Module Integration**: Chaining four single-cell Bioconductor modules into one workflow
+- **Data Flow**: Passing a `SingleCellExperiment` RDS object through QC, normalization, dimensionality reduction, and annotation steps
+- **Cross-Module Reuse**: `ww-scater` reuses `ww-scran`'s highly variable gene selection via the `hvg_list` output/input, instead of recomputing it
+- **Scatter-Gather**: Parallel per-sample processing of multiple single-cell samples
+
+## Pipeline Steps
+
+1. **Load Matrix** (using `ww-dropletutils` module):
+   - For pre-filtered samples (`h5_matrix`): loads the 10x Genomics filtered feature-barcode matrix (H5 format) directly into a `SingleCellExperiment` object
+   - For raw samples (`raw_h5_matrix`): calls real cells from the unfiltered matrix with `emptyDrops` first, then loads the result into a `SingleCellExperiment` object
+
+2. **QC, Normalization, and HVG Selection** (using `ww-scran` module):
+   - Computes per-cell QC metrics and flags low-quality cells
+   - Normalizes with scran's pooling/deconvolution method
+   - Models mean-variance trends and selects highly variable genes
+
+3. **Dimensionality Reduction** (using `ww-scater` module):
+   - Runs PCA on the highly variable genes selected by `ww-scran` (reused via `hvg_list`)
+   - Runs UMAP on the PCA embedding
+   - Generates QC and reduced-dimension diagnostic plots
+
+4. **Clustering, Marker Genes, and Cell-Type Annotation** (using `ww-singler` module):
+   - Clusters cells using the PCA embedding
+   - Identifies per-cluster marker genes
+   - Annotates each cluster's cell type against a celldex reference dataset (or a custom reference)
+
+## Module Dependencies
+
+This pipeline imports and uses:
+- **ww-dropletutils module**: For loading 10x feature-barcode matrices (`read10x_counts` task) and calling real cells from raw matrices (`empty_drops_filter` task)
+- **ww-scran module**: For QC filtering, normalization, and HVG selection (`run_scran` task)
+- **ww-scater module**: For PCA/UMAP dimensionality reduction and QC visualization (`run_scater` task)
+- **ww-singler module**: For clustering, marker gene identification, and cell-type annotation (`run_singler` task)
+
+## Usage
+
+### Requirements
+
+- WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
+- Docker/Apptainer support
+- Internet access for module imports and celldex reference dataset downloads
+
+### Input Configuration
+
+Create an inputs JSON file with your samples:
+
+```json
+{
+  "bioc_sc.samples": [
+    {
+      "name": "sample1",
+      "h5_matrix": "/path/to/sample1_filtered_feature_bc_matrix.h5"
+    },
+    {
+      "name": "sample2",
+      "raw_h5_matrix": "/path/to/sample2_raw_feature_bc_matrix.h5"
+    }
+  ],
+  "bioc_sc.mito_pattern": "^MT-",
+  "bioc_sc.reference_dataset": "HumanPrimaryCellAtlasData"
+}
+```
+
+### Running the Pipeline
+
+```bash
+# Using Cromwell
+java -jar cromwell.jar run ww-bioc-sc.wdl --inputs inputs.json
+
+# Using miniWDL
+miniwdl run ww-bioc-sc.wdl -i inputs.json
+
+# Using Sprocket
+sprocket run ww-bioc-sc.wdl @inputs.json
+```
+
+### For Fred Hutch Users
+
+Fred Hutch users can use [PROOF](https://sciwiki.fredhutch.org/datademos/proof-how-to/) to submit this pipeline directly to the on-premise HPC cluster:
+
+1. Ensure your input files are accessible by the cluster
+2. Update the inputs JSON with your sample information
+3. Submit through the PROOF interface
+
+## Input Parameters
+
+| Parameter | Description | Type | Required? | Default |
+|-----------|-------------|------|-----------|---------|
+| `samples` | List of SingleCellSample objects, each with a name and either a pre-filtered (`h5_matrix`) or raw (`raw_h5_matrix`) 10x feature-barcode matrix (H5) | Array[SingleCellSample] | Yes | - |
+| `mito_pattern` | Regex pattern identifying mitochondrial gene symbols (passed to `ww-scran`) | String | No | `^MT-` |
+| `nmads` | Number of median absolute deviations used to flag low-quality cells (passed to `ww-scran`) | Float | No | 3.0 |
+| `n_hvgs` | Number of top highly variable genes to select (passed to `ww-scran` and used as a fallback in `ww-scater`) | Int | No | 2000 |
+| `n_pcs` | Number of principal components to compute (passed to `ww-scater`) | Int | No | 50 |
+| `reference_dataset` | Name of the celldex reference dataset function to fetch for cell-type annotation (passed to `ww-singler`) | String | No | `HumanPrimaryCellAtlasData` |
+| `reference_ensembl` | Fetch the celldex reference with Ensembl gene IDs instead of gene symbols (passed to `ww-singler`) | Boolean | No | `true` |
+| `label_column` | Column name in the reference object's colData containing cell-type labels (passed to `ww-singler`) | String | No | `label.main` |
+| `cpu_cores` | Number of CPU cores allocated for `ww-dropletutils`, `ww-scran`, and `ww-scater` tasks | Int | No | 2 |
+| `memory_gb` | Memory allocated in GB for `ww-dropletutils`, `ww-scran`, and `ww-scater` tasks | Int | No | 8 |
+| `singler_memory_gb` | Memory allocated in GB for `ww-singler` tasks (higher default: celldex reference loading and clustering need more headroom) | Int | No | 16 |
+
+### SingleCellSample Structure
+
+Provide exactly one of `h5_matrix` or `raw_h5_matrix` per sample.
+
+**Pre-filtered matrix:**
+```json
+{
+  "name": "sample_name",
+  "h5_matrix": "/path/to/filtered_feature_bc_matrix.h5"
+}
+```
+
+**Raw (unfiltered) matrix** (real cells are called with `emptyDrops` first):
+```json
+{
+  "name": "sample_name",
+  "raw_h5_matrix": "/path/to/raw_feature_bc_matrix.h5"
+}
+```
+
+## Output Files
+
+The pipeline produces arrays of outputs (one per sample) from all four modules:
+
+| Output | Description | Source Module |
+|--------|-------------|---------------|
+| `sce_rds` | Loaded `SingleCellExperiment` RDS objects, prior to QC/normalization | ww-dropletutils |
+| `empty_drops_csv` | Per-barcode `emptyDrops` statistics, for samples provided as a raw matrix (null for pre-filtered samples) | ww-dropletutils |
+| `barcode_rank_plot` | Barcode-rank QC plots, for samples provided as a raw matrix (null for pre-filtered samples) | ww-dropletutils |
+| `scran_sce_object` | Normalized `SingleCellExperiment` RDS objects with size factors and PCA | ww-scran |
+| `scran_qc_plot` | Per-cell QC scatter plots from scran | ww-scran |
+| `scran_size_factor_plot` | Size factor histograms | ww-scran |
+| `scran_mean_variance_plot` | Mean-variance trend plots | ww-scran |
+| `scran_hvg_table` | CSVs of genes ranked by biological variance | ww-scran |
+| `scater_sce_object` | `SingleCellExperiment` RDS objects with PCA and UMAP embeddings | ww-scater |
+| `scater_pca_plot` | PCA scatter plots | ww-scater |
+| `scater_umap_plot` | UMAP scatter plots | ww-scater |
+| `scater_qc_plot` | Per-cell QC scatter plots from scater | ww-scater |
+| `singler_sce_object` | Final `SingleCellExperiment` RDS objects with cluster assignments and predicted cell types | ww-singler |
+| `singler_cluster_table` | CSVs mapping cell barcodes to clusters | ww-singler |
+| `singler_marker_table` | CSVs of top marker genes per cluster | ww-singler |
+| `singler_prediction_table` | CSVs of SingleR cell-type predictions per cluster | ww-singler |
+
+## Resource Considerations
+
+### Compute Requirements
+- **Memory**: 8GB recommended for `ww-dropletutils`/`ww-scran`/`ww-scater` tasks; 16GB recommended for `ww-singler` tasks (celldex reference loading)
+- **CPUs**: 2 cores per task is sufficient for most single-cell datasets; these tools are largely single-threaded per sample
+- **Network**: Stable internet connection for module imports and celldex reference dataset downloads (cached after first fetch by the underlying ExperimentHub, but not across separate task invocations)
+
+### Optimization Tips
+- Scatter parallelism means resource requirements apply per sample, not per pipeline run; total resource usage scales with the number of samples processed concurrently
+- Provide a custom reference `SingleCellExperiment` via `ww-singler`'s underlying `reference_rds` input (not exposed at the pipeline level in v1) if celldex's built-in references don't fit your organism or cell types
+
+## Testing the Pipeline
+
+The pipeline includes a test workflow that downloads a public 10x Genomics PBMC dataset:
+
+```bash
+# Using Cromwell
+java -jar cromwell.jar run testrun.wdl
+
+# Using miniWDL
+miniwdl run testrun.wdl
+
+# Using Sprocket
+sprocket run testrun.wdl --entrypoint bioc_sc_example
+```
+
+The test workflow automatically:
+1. Downloads a raw (unfiltered) 10x Genomics H5 matrix (human PBMC sample) via `ww-testdata`
+2. Runs the full `ww-bioc-sc` pipeline on it via the `raw_h5_matrix` path (calling real cells with `emptyDrops` before QC)
+3. Validates all output files
+
+**Test Dataset Details:**
+- Uses the human PBMC raw-matrix fixture from `ww-testdata`, paired with the default `HumanPrimaryCellAtlasData` celldex reference, so `ww-singler`'s cell-type predictions are biologically meaningful for this demo run
+
+## Integration Patterns
+
+This pipeline demonstrates several key WDL patterns:
+- **Module Composition**: Chaining four analysis modules into a single coherent workflow
+- **Cross-Module Data Reuse**: Passing an intermediate result (`ww-scran`'s `hvg_list`) between modules to avoid redundant computation, while keeping each module independently usable on its own
+- **Struct Usage**: Grouping per-sample inputs (name, matrix file) into a single struct
+- **Scatter-Gather**: Parallel processing of multiple samples with array-based outputs
+
+## Extending the Pipeline
+
+This pipeline can be extended by:
+- Exposing `ww-singler`'s custom `reference_rds` input at the pipeline level for organism/cell-type combinations not covered by celldex
+- Adding multi-sample integration (e.g. batch correction) before or after clustering
+- Adding doublet detection upstream of QC filtering
+- Adding ambient RNA correction (e.g. `ww-cellbender`) upstream of `ww-dropletutils`
+
+## Related WILDS Components
+
+- **ww-dropletutils module**: 10x matrix loading and empty droplet calling
+- **ww-scran module**: QC filtering, normalization, and HVG selection
+- **ww-scater module**: PCA/UMAP dimensionality reduction and visualization
+- **ww-singler module**: Clustering, marker genes, and cell-type annotation
+- **Other pipelines**: Additional integration examples
+
+## Support
+
+For questions, bugs, and/or feature requests, reach out to the Fred Hutch Office of the Chief Data Officer (OCDO) at wilds@fredhutch.org, or open an issue on the [WILDS WDL Library issue tracker](https://github.com/getwilds/wilds-wdl-library/issues).
+
+## Contributing
+
+If you would like to contribute to this WILDS WDL pipeline, please see our [contributing guidelines](https://github.com/getwilds/wilds-wdl-library/blob/main/.github/CONTRIBUTING.md) for more details.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for details.

--- a/pipelines/ww-bioc-sc/inputs.json
+++ b/pipelines/ww-bioc-sc/inputs.json
@@ -1,0 +1,22 @@
+{
+  "bioc_sc.samples": [
+    {
+      "name": "sample1",
+      "h5_matrix": "/path/to/sample1_filtered_feature_bc_matrix.h5"
+    },
+    {
+      "name": "sample2",
+      "raw_h5_matrix": "/path/to/sample2_raw_feature_bc_matrix.h5"
+    }
+  ],
+  "bioc_sc.mito_pattern": "^MT-",
+  "bioc_sc.nmads": 3.0,
+  "bioc_sc.n_hvgs": 2000,
+  "bioc_sc.n_pcs": 50,
+  "bioc_sc.reference_dataset": "HumanPrimaryCellAtlasData",
+  "bioc_sc.reference_ensembl": true,
+  "bioc_sc.label_column": "label.main",
+  "bioc_sc.cpu_cores": 2,
+  "bioc_sc.memory_gb": 8,
+  "bioc_sc.singler_memory_gb": 16
+}

--- a/pipelines/ww-bioc-sc/module.json
+++ b/pipelines/ww-bioc-sc/module.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openwdl/wdl/8199dd7e3f17322e827225d6e6bc886dac139207/modules/schemas/module.schema.json",
+  "name": "ww-bioc-sc",
+  "license": "MIT",
+  "authors": [
+    "Taylor Firman <tfirman@fredhutch.org>"
+  ],
+  "description": "WILDS WDL pipeline for standard Bioconductor/OSCA single-cell RNA-seq post-processing: load matrix, QC filter, normalize, HVG selection, dimensionality reduction, clustering, marker genes, and cell-type annotation",
+  "repository": "https://github.com/getwilds/wilds-wdl-library",
+  "homepage": "https://getwilds.org/",
+  "entrypoint": "ww-bioc-sc.wdl",
+  "readme": "README.md",
+  "dependencies": {
+    "ww_dropletutils": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-dropletutils"
+    },
+    "ww_scran": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-scran"
+    },
+    "ww_scater": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-scater"
+    },
+    "ww_singler": {
+      "git": "https://github.com/getwilds/wilds-wdl-library",
+      "branch": "main",
+      "path": "modules/ww-singler"
+    }
+  }
+}

--- a/pipelines/ww-bioc-sc/testrun.wdl
+++ b/pipelines/ww-bioc-sc/testrun.wdl
@@ -1,0 +1,122 @@
+version 1.0
+
+import "../../modules/ww-testdata/ww-testdata.wdl" as ww_testdata
+import "./ww-bioc-sc.wdl" as bioc_sc_workflow
+
+struct SingleCellSample {
+    String name
+    File? h5_matrix
+    File? raw_h5_matrix
+}
+
+workflow bioc_sc_example {
+  # Download a raw (unfiltered) 10x Genomics H5 matrix of human PBMCs
+  call ww_testdata.download_10x_raw_h5_data { }
+
+  SingleCellSample sample1 = {
+    "name": "pbmc_10k_v3",
+    "raw_h5_matrix": download_10x_raw_h5_data.raw_h5_matrix
+  }
+
+  # Run the full pipeline. Human PBMC data lets emptyDrops call real cells
+  # from the raw matrix and lets ww-singler annotate against the default
+  # HumanPrimaryCellAtlasData reference with biologically meaningful results.
+  call bioc_sc_workflow.bioc_sc { input:
+      samples = [sample1],
+      mito_pattern = "^MT-",
+      cpu_cores = 2,
+      memory_gb = 4,
+      singler_memory_gb = 8
+  }
+
+  output {
+    Array[File] sce_rds = bioc_sc.sce_rds
+    Array[File?] empty_drops_csv = bioc_sc.empty_drops_csv
+    Array[File?] barcode_rank_plot = bioc_sc.barcode_rank_plot
+    Array[File] scran_sce_object = bioc_sc.scran_sce_object
+    Array[File] scran_qc_plot = bioc_sc.scran_qc_plot
+    Array[File] scran_size_factor_plot = bioc_sc.scran_size_factor_plot
+    Array[File] scran_mean_variance_plot = bioc_sc.scran_mean_variance_plot
+    Array[File] scran_hvg_table = bioc_sc.scran_hvg_table
+    Array[File] scater_sce_object = bioc_sc.scater_sce_object
+    Array[File] scater_pca_plot = bioc_sc.scater_pca_plot
+    Array[File] scater_umap_plot = bioc_sc.scater_umap_plot
+    Array[File] scater_qc_plot = bioc_sc.scater_qc_plot
+    Array[File] singler_sce_object = bioc_sc.singler_sce_object
+    Array[File] singler_cluster_table = bioc_sc.singler_cluster_table
+    Array[File] singler_marker_table = bioc_sc.singler_marker_table
+    Array[File] singler_prediction_table = bioc_sc.singler_prediction_table
+    File validation_report = validate_outputs.report
+  }
+
+  call validate_outputs { input:
+      singler_sce_object = bioc_sc.singler_sce_object,
+      singler_cluster_table = bioc_sc.singler_cluster_table,
+      singler_marker_table = bioc_sc.singler_marker_table,
+      singler_prediction_table = bioc_sc.singler_prediction_table
+  }
+}
+
+task validate_outputs {
+  meta {
+    description: "Validate that all expected ww-bioc-sc output files were generated correctly"
+    outputs: {
+        report: "Validation report summarizing file checks"
+    }
+  }
+
+  parameter_meta {
+    singler_sce_object: "Array of final SingleCellExperiment RDS objects"
+    singler_cluster_table: "Array of per-cell cluster assignment CSVs"
+    singler_marker_table: "Array of per-cluster marker gene CSVs"
+    singler_prediction_table: "Array of per-cluster SingleR prediction CSVs"
+  }
+
+  input {
+    Array[File] singler_sce_object
+    Array[File] singler_cluster_table
+    Array[File] singler_marker_table
+    Array[File] singler_prediction_table
+  }
+
+  command <<<
+    set -eo pipefail
+
+    echo "=== ww-bioc-sc Pipeline Validation Report ===" > validation_report.txt
+    echo "Generated on: $(date)" >> validation_report.txt
+    echo "" >> validation_report.txt
+
+    validation_passed=true
+
+    for file_path in ~{sep=" " singler_sce_object} ~{sep=" " singler_cluster_table} ~{sep=" " singler_marker_table} ~{sep=" " singler_prediction_table}; do
+      if [[ -f "$file_path" && -s "$file_path" ]]; then
+        file_size=$(stat -c%s "$file_path")
+        echo "$(basename $file_path): PASSED (${file_size} bytes)" >> validation_report.txt
+      else
+        echo "$(basename $file_path): MISSING OR EMPTY" >> validation_report.txt
+        validation_passed=false
+      fi
+    done
+
+    echo "" >> validation_report.txt
+    echo "=== Validation Summary ===" >> validation_report.txt
+    if [[ "$validation_passed" == "true" ]]; then
+      echo "Overall Status: PASSED" >> validation_report.txt
+    else
+      echo "Overall Status: FAILED" >> validation_report.txt
+      exit 1
+    fi
+
+    cat validation_report.txt
+  >>>
+
+  output {
+    File report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+    memory: "2 GB"
+    cpu: 1
+  }
+}

--- a/pipelines/ww-bioc-sc/testrun.wdl
+++ b/pipelines/ww-bioc-sc/testrun.wdl
@@ -10,12 +10,20 @@ struct SingleCellSample {
 }
 
 workflow bioc_sc_example {
+  input {
+    File? no_h5_matrix
+  }
+
   # Download a raw (unfiltered) 10x Genomics H5 matrix of human PBMCs
   call ww_testdata.download_10x_raw_h5_data { }
 
-  SingleCellSample sample1 = {
-    "name": "pbmc_10k_v3",
-    "raw_h5_matrix": download_10x_raw_h5_data.raw_h5_matrix
+  # WDL struct literals must specify every member (optional fields included)
+  # when constructed as an object; no_h5_matrix is left undefined so
+  # h5_matrix evaluates to null, since this sample uses raw_h5_matrix
+  SingleCellSample sample1 = object {
+    name: "pbmc_10k_v3",
+    h5_matrix: no_h5_matrix,
+    raw_h5_matrix: download_10x_raw_h5_data.raw_h5_matrix
   }
 
   # Run the full pipeline. Human PBMC data lets emptyDrops call real cells

--- a/pipelines/ww-bioc-sc/ww-bioc-sc.wdl
+++ b/pipelines/ww-bioc-sc/ww-bioc-sc.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-dropletutils/ww-dropletutils.wdl" as dropletutils_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scran/ww-scran.wdl" as scran_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scater/ww-scater.wdl" as scater_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-singler/ww-singler.wdl" as singler_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-bioc-sc/modules/ww-dropletutils/ww-dropletutils.wdl" as dropletutils_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-bioc-sc/modules/ww-scran/ww-scran.wdl" as scran_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-bioc-sc/modules/ww-scater/ww-scater.wdl" as scater_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-bioc-sc/modules/ww-singler/ww-singler.wdl" as singler_tasks
 
 struct SingleCellSample {
     String name

--- a/pipelines/ww-bioc-sc/ww-bioc-sc.wdl
+++ b/pipelines/ww-bioc-sc/ww-bioc-sc.wdl
@@ -1,0 +1,144 @@
+version 1.0
+
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-dropletutils/ww-dropletutils.wdl" as dropletutils_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scran/ww-scran.wdl" as scran_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scater/ww-scater.wdl" as scater_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-singler/ww-singler.wdl" as singler_tasks
+
+struct SingleCellSample {
+    String name
+    File? h5_matrix
+    File? raw_h5_matrix
+}
+
+workflow bioc_sc {
+  meta {
+    author: [
+        {
+            name: "Taylor Firman",
+            email: "tfirman@fredhutch.org"
+        }
+    ]
+    description: "WDL pipeline for standard Bioconductor/OSCA single-cell RNA-seq post-processing: load matrix, QC filter, normalize, select highly variable genes, run dimensionality reduction, cluster, identify marker genes, and annotate cell types"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/pipelines/ww-bioc-sc/ww-bioc-sc.wdl"
+    outputs: {
+        sce_rds: "Array of loaded SingleCellExperiment RDS objects for each sample, prior to QC/normalization",
+        empty_drops_csv: "Array of per-barcode emptyDrops statistics for samples provided as a raw matrix (empty for samples provided pre-filtered)",
+        barcode_rank_plot: "Array of barcode-rank QC plots for samples provided as a raw matrix (empty for samples provided pre-filtered)",
+        scran_sce_object: "Array of normalized SingleCellExperiment RDS objects with size factors and PCA for each sample",
+        scran_qc_plot: "Array of per-cell QC scatter plots from scran for each sample",
+        scran_size_factor_plot: "Array of size factor histograms for each sample",
+        scran_mean_variance_plot: "Array of mean-variance trend plots for each sample",
+        scran_hvg_table: "Array of CSVs of genes ranked by biological variance for each sample",
+        scater_sce_object: "Array of SingleCellExperiment RDS objects with PCA and UMAP embeddings for each sample",
+        scater_pca_plot: "Array of PCA scatter plots for each sample",
+        scater_umap_plot: "Array of UMAP scatter plots for each sample",
+        scater_qc_plot: "Array of per-cell QC scatter plots from scater for each sample",
+        singler_sce_object: "Array of final SingleCellExperiment RDS objects with cluster assignments and predicted cell types for each sample",
+        singler_cluster_table: "Array of CSVs mapping cell barcodes to clusters for each sample",
+        singler_marker_table: "Array of CSVs of top marker genes per cluster for each sample",
+        singler_prediction_table: "Array of CSVs of SingleR cell-type predictions for each sample"
+    }
+  }
+
+  parameter_meta {
+    samples: "List of single-cell sample objects, each with a name and either a pre-filtered 10x feature-barcode matrix (h5_matrix) or a raw, unfiltered one (raw_h5_matrix). Exactly one of the two must be provided per sample; if raw_h5_matrix is given, real cells are called with emptyDrops before QC"
+    mito_pattern: "Regex pattern identifying mitochondrial gene symbols, passed to ww-scran"
+    nmads: "Number of median absolute deviations from the median used to flag low-quality cells, passed to ww-scran"
+    n_hvgs: "Number of top highly variable genes to select in ww-scran and use for PCA in ww-scater"
+    n_pcs: "Number of principal components to compute in ww-scater"
+    reference_dataset: "Name of the celldex reference dataset function to fetch for cell-type annotation, passed to ww-singler"
+    reference_ensembl: "Fetch the celldex reference with Ensembl gene IDs instead of gene symbols, passed to ww-singler"
+    label_column: "Column name in the reference object's colData containing cell-type labels, passed to ww-singler"
+    cpu_cores: "Number of CPU cores allocated per task"
+    memory_gb: "Memory allocated in GB for ww-dropletutils, ww-scran, and ww-scater tasks"
+    singler_memory_gb: "Memory allocated in GB for ww-singler tasks (higher default since celldex reference loading and clustering need more headroom)"
+  }
+
+  input {
+    Array[SingleCellSample] samples
+    String mito_pattern = "^MT-"
+    Float nmads = 3.0
+    Int n_hvgs = 2000
+    Int n_pcs = 50
+    String reference_dataset = "HumanPrimaryCellAtlasData"
+    Boolean reference_ensembl = true
+    String label_column = "label.main"
+    Int cpu_cores = 2
+    Int memory_gb = 8
+    Int singler_memory_gb = 16
+  }
+
+  scatter (sample in samples) {
+    # Pre-filtered matrix path
+    if (defined(sample.h5_matrix)) {
+      call dropletutils_tasks.read10x_counts { input:
+          h5_matrix = select_first([sample.h5_matrix]),
+          sample_name = sample.name,
+          cpu_cores = cpu_cores,
+          memory_gb = memory_gb
+      }
+    }
+
+    # Raw (unfiltered) matrix path: call real cells with emptyDrops first
+    if (defined(sample.raw_h5_matrix)) {
+      call dropletutils_tasks.empty_drops_filter { input:
+          raw_h5_matrix = select_first([sample.raw_h5_matrix]),
+          sample_name = sample.name,
+          cpu_cores = cpu_cores,
+          memory_gb = memory_gb
+      }
+    }
+
+    File sample_sce_rds = select_first([read10x_counts.sce_rds, empty_drops_filter.filtered_sce_rds])
+
+    call scran_tasks.run_scran { input:
+        sce_rds = sample_sce_rds,
+        sample_name = sample.name,
+        mito_pattern = mito_pattern,
+        nmads = nmads,
+        n_hvgs = n_hvgs,
+        cpu_cores = cpu_cores,
+        memory_gb = memory_gb
+    }
+
+    call scater_tasks.run_scater { input:
+        sce_rds = run_scran.sce_object,
+        hvg_list = run_scran.hvg_list,
+        sample_name = sample.name,
+        n_pcs = n_pcs,
+        n_hvgs = n_hvgs,
+        cpu_cores = cpu_cores,
+        memory_gb = memory_gb
+    }
+
+    call singler_tasks.run_singler { input:
+        sce_rds = run_scater.sce_object,
+        sample_name = sample.name,
+        reference_dataset = reference_dataset,
+        reference_ensembl = reference_ensembl,
+        label_column = label_column,
+        cpu_cores = cpu_cores,
+        memory_gb = singler_memory_gb
+    }
+  }
+
+  output {
+    Array[File] sce_rds = sample_sce_rds
+    Array[File?] empty_drops_csv = empty_drops_filter.empty_drops_csv
+    Array[File?] barcode_rank_plot = empty_drops_filter.barcode_rank_pdf
+    Array[File] scran_sce_object = run_scran.sce_object
+    Array[File] scran_qc_plot = run_scran.qc_plot
+    Array[File] scran_size_factor_plot = run_scran.size_factor_plot
+    Array[File] scran_mean_variance_plot = run_scran.mean_variance_plot
+    Array[File] scran_hvg_table = run_scran.hvg_table
+    Array[File] scater_sce_object = run_scater.sce_object
+    Array[File] scater_pca_plot = run_scater.pca_plot
+    Array[File] scater_umap_plot = run_scater.umap_plot
+    Array[File] scater_qc_plot = run_scater.qc_plot
+    Array[File] singler_sce_object = run_singler.sce_object
+    Array[File] singler_cluster_table = run_singler.cluster_table
+    Array[File] singler_marker_table = run_singler.marker_table
+    Array[File] singler_prediction_table = run_singler.prediction_table
+  }
+}


### PR DESCRIPTION
## Type of Change

- New pipeline

## Description

Adds `ww-bioc-sc`, a new WILDS WDL pipeline chaining the four Bioconductor/OSCA single-cell RNA-seq modules built out over the last several PRs: [`ww-dropletutils`](https://github.com/getwilds/wilds-wdl-library/pull/386) -> [`ww-scran`](https://github.com/getwilds/wilds-wdl-library/pull/387) -> [`ww-scater`](https://github.com/getwilds/wilds-wdl-library/pull/389) -> [`ww-singler`](https://github.com/getwilds/wilds-wdl-library/pull/390). This is the pipeline referenced in issue #333's Bioconductor/OSCA stack scope, following the standard post-processing chain: load matrix -> QC filter -> normalize -> HVG -> PCA -> UMAP -> clustering -> marker genes -> cell-type annotation.

**Complexity level:** Intermediate (4 modules)

Key design points:

- **Struct-based sample input**: `SingleCellSample` accepts either a pre-filtered (`h5_matrix`) or raw, unfiltered (`raw_h5_matrix`) 10x feature-barcode matrix per sample. Raw matrices are routed through `ww-dropletutils.empty_drops_filter` (real-cell calling via `emptyDrops`) before QC; pre-filtered matrices go straight into `ww-dropletutils.read10x_counts`.
- **Cross-module reuse**: `ww-scater` reuses `ww-scran`'s highly variable gene selection via the `hvg_list` output/input added to those two modules specifically to support this pipeline, avoiding redundant HVG recomputation while keeping each module independently usable on its own.
- **Per-task resource tuning**: `ww-singler` gets its own `singler_memory_gb` (default 16) input, separate from the shared `memory_gb` (default 8) used by the other three tasks, since celldex reference loading and clustering need more headroom.

This branch is stacked on `add-singler` (which stacks on `add-scater`, which stacks on `add-scran`), since the pipeline imports all four modules and `testrun.wdl` exercises the full chain. **This PR should merge into `add-singler`, not `main`**, as part of the same stack as the four module PRs.

## Related Issue

Related to #333

## Testing

**How did you test these changes?**
Ran `make lint NAME=ww-bioc-sc`, see CI/CD test run executions below.

**What workflow engine did you use?**
Sprocket, Cromwell, and miniWDL

**Did the tests pass?**
Yes, linting and the CI/CD test run both pass.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [ ] I ran `make docs` to check documentation rendering (if applicable)

