### PR TITLE
Testing BiocJobs functionality in ww-deseq2

### DIFF
--- a/modules/ww-deseq2/testrun.wdl
+++ b/modules/ww-deseq2/testrun.wdl
@@ -1,7 +1,10 @@
 version 1.0
 
-import "../ww-testdata/ww-testdata.wdl" as ww_testdata
-import "./ww-deseq2.wdl" as ww_deseq2
+# import "../ww-testdata/ww-testdata.wdl" as ww_testdata
+# import "./ww-deseq2.wdl" as ww_deseq2
+
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/deseq2-bioc-test/modules/ww-deseq2/ww-deseq2.wdl" as ww_deseq2
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/deseq2-bioc-test/modules/ww-testdata/ww-testdata.wdl" as ww_testdata
 
 workflow deseq2_example {
   # Generate test data
@@ -208,7 +211,7 @@ try:
     results_df = pd.read_csv("~{results}", sep="\t")
     print(f"Results file loaded: {len(results_df)} genes")
 
-    required_cols = ["baseMean", "log2FoldChange", "lfcSE", "stat", "pvalue", "padj"]
+    required_cols = ["baseMean", "log2FoldChange", "lfcSE", "pvalue", "padj"]
     missing_cols = [col for col in required_cols if col not in results_df.columns]
     if missing_cols:
         validation_issues.append(f"Missing required columns in results: {missing_cols}")

--- a/modules/ww-deseq2/testrun.wdl
+++ b/modules/ww-deseq2/testrun.wdl
@@ -26,10 +26,25 @@ workflow deseq2_example {
       contrast = ""
   }
 
+  call ww_deseq2.run_deseq2_biocjobs { input:
+      counts = combine_count_matrices.counts_matrix,
+      coldata = combine_count_matrices.sample_metadata,
+      design = "~ condition",
+      contrast_factor = "condition",
+      contrast_numerator = "treated",
+      contrast_denominator = "untreated"
+  }
+
   call validate_outputs { input:
       deseq2_results = run_deseq2.deseq2_results,
       deseq2_significant = run_deseq2.deseq2_significant,
       normalized_counts = run_deseq2.deseq2_normalized_counts,
+      expected_samples = length(generate_test_data.sample_names)
+  }
+
+  call validate_biocjobs_outputs { input:
+      results = run_deseq2_biocjobs.results,
+      normalized_counts = run_deseq2_biocjobs.normalized_counts,
       expected_samples = length(generate_test_data.sample_names)
   }
 
@@ -43,6 +58,10 @@ workflow deseq2_example {
     File deseq2_volcano_plot = run_deseq2.deseq2_volcano_plot
     File deseq2_heatmap = run_deseq2.deseq2_heatmap
     File validation_report = validate_outputs.validation_report
+    File biocjobs_results = run_deseq2_biocjobs.results
+    File biocjobs_normalized_counts = run_deseq2_biocjobs.normalized_counts
+    File biocjobs_ma_plot = run_deseq2_biocjobs.ma_plot
+    File biocjobs_validation_report = validate_biocjobs_outputs.validation_report
   }
 }
 
@@ -127,6 +146,100 @@ with open("validation_report.txt", "w") as f:
     f.write("DESeq2 Output Validation Report\n")
     f.write("=" * 35 + "\n\n")
     
+    if validation_issues:
+        f.write("VALIDATION FAILED\n")
+        f.write("Issues found:\n")
+        for issue in validation_issues:
+            f.write(f"- {issue}\n")
+        sys.exit(1)
+    else:
+        f.write("VALIDATION PASSED\n")
+        f.write("All outputs validated successfully.\n")
+
+EOF
+
+    echo "Validation completed successfully"
+  >>>
+
+  output {
+    File validation_report = "validation_report.txt"
+  }
+
+  runtime {
+    docker: "getwilds/python-utils:0.1.0"
+    memory: "2 GB"
+    cpu: 1
+  }
+}
+
+task validate_biocjobs_outputs {
+  meta {
+    description: "Validate run_deseq2_biocjobs outputs for correctness and completeness"
+    outputs: {
+        validation_report: "Report summarizing validation results and any issues found"
+    }
+  }
+
+  parameter_meta {
+    results: "biocjobs DESeq2 results file to validate"
+    normalized_counts: "biocjobs normalized counts file to validate"
+    expected_samples: "Expected number of samples in the analysis"
+    expected_genes_min: "Minimum expected number of genes in results"
+  }
+
+  input {
+    File results
+    File normalized_counts
+    Int expected_samples
+    Int expected_genes_min = 1000
+  }
+
+  command <<<
+    set -eo pipefail
+
+    python3 << 'EOF'
+import pandas as pd
+import sys
+
+validation_issues = []
+
+# Validate main results file
+try:
+    results_df = pd.read_csv("~{results}", sep="\t")
+    print(f"Results file loaded: {len(results_df)} genes")
+
+    required_cols = ["baseMean", "log2FoldChange", "lfcSE", "stat", "pvalue", "padj"]
+    missing_cols = [col for col in required_cols if col not in results_df.columns]
+    if missing_cols:
+        validation_issues.append(f"Missing required columns in results: {missing_cols}")
+    else:
+        print("All required columns present in results")
+
+    if len(results_df) < ~{expected_genes_min}:
+        validation_issues.append(f"Too few genes in results: {len(results_df)} < ~{expected_genes_min}")
+
+except Exception as e:
+    validation_issues.append(f"Failed to validate results file: {str(e)}")
+
+# Validate normalized counts
+try:
+    counts_df = pd.read_csv("~{normalized_counts}", sep="\t", index_col=0)
+    print(f"Normalized counts loaded: {counts_df.shape[0]} genes, {counts_df.shape[1]} samples")
+
+    if counts_df.shape[1] != ~{expected_samples}:
+        validation_issues.append(f"Expected ~{expected_samples} samples, got {counts_df.shape[1]}")
+
+    if (counts_df < 0).any().any():
+        validation_issues.append("Negative values found in normalized counts")
+
+except Exception as e:
+    validation_issues.append(f"Failed to validate normalized counts: {str(e)}")
+
+# Write validation report
+with open("validation_report.txt", "w") as f:
+    f.write("run_deseq2_biocjobs Output Validation Report\n")
+    f.write("=" * 45 + "\n\n")
+
     if validation_issues:
         f.write("VALIDATION FAILED\n")
         f.write("Issues found:\n")

--- a/modules/ww-deseq2/ww-deseq2.wdl
+++ b/modules/ww-deseq2/ww-deseq2.wdl
@@ -177,6 +177,97 @@ task run_deseq2 {
   }
 }
 
+task run_deseq2_biocjobs {
+  meta {
+    author: "Taylor Firman"
+    email: "tfirman@fredhutch.org"
+    description: "Run the canonical DESeq2 differential expression workflow on a raw count matrix using the biocjobs package"
+    url: "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-deseq2/ww-deseq2.wdl"
+    outputs: {
+        results: "Per-gene DESeq2 results table with log2 fold changes and adjusted p-values",
+        normalized_counts: "Median-of-ratios normalized count values for all samples",
+        ma_plot: "MA plot showing log fold change vs. mean expression"
+    }
+    topic: "transcriptomics,gene_expression"
+    species: "human,eukaryote,prokaryote,virus"
+    operation: "statistical_calculation"
+    input_sample_required: "counts:gene_expression_matrix:tsv,coldata:report:tsv"
+    input_sample_optional: "none"
+    input_reference_required: "none"
+    input_reference_optional: "none"
+    output_sample: "results:report:tsv,normalized_counts:report:tsv,ma_plot:plot:pdf"
+    output_reference: "none"
+    biocjobs_package: "DESeq2"
+    biocjobs_job: "deseq2-differential-expression"
+    biocjobs_job_version: "1.0.0"
+  }
+  
+  parameter_meta {
+    counts: "Raw count matrix. Tab-separated matrix of raw (un-normalized) integer read counts: first column gene identifiers, one further column per sample. Do not supply TPM/FPKM or otherwise normalized values.. Format: tsv."
+    coldata: "Sample table. Tab-separated sample annotation: first column sample identifiers matching the count matrix column names, one further column per covariate (e.g. condition, batch). Every variable used in the design formula must be a column of this table.. Format: tsv."
+    design: "Design formula. R formula over sample table columns. Control for covariates by putting them first; the tested variable comes last (e.g. \"~ batch + condition\")."
+    contrast_factor: "Factor to test. Sample table column containing the tested condition."
+    contrast_numerator: "Treatment level (numerator). Level of the tested factor whose effect is reported."
+    contrast_denominator: "Reference level (denominator). Baseline level the treatment is compared against."
+    alpha: "FDR threshold (alpha). Significance cutoff used to optimize independent filtering. Set it to the adjusted p-value threshold you will actually use.. Range: 0 to 1."
+    shrinkage: "Log2 fold change shrinkage. Shrinkage estimator applied to the reported log2 fold changes; \"apeglm\" is the recommended default, \"none\" reports maximum likelihood estimates.. One of: apeglm, ashr, normal, none."
+    prefilter: "Pre-filter low-count genes. Remove genes with insufficient counts before testing."
+    prefilter_min_count: "Pre-filter minimum count. Range: 1 to Inf."
+    prefilter_min_samples: "Pre-filter minimum samples. Keep genes with at least the minimum count in at least this many samples. 0 (default) means automatic: the size of the smallest group of the tested factor.. Range: 0 to Inf."
+    memory_gb: "Memory allocated for the task in GB"
+    cpu_cores: "Number of CPU cores allocated for the task"
+    docker_image: "Docker image to use for this task"
+  }
+
+  input {
+    File counts
+    File coldata
+    String design = "~ condition"
+    String contrast_factor
+    String contrast_numerator
+    String contrast_denominator
+    String alpha = "0.1"
+    String shrinkage = "apeglm"
+    Boolean prefilter = true
+    Int prefilter_min_count = 10
+    Int prefilter_min_samples = 0
+    Int memory_gb = 8
+    Int cpu_cores = 2
+    String docker_image = "ghcr.io/almahmoud/deseq2:devel"
+  }
+
+  command <<<
+    set -euo pipefail
+    Rscript -e 'BiocJobs::execJob("DESeq2", "deseq2-differential-expression")' \
+      --counts '~{sub(counts, "'", "'\\''")}' \
+      --coldata '~{sub(coldata, "'", "'\\''")}' \
+      --design '~{sub(design, "'", "'\\''")}' \
+      --contrast_factor '~{sub(contrast_factor, "'", "'\\''")}' \
+      --contrast_numerator '~{sub(contrast_numerator, "'", "'\\''")}' \
+      --contrast_denominator '~{sub(contrast_denominator, "'", "'\\''")}' \
+      --alpha '~{sub(alpha, "'", "'\\''")}' \
+      --shrinkage '~{sub(shrinkage, "'", "'\\''")}' \
+      --prefilter ~{prefilter} \
+      --prefilter_min_count ~{prefilter_min_count} \
+      --prefilter_min_samples ~{prefilter_min_samples} \
+      --results 'results.tsv' \
+      --normalized_counts 'normalized_counts.tsv' \
+      --ma_plot 'ma_plot.pdf'
+  >>>
+
+  output {
+    File results = "results.tsv"
+    File normalized_counts = "normalized_counts.tsv"
+    File ma_plot = "ma_plot.pdf"
+  }
+
+  runtime {
+    docker: docker_image
+    cpu: cpu_cores
+    memory: "~{memory_gb} GB"
+  }
+}
+
 task compile_deseq2_results {
   meta {
     author: [


### PR DESCRIPTION
## Type of Change

- Other (exploratory investigation, not intended for merge)

## Description

Explored using the new [`BiocJobs`](https://github.com/almahmoud/BiocJobs) package, developed as part of the [BiocNA2026 Hackathon](https://github.com/BiocCodingCollaborations/BiocNA2026_Hackathon), to run standard Bioconductor functionality (here, DESeq2) as a WDL task, as an alternative to the hand-written `deseq2_analysis.R` script used by the existing `run_deseq2` task. The task command was adapted from `BiocJobs`' own [generated DESeq2 example WDL](https://github.com/almahmoud/BiocJobs/blob/main/examples/DESeq2/generated/deseq2_differential_expression.wdl).

Added a new `run_deseq2_biocjobs` task to `ww-deseq2.wdl` that calls `BiocJobs::execJob("DESeq2", "deseq2-differential-expression")` against the `ghcr.io/almahmoud/deseq2:devel` image (built from [almahmoud's DESeq2 fork](https://github.com/almahmoud/DESeq2/tree/devel), which carries the `biocjobs/` job spec DESeq2 itself doesn't ship yet), taking a raw count matrix and sample table and producing a results table, normalized counts, and an MA plot. `meta`/`parameter_meta` were brought in line with the rest of the module's conventions (author, email, url, outputs, topic/species/operation, input/output sample-reference fields), and the `runtime.memory` value was fixed to use the `"~{memory_gb} GB"` string format expected by the engines.

Wired the new task into `testrun.wdl`, reusing the existing `combine_count_matrices` outputs as `counts`/`coldata` inputs, and added a `validate_biocjobs_outputs` task to confirm the results table has the expected columns (`baseMean`, `log2FoldChange`, `lfcSE`, `pvalue`, `padj`) and that normalized counts match the expected sample count.

**Outcome:** the task runs successfully end-to-end and produces valid output. `BiocJobs` looks like a viable path for wrapping standard Bioconductor workflows going forward, but it's not ready to replace `run_deseq2` in this module yet, since it requires the target package (here, DESeq2, via almahmoud's fork) to ship its own `biocjobs/` job spec, which isn't broadly adopted across Bioconductor packages yet. Keeping this branch's history as a reference for when `BiocJobs` adoption is further along, rather than merging it now.

## Testing

**How did you test these changes?**
Ran `testrun.wdl` end-to-end via `sprocket run`, including the new `run_deseq2_biocjobs` call and its `validate_biocjobs_outputs` check. Also ran the CI/CD test runs in the GitHub Action checks below.

**What workflow engine did you use?**
Sprocket, Cromwell, and miniwdl.

**Did the tests pass?**
Yes, after two fixes along the way: an initial failure because the `ghcr.io/almahmoud/deseq2:devel` image didn't yet have a working `biocjobs/DESeq2` job spec installed, and a second failure because the validation task incorrectly expected a `stat` column that `BiocJobs`' results output doesn't produce. Both were resolved and the final run passed validation.

## Documentation

- [x] ~~I updated the README (if applicable)~~
- [x] I added/updated parameter descriptions in the WDL (if applicable)
- [x] ~~I ran `make docs-preview` to check documentation rendering (if applicable)~~

## Additional Context

This PR is not intended to be merged. `run_deseq2_biocjobs` depends on an unpinned, non-`getwilds/*` development image (`ghcr.io/almahmoud/deseq2:devel`, built from [almahmoud's DESeq2 fork](https://github.com/almahmoud/DESeq2/tree/devel)) and duplicates functionality already provided by `run_deseq2`. The branch is being kept open (and this PR filed) purely to document that the [`BiocJobs`](https://github.com/almahmoud/BiocJobs) approach (from the [BiocNA2026 Hackathon](https://github.com/BiocCodingCollaborations/BiocNA2026_Hackathon)) works, for future reference once the package sees wider adoption across Bioconductor tools. Plan is to close this PR and delete the branch after review.
