### PR TITLE
Fix stale branch URLs in `ww-bioc-sc`, `ww-scater`, `ww-scran`, and `ww-singler`

### DIFF
--- a/modules/ww-scater/ww-scater.wdl
+++ b/modules/ww-scater/ww-scater.wdl
@@ -55,7 +55,7 @@ task run_scater {
     set -eo pipefail
 
     curl -so scater_analysis.R \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-scater/modules/ww-scater/scater_analysis.R"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scater/scater_analysis.R"
 
     Rscript scater_analysis.R \
       --sce_rds="~{sce_rds}" \

--- a/modules/ww-scran/ww-scran.wdl
+++ b/modules/ww-scran/ww-scran.wdl
@@ -57,7 +57,7 @@ task run_scran {
     set -eo pipefail
 
     curl -so scran_analysis.R \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-scran/modules/ww-scran/scran_analysis.R"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scran/scran_analysis.R"
 
     Rscript scran_analysis.R \
       --sce_rds="~{sce_rds}" \

--- a/modules/ww-singler/ww-singler.wdl
+++ b/modules/ww-singler/ww-singler.wdl
@@ -59,7 +59,7 @@ task run_singler {
     set -eo pipefail
 
     curl -so singler_analysis.R \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-singler/modules/ww-singler/singler_analysis.R"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-singler/singler_analysis.R"
 
     Rscript singler_analysis.R \
       --sce_rds="~{sce_rds}" \

--- a/pipelines/ww-bioc-sc/ww-bioc-sc.wdl
+++ b/pipelines/ww-bioc-sc/ww-bioc-sc.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-bioc-sc/modules/ww-dropletutils/ww-dropletutils.wdl" as dropletutils_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-bioc-sc/modules/ww-scran/ww-scran.wdl" as scran_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-bioc-sc/modules/ww-scater/ww-scater.wdl" as scater_tasks
-import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/add-bioc-sc/modules/ww-singler/ww-singler.wdl" as singler_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-dropletutils/ww-dropletutils.wdl" as dropletutils_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scran/ww-scran.wdl" as scran_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-scater/ww-scater.wdl" as scater_tasks
+import "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-singler/ww-singler.wdl" as singler_tasks
 
 struct SingleCellSample {
     String name


### PR DESCRIPTION
## Type of Change

- Bug fix

## Description

Fixed leftover import and script URLs in `ww-bioc-sc`, `ww-scater`, `ww-scran`, and `ww-singler` that still pointed to their original feature branches (`add-bioc-sc`, `add-scater`, `add-scran`, `add-singler`) instead of `main`. All `raw.githubusercontent.com` URLs now point to `refs/heads/main`.

## Testing

**How did you test these changes?**
No functional change, but see GitHub Actions test runs below.

**What workflow engine did you use?**
Cromwell, miniwdl, Sprocket.

**Did the tests pass?**
Yes.