### PR TITLE
Describe how to use ontology

### DIFF
--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -41,8 +41,18 @@ Create four files in `modules/ww-$ARGUMENTS/`:
 - Add a header comment block describing the module
 - Define task(s) with the tool's core functionality
 - Every task MUST have:
-  - `meta` block with: author, email, description, url, outputs
+  - `meta` block with: author, email, description, url, outputs, and ontology-related fields
     - Use `author: "WILDS Team"` and `email: "wilds@fredhutch.org"` as placeholders — the actual contributor will replace these in review
+    - Ontology-related fields: read the "Ontology metadata" section of [.github/CONTRIBUTING.md](../../../.github/CONTRIBUTING.md) for the full field definitions and conventions (e.g. using `"any"` for non-specific tasks, or `|` to separate multiple formats for one parameter). Fill in these fields on the task's `meta` block:
+      - `topic`
+      - `species`
+      - `operation`
+      - `input_sample_required`
+      - `input_sample_optional`
+      - `input_reference_required`
+      - `input_reference_optional`
+      - `output_sample`
+      - `output_reference`
   - `parameter_meta` block describing every input
   - `input` block with typed parameters; include `cpu_cores` (Int, default sensible), `memory_gb` (Int, default sensible), and `String docker_image = "getwilds/$ARGUMENTS:<version>"` (pinned, never `latest`)
   - `command <<<` block starting with `set -eo pipefail`, using `~{var}` interpolation

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -119,14 +119,15 @@ For modules where CI execution is impractical (GPU-only tools, license-gated too
 - **Version declaration**: Use WDL version 1.0 (default). Use `version 1.2` only when a feature unavailable in 1.0 is required (e.g., the `Directory` type); document the reason in the module README. Note that WDL 1.2 modules are not tested with Cromwell.
 - **Task definitions**: Individual tasks with proper resource requirements
 - **Metadata documentation**: Describe properties of tasks (e.g. inputs, outputs) using `meta` and `parameter_meta` blocks
-- **Optional metadata**: Include the following metadata tags in each task's `meta` block to describe the task with [EDAM ontology](https://www.ebi.ac.uk/ols4/ontologies/edam) terms (using underscores instead of spaces):
+- **Ontology metadata**: Include the following metadata tags in each task's `meta` block to describe the task and its `File` parameters with [EDAM ontology](https://www.ebi.ac.uk/ols4/ontologies/edam) terms (using underscores instead of spaces):
   - **`topic`**: Comma-separated EDAM `topic` terms describing the bioinformatics topic and data type(s) the task handles. For example, a DNA variant caller for SNPs would be `"genomics,dna_polymorphism"`. Use `"any"` for tasks that are very non-specific (e.g. downloading data from AWS).
-  - **`operation`**: An EDAM `operation` term describing what the task does (e.g. `"variant_calling"`). Use `"any"` for tasks that are very non-specific.
-  - **`species`**: Comma-separated list of species terms. Choose from: `human` (human data), `eukaryote` (non-human eukaryote data), `prokaryote` (prokaryote data), `virus` (viral data). Include all that apply. For example, a task that works on both human and mouse data should include both `human` and `eukaryote`.
+  - **`operation`**: An EDAM `operation` term describing what the task does (e.g. `"variant_calling"`). Use `"any"` for tasks that are extremely non-specific.
+  - **`species`**: Comma-separated list of species terms. Choose from: `human` (human data), `eukaryote` (non-human eukaryote data), `prokaryote` (prokaryote data), `virus` (viral data). Include all that apply. For example, a task that works on both human and mouse data would be `"human,eukaryote"`.
   - **File inputs/outputs**: Describe `File`-type parameters (not strings, integers, booleans, etc.) using the format `<param_name>:<EDAM data type>:<EDAM format type>`. Use `"none"` if a category has no files. For important but niche formats not in EDAM, you may use the file extension (e.g. `sig`, `csi`). Separate multiple formats per parameter with `|` (e.g. `"input_aln:nucleic_acid_sequence_alignment:bam|sam|cram"`). Use these metadata tags to describe file inputs/outputs:
     - Sample or run-specific data (e.g. target region BED file, sample FASTQ): `input_sample_required`, `input_sample_optional`
     - Reference data (e.g. allele frequencies, reference genome)`input_reference_required`, `input_reference_optional`
     - Output files (e.g. sample BAM, reference genome index)`output_sample`, `output_reference`
+    - Common `<file extension> = <EDAM format>` mappings: `txt` = `textual_format`; `rds` = `binary_format`; `zip` = the format of the file before the `.zip` (e.g. `.txt.zip` should be `textual_format`); `gz` = the format of the file before the `.gz` (e.g. `.tar.gz` should be `tar_format`)
 
 **Your test workflow file (`testrun.wdl` or `testrun_hpc.wdl`) must include:**
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,6 @@ Thank you for your interest in contributing to the WILDS WDL Library! This docum
 - [Module Development Guidelines](#module-development-guidelines)
 - [Pipeline Development Guidelines](#pipeline-development-guidelines)
 - [Testing Requirements](#testing-requirements)
-- [Documentation Standards](#documentation-standards)
 - [Documentation Website](#documentation-website)
 - [Citation and Attribution](#citation-and-attribution)
 - [Dockstore Registration](#dockstore-registration)

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Fred Hutch researchers can use [PROOF](https://sciwiki.fredhutch.org/datademos/p
 - **Standardized Structure**: Consistent organization across all components
 - **Container Management**: Versioned, tested Docker images from the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library)
 - **Documentation Standards**: Comprehensive README files and inline documentation
+- **Ontology-Described Metadata**: Tasks use custom metadata fields and [EDAM ontology](https://www.ebi.ac.uk/ols4/ontologies/edam) terms ([publication](https://pubmed.ncbi.nlm.nih.gov/23479348/)) to describe what each task does and its file inputs/outputs
 - **Version Control**: Semantic versioning and careful dependency management
 
 ## AI Disclosure


### PR DESCRIPTION
## Type of Change

- Documentation update

## Description

Added more information about how to write the ontology-related `meta` fields when creating a new module. 

Instead of making a new SKILL file, I added to the `create-module` one and pointed it to a more fleshed out `CONTRIBUTING.md`.

## Related Issue

Closes #394 

## Testing

**How did you test these changes?**
Asked an LLM to create a new module for `tcrconvert` and it did a good job with the ontology metadata.

**What workflow engine did you use?**
N/A

**Did the tests pass?**
N/A

## Documentation

- [X] I updated the README (if applicable)
- [ ] I added/updated parameter descriptions in the WDL (if applicable)
- [ ] I ran `make docs-preview` to check documentation rendering (if applicable)
