### PR TITLE
Fix read-only hub cache failure in `ww-singler` on Apptainer

### DIFF
--- a/modules/ww-singler/README.md
+++ b/modules/ww-singler/README.md
@@ -157,3 +157,4 @@ If you would like to contribute to this WILDS WDL module, please see our [contri
 ## License
 
 Distributed under the MIT License. See `LICENSE` for details.
+

--- a/modules/ww-singler/README.md
+++ b/modules/ww-singler/README.md
@@ -15,6 +15,12 @@ This module provides a reusable WDL task for graph-based clustering, per-cluster
 
 This module is intended to run downstream of [`ww-scater`](../ww-scater/) in the standard single-cell post-processing chain (load matrix -> QC filter -> normalize -> HVG -> PCA -> UMAP -> clustering -> marker genes -> cell-type annotation).
 
+### Reference dataset caching
+
+When a named celldex reference is used (the default), `celldex` 2.x fetches it through the `gypsum` backend. The `getwilds/singler:2.14.1` image bakes the `HumanPrimaryCellAtlasData` reference (both the gene-symbol and Ensembl-ID variants) into `/opt/hubcache/gypsum` so the annotation step does not need to download it at runtime.
+
+`gypsum` takes a write lock in its cache directory even when the requested data is already present, and the baked-in path is read-only under Apptainer. The `run_singler` task therefore copies the baked cache into the task working directory and points `GYPSUM_CACHE_DIR` at that writable copy before running the analysis script. This is transparent to callers; it just means a named `HumanPrimaryCellAtlasData` run works without network access to the celldex servers. Other celldex references (for example `MouseRNAseqData`) are not bundled and are still downloaded on first use.
+
 ## Module Structure
 
 This module is part of the [WILDS WDL Library](https://github.com/getwilds/wilds-wdl-library) and contains:
@@ -132,7 +138,7 @@ sprocket run testrun.wdl --entrypoint singler_example
 ## Requirements
 
 - WDL-compatible workflow executor (Cromwell, miniWDL, Sprocket, etc.)
-- Internet access for fetching scripts from GitHub and reference datasets from celldex at runtime
+- Internet access for fetching scripts from GitHub at runtime. The default `HumanPrimaryCellAtlasData` reference is baked into the container (see [Reference dataset caching](#reference-dataset-caching)), but any other celldex reference or a from-scratch fetch still needs network access to the celldex servers
 - R environment with scran, SingleR, and celldex (provided by `getwilds/singler:2.14.1` container)
 
 ## Citation

--- a/modules/ww-singler/singler_analysis.R
+++ b/modules/ww-singler/singler_analysis.R
@@ -5,25 +5,6 @@ library(SingleR)
 library(celldex)
 library(SingleCellExperiment)
 
-# TEMPORARY: verbose HTTP tracing to debug an intermittent
-# save_file()/array.h5 fetch failure seen only in Sprocket runs on HPC
-# (not reproducible via GitHub CI or any manual repro attempt so far).
-# Remove once root-caused.
-library(httr)
-httr::set_config(httr::verbose(data_out = TRUE, data_in = TRUE, info = TRUE, ssl = TRUE))
-message("DEBUG HOME = ", Sys.getenv("HOME"))
-writable <- function(p) if (nzchar(p)) file.access(p, mode = 2) == 0 else NA
-for (v in c("GYPSUM_CACHE_DIR", "ANNOTATION_HUB_CACHE", "EXPERIMENT_HUB_CACHE")) {
-  p <- Sys.getenv(v)
-  message("DEBUG ", v, " = ", p,
-          "  (exists=", dir.exists(p), " writable=", writable(p), ")")
-}
-message("DEBUG gypsum::cacheDirectory() = ",
-        tryCatch(gypsum::cacheDirectory(), error = function(e) paste("ERR:", conditionMessage(e))))
-message("DEBUG AnnotationHub cache dir = ",
-        tryCatch(tools::R_user_dir("AnnotationHub", "cache"),
-                 error = function(e) paste("ERR:", conditionMessage(e))))
-
 # Parse simple --key=value arguments (no optparse dependency; not present
 # in the getwilds/singler image)
 parse_args <- function(args, defaults) {

--- a/modules/ww-singler/singler_analysis.R
+++ b/modules/ww-singler/singler_analysis.R
@@ -12,6 +12,14 @@ library(SingleCellExperiment)
 library(httr)
 httr::set_config(httr::verbose(data_out = TRUE, data_in = TRUE, info = TRUE, ssl = TRUE))
 message("DEBUG HOME = ", Sys.getenv("HOME"))
+message("DEBUG GYPSUM_CACHE_DIR = ", Sys.getenv("GYPSUM_CACHE_DIR"))
+message("DEBUG gypsum::cacheDirectory() = ",
+        tryCatch(gypsum::cacheDirectory(), error = function(e) paste("ERR:", conditionMessage(e))))
+message("DEBUG baked cache present = ", dir.exists("/opt/hubcache/gypsum"))
+message("DEBUG seeded cache present = ",
+        dir.exists(file.path(getwd(), "gypsum-cache")))
+message("DEBUG gypsum cache writable = ",
+        file.access(Sys.getenv("GYPSUM_CACHE_DIR", "/nonexistent"), mode = 2) == 0)
 
 # Parse simple --key=value arguments (no optparse dependency; not present
 # in the getwilds/singler image)

--- a/modules/ww-singler/singler_analysis.R
+++ b/modules/ww-singler/singler_analysis.R
@@ -12,14 +12,17 @@ library(SingleCellExperiment)
 library(httr)
 httr::set_config(httr::verbose(data_out = TRUE, data_in = TRUE, info = TRUE, ssl = TRUE))
 message("DEBUG HOME = ", Sys.getenv("HOME"))
-message("DEBUG GYPSUM_CACHE_DIR = ", Sys.getenv("GYPSUM_CACHE_DIR"))
+writable <- function(p) if (nzchar(p)) file.access(p, mode = 2) == 0 else NA
+for (v in c("GYPSUM_CACHE_DIR", "ANNOTATION_HUB_CACHE", "EXPERIMENT_HUB_CACHE")) {
+  p <- Sys.getenv(v)
+  message("DEBUG ", v, " = ", p,
+          "  (exists=", dir.exists(p), " writable=", writable(p), ")")
+}
 message("DEBUG gypsum::cacheDirectory() = ",
         tryCatch(gypsum::cacheDirectory(), error = function(e) paste("ERR:", conditionMessage(e))))
-message("DEBUG baked cache present = ", dir.exists("/opt/hubcache/gypsum"))
-message("DEBUG seeded cache present = ",
-        dir.exists(file.path(getwd(), "gypsum-cache")))
-message("DEBUG gypsum cache writable = ",
-        file.access(Sys.getenv("GYPSUM_CACHE_DIR", "/nonexistent"), mode = 2) == 0)
+message("DEBUG AnnotationHub cache dir = ",
+        tryCatch(tools::R_user_dir("AnnotationHub", "cache"),
+                 error = function(e) paste("ERR:", conditionMessage(e))))
 
 # Parse simple --key=value arguments (no optparse dependency; not present
 # in the getwilds/singler image)

--- a/modules/ww-singler/singler_analysis.R
+++ b/modules/ww-singler/singler_analysis.R
@@ -5,6 +5,14 @@ library(SingleR)
 library(celldex)
 library(SingleCellExperiment)
 
+# TEMPORARY: verbose HTTP tracing to debug an intermittent
+# save_file()/array.h5 fetch failure seen only in Sprocket runs on HPC
+# (not reproducible via GitHub CI or any manual repro attempt so far).
+# Remove once root-caused.
+library(httr)
+httr::set_config(httr::verbose(data_out = TRUE, data_in = TRUE, info = TRUE, ssl = TRUE))
+message("DEBUG HOME = ", Sys.getenv("HOME"))
+
 # Parse simple --key=value arguments (no optparse dependency; not present
 # in the getwilds/singler image)
 parse_args <- function(args, defaults) {

--- a/modules/ww-singler/ww-singler.wdl
+++ b/modules/ww-singler/ww-singler.wdl
@@ -61,6 +61,15 @@ task run_singler {
     curl -so singler_analysis.R \
       "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/singler-debugging/modules/ww-singler/singler_analysis.R"
 
+    # gypsum locks its cache dir even for a cache hit, and the image's baked-in
+    # reference cache is read-only under Apptainer. Seed a writable copy in the
+    # task dir and point gypsum at it (skipped for images without the cache).
+    if [ -d /opt/hubcache/gypsum ]; then
+      mkdir -p "${PWD}/gypsum-cache"
+      cp -r /opt/hubcache/gypsum/. "${PWD}/gypsum-cache/"
+      export GYPSUM_CACHE_DIR="${PWD}/gypsum-cache"
+    fi
+
     Rscript singler_analysis.R \
       --sce_rds="~{sce_rds}" \
       --sample_name="~{sample_name}" \

--- a/modules/ww-singler/ww-singler.wdl
+++ b/modules/ww-singler/ww-singler.wdl
@@ -59,7 +59,7 @@ task run_singler {
     set -eo pipefail
 
     curl -so singler_analysis.R \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-singler/singler_analysis.R"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/singler-debugging/modules/ww-singler/singler_analysis.R"
 
     Rscript singler_analysis.R \
       --sce_rds="~{sce_rds}" \

--- a/modules/ww-singler/ww-singler.wdl
+++ b/modules/ww-singler/ww-singler.wdl
@@ -61,13 +61,27 @@ task run_singler {
     curl -so singler_analysis.R \
       "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/singler-debugging/modules/ww-singler/singler_analysis.R"
 
-    # gypsum locks its cache dir even for a cache hit, and the image's baked-in
-    # reference cache is read-only under Apptainer. Seed a writable copy in the
-    # task dir and point gypsum at it (skipped for images without the cache).
+    # celldex/AnnotationHub/gypsum all take a write lock in their cache dir even
+    # for a cache hit, and the getwilds/singler image's baked-in caches are
+    # read-only under Apptainer. Seed a writable copy of each in the task dir
+    # and repoint the corresponding env var (skipped for images without them).
     if [ -d /opt/hubcache/gypsum ]; then
       mkdir -p "${PWD}/gypsum-cache"
       cp -r /opt/hubcache/gypsum/. "${PWD}/gypsum-cache/"
       export GYPSUM_CACHE_DIR="${PWD}/gypsum-cache"
+    fi
+    if [ -d /opt/hubcache/annotationhub ]; then
+      mkdir -p "${PWD}/annotationhub-cache"
+      cp -r /opt/hubcache/annotationhub/. "${PWD}/annotationhub-cache/"
+      export ANNOTATION_HUB_CACHE="${PWD}/annotationhub-cache"
+      # Work purely from the local cache; skip the online metadata refresh and
+      # its own read-only lock on the metadata SQLite DB.
+      export ANNOTATION_HUB_LOCAL=TRUE
+    fi
+    if [ -d /opt/hubcache/experimenthub ]; then
+      mkdir -p "${PWD}/experimenthub-cache"
+      cp -r /opt/hubcache/experimenthub/. "${PWD}/experimenthub-cache/"
+      export EXPERIMENT_HUB_CACHE="${PWD}/experimenthub-cache"
     fi
 
     Rscript singler_analysis.R \


### PR DESCRIPTION
## Type of Change

- Bug fix
- Documentation update

## Description

Fixes `ww-singler` runtime failures on the Fred Hutch HPC (Sprocket / Apptainer).

`gypsum`, `AnnotationHub`, and `ExperimentHub` all take a write lock in their cache dir even on a cache hit, but the `getwilds/singler:2.14.1` image's baked `/opt/hubcache` is read-only under Apptainer, so the SingleR annotation step failed acquiring the lock.

The `run_singler` command now copies each baked hub cache into the task working directory and repoints the matching env vars (`GYPSUM_CACHE_DIR`, `ANNOTATION_HUB_CACHE` + `ANNOTATION_HUB_LOCAL=TRUE`, `EXPERIMENT_HUB_CACHE`) before running the analysis script. Each block is guarded, so images without a given cache are unaffected. A default `HumanPrimaryCellAtlasData` run now works offline; other references (e.g. `MouseRNAseqData`) are still downloaded on first use. README gains a "Reference dataset caching" section and an updated Requirements note.

## Related Issue

- Related to recent failures in the HPC test run, issue #324 

## Testing

**How did you test these changes?**
Ran `ww-singler` end-to-end on the Fred Hutch HPC via Sprocket. It previously failed at the annotation step with a read-only cache / write-lock error and now completes. Debugging verbosity used to isolate the cause has been removed.

**What workflow engine did you use?**
Sprocket on the Fred Hutch HPC.

**Did the tests pass?**
Yes. CI (Cromwell, miniWDL, Sprocket) runs automatically on this PR.

## Documentation

- [x] I updated the README (if applicable)
- [x] I added/updated parameter descriptions in the WDL (if applicable) — no new parameters
- [x] I ran `make docs` to check documentation rendering (if applicable)