### PR TITLE
Switching curl URL for `ww-singler` back to main

### DIFF
--- a/modules/ww-singler/ww-singler.wdl
+++ b/modules/ww-singler/ww-singler.wdl
@@ -59,7 +59,7 @@ task run_singler {
     set -eo pipefail
 
     curl -so singler_analysis.R \
-      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/singler-debugging/modules/ww-singler/singler_analysis.R"
+      "https://raw.githubusercontent.com/getwilds/wilds-wdl-library/refs/heads/main/modules/ww-singler/singler_analysis.R"
 
     # celldex/AnnotationHub/gypsum all take a write lock in their cache dir even
     # for a cache hit, and the getwilds/singler image's baked-in caches are


### PR DESCRIPTION
## Type of Change

- Other: switching curl branch back to `main`

## Description

- No functional change, just switching `curl` command in `ww-singler` to point back to `main` from https://github.com/getwilds/wilds-wdl-library/pull/396
- See GitHub Action test runs below just in case.