### PR TITLE
Pin `sprocket run` to 0.25.0 to unblock GPU module test runs

### DIFF
--- a/.github/workflows/testrun-reusable.yml
+++ b/.github/workflows/testrun-reusable.yml
@@ -159,8 +159,14 @@ jobs:
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     -
       name: Install Sprocket
+      # Pinned to 0.25.0: Sprocket 0.28.0 added version-aware runtime key type
+      # checking that rejects `gpu: <Boolean>` in the `runtime` section (it types
+      # `gpu` as `Int | String` per WDL 1.1+), breaking `sprocket run` on the
+      # GPU-enabled modules (ww-starling, ww-clair3, ww-cellbender, ww-colabfold,
+      # ww-esmfold). Linting stays on 0.28.0. Revisit once those modules move to
+      # `version 1.2` + `requirements { gpu: Boolean }`.
       run: |
-        cargo-binstall sprocket --version 0.28.0 -y
+        cargo-binstall sprocket --version 0.25.0 -y
     -
       name: Run workflow with Sprocket
       run: |


### PR DESCRIPTION
## Type of Change

- Bug fix (CI/CD)

## Description

Sprocket 0.28.0 (bumped in #385) type-checks the `runtime` `gpu` key as `Int | String`, so `gpu: gpu_enabled` (a `Boolean`) now fails `sprocket run` on the GPU modules (`ww-starling`, `ww-clair3`, `ww-cellbender`, `ww-colabfold`, `ww-esmfold`) and pipelines that import them. Linting does not catch it, so it only broke the monthly test run.

This pins the `sprocket run` step back to `0.25.0` as a temporary fix. Linting and docs stay on `0.28.0`. Proper fix is a follow-up: move those modules to `version 1.2` with `requirements { gpu: gpu_enabled }`.

## Testing

**How did you test these changes?**
Confirmed from the failing monthly run logs and a local repro. These modules passed under Sprocket 0.25.0 prior to #385; CI on this PR should go green again.

**What workflow engine did you use?**
Sprocket.

**Did the tests pass?**
Pending CI on this PR.

## Documentation

CI workflow only, no docs changes.

## Additional Context

- Only `.github/workflows/testrun-reusable.yml` changes.
- Follow-up: might want to migrate the GPU modules to `version 1.2` + `requirements { gpu: gpu_enabled }`